### PR TITLE
Fix UI improvements in the Create Order screen

### DIFF
--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -79,7 +79,7 @@ class HomeScreen extends ConsumerWidget {
             ),
           ),
           Positioned(
-            bottom: 100,
+            bottom: 80 + MediaQuery.of(context).viewPadding.bottom + 16,
             right: 16,
             child: const AddOrderButton(),
           ),

--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -17,6 +17,9 @@ class OrderListItem extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(timeProvider);
 
+    // Determine if this is a fixed order (has specific sats amount)
+    final bool isFixedOrder = order.amount != null && order.amount!.isNotEmpty;
+
     // Determine if the premium is positive or negative for the color
     final premiumValue =
         order.premium != null ? double.tryParse(order.premium!) ?? 0.0 : 0.0;
@@ -105,54 +108,74 @@ class OrderListItem extends ConsumerWidget {
                 ),
               ),
 
-              // Second row: Amount and currency with flag and percentage
+              // Second row: Amount and currency with flag and percentage (if not fixed)
               Padding(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.baseline,
-                  textBaseline: TextBaseline.alphabetic,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // Large amount with more contrast
-                    Text(
-                      order.fiatAmount.toString(),
-                      style: const TextStyle(
-                        fontSize: 28,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
-                        height: 1.1,
-                      ),
-                    ),
-                    const SizedBox(width: 8),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.baseline,
+                      textBaseline: TextBaseline.alphabetic,
+                      children: [
+                        // Large amount with more contrast
+                        Text(
+                          order.fiatAmount.toString(),
+                          style: const TextStyle(
+                            fontSize: 28,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                            height: 1.1,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
 
-                    // Currency code and flag
-                    Text(
-                      '${order.currency ?? "CUP"} ',
-                      style: const TextStyle(
-                        fontSize: 18,
-                        color: Colors.white,
-                      ),
-                    ),
-                    Text(
-                      () {
-                        final String currencyCode = order.currency ?? 'CUP';
-                        return CurrencyUtils.getFlagFromCurrency(
-                                currencyCode) ??
-                            '';
-                      }(),
-                      style: const TextStyle(fontSize: 18),
-                    ),
-                    const SizedBox(width: 4),
+                        // Currency code and flag
+                        Text(
+                          '${order.currency ?? "CUP"} ',
+                          style: const TextStyle(
+                            fontSize: 18,
+                            color: Colors.white,
+                          ),
+                        ),
+                        Text(
+                          () {
+                            final String currencyCode = order.currency ?? 'CUP';
+                            return CurrencyUtils.getFlagFromCurrency(
+                                    currencyCode) ??
+                                '';
+                          }(),
+                          style: const TextStyle(fontSize: 18),
+                        ),
+                        const SizedBox(width: 4),
 
-                    // Percentage with more vibrant color
-                    Text(
-                      premiumText,
-                      style: TextStyle(
-                        fontSize: 16,
-                        color: premiumColor,
-                        fontWeight: FontWeight.w600,
-                      ),
+                        // Percentage with more vibrant color (only for non-fixed orders)
+                        if (!isFixedOrder)
+                          Text(
+                            premiumText,
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: premiumColor,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                      ],
                     ),
+                    
+                    // Display sats amount for fixed orders
+                    if (isFixedOrder)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          '${order.orderType == OrderType.buy ? "Buying" : "Selling"} ${order.fiatAmount} ${order.currency ?? ""} for ${order.amount} sats',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Colors.white70,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
                   ],
                 ),
               ),

--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -17,10 +17,11 @@ class OrderListItem extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(timeProvider);
 
-    // Determine if this is a fixed order (has specific sats amount)
-    final bool isFixedOrder = order.amount != null && order.amount!.isNotEmpty;
+    // Determine if this is a fixed order (has specific sats amount and is not zero)
+    final bool isFixedOrder =
+        order.amount != null && order.amount != "0" && order.amount!.isNotEmpty;
 
-    // Determine if the premium is positive or negative for the color
+    // Calcular el valor del premium para órdenes de tipo market
     final premiumValue =
         order.premium != null ? double.tryParse(order.premium!) ?? 0.0 : 0.0;
     final isPremiumPositive = premiumValue >= 0;
@@ -149,33 +150,42 @@ class OrderListItem extends ConsumerWidget {
                           style: const TextStyle(fontSize: 18),
                         ),
                         const SizedBox(width: 4),
-
-                        // Percentage with more vibrant color (only for non-fixed orders)
-                        if (!isFixedOrder)
-                          Text(
-                            premiumText,
-                            style: TextStyle(
-                              fontSize: 16,
-                              color: premiumColor,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
                       ],
                     ),
-                    
-                    // Display sats amount for fixed orders
-                    if (isFixedOrder)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Text(
-                          '${order.orderType == OrderType.buy ? "Buying" : "Selling"} ${order.fiatAmount} ${order.currency ?? ""} for ${order.amount} sats',
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: Colors.white70,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ),
+
+                    // Display sats amount for all orders (simplified)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: isFixedOrder
+                          ? Text(
+                              'For ${order.amount!} sats',
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: Colors.white70,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            )
+                          : Row(
+                              children: [
+                                Text(
+                                  'Market Price ',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: Colors.white70,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                Text(
+                                  premiumText,
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: premiumColor,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ],
+                            ),
+                    ),
                   ],
                 ),
               ),

--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -21,7 +21,6 @@ class OrderListItem extends ConsumerWidget {
     final bool isFixedOrder =
         order.amount != null && order.amount != "0" && order.amount!.isNotEmpty;
 
-    // Calcular el valor del premium para órdenes de tipo market
     final premiumValue =
         order.premium != null ? double.tryParse(order.premium!) ?? 0.0 : 0.0;
     final isPremiumPositive = premiumValue >= 0;

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
@@ -187,8 +188,15 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
                                 if (!_marketRate && (value == null || value.isEmpty)) {
                                   return 'Please enter sats amount';
                                 }
+                                if (!_marketRate && !RegExp(r'^[0-9]+$').hasMatch(value!)) {
+                                  return 'Please enter numbers only';
+                                }
                                 return null;
                               },
+                              // Restricting input to numbers only
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
                             ),
                           ),
                         ],

--- a/lib/features/order/widgets/form_section.dart
+++ b/lib/features/order/widgets/form_section.dart
@@ -7,6 +7,7 @@ class FormSection extends StatelessWidget {
   final Color iconBackgroundColor;
   final Widget child;
   final Widget? extraContent;
+  final String? infoTooltip;
 
   const FormSection({
     super.key,
@@ -15,6 +16,7 @@ class FormSection extends StatelessWidget {
     required this.iconBackgroundColor,
     required this.child,
     this.extraContent,
+    this.infoTooltip,
   });
 
   @override
@@ -29,12 +31,69 @@ class FormSection extends StatelessWidget {
         children: [
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-            child: Text(
-              title,
-              style: TextStyle(
-                color: Colors.white.withOpacity(0.7),
-                fontSize: 14,
-              ),
+            child: Row(
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: Colors.white.withOpacity(0.7),
+                    fontSize: 14,
+                  ),
+                ),
+                if (infoTooltip != null) ...[  
+                  const SizedBox(width: 4),
+                  GestureDetector(
+                    onTap: () {
+                      showDialog(
+                        context: context,
+                        builder: (context) => Dialog(
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          backgroundColor: const Color(0xFF1E2230),
+                          child: Padding(
+                            padding: const EdgeInsets.all(20.0),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
+                                  child: Text(
+                                    infoTooltip!,
+                                    style: const TextStyle(color: Colors.white, fontSize: 16, height: 1.4),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ),
+                                const SizedBox(height: 16),
+                                SizedBox(
+                                  width: double.infinity,
+                                  child: ElevatedButton(
+                                    style: ElevatedButton.styleFrom(
+                                      backgroundColor: const Color(0xFF8CC63F),
+                                      foregroundColor: Colors.black,
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(8),
+                                      ),
+                                      padding: const EdgeInsets.symmetric(vertical: 12),
+                                    ),
+                                    onPressed: () => Navigator.of(context).pop(),
+                                    child: const Text('OK', style: TextStyle(fontWeight: FontWeight.bold)),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                    child: Icon(
+                      Icons.info_outline,
+                      size: 14,
+                      color: AppTheme.textSubtle,
+                    ),
+                  ),
+                ],
+              ],
             ),
           ),
           Container(

--- a/lib/features/order/widgets/premium_section.dart
+++ b/lib/features/order/widgets/premium_section.dart
@@ -14,9 +14,9 @@ class PremiumSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Define the premium value display as the icon
+    // Define the premium value display as the icon - showing only whole numbers
     final premiumValueIcon = Text(
-      value.toStringAsFixed(1),
+      value.round().toString(),
       style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
     );
     

--- a/lib/features/order/widgets/premium_section.dart
+++ b/lib/features/order/widgets/premium_section.dart
@@ -25,6 +25,7 @@ class PremiumSection extends StatelessWidget {
       title: 'Premium (%) ',
       icon: premiumValueIcon,
       iconBackgroundColor: AppTheme.purpleAccent, // Purple color for premium
+      infoTooltip: 'Adjust how much above or below the market price you want your offer. By default, it\'s set to 0%, with no premium or discount, so if you don\'t want to change the price, you can leave it as is.',
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -63,18 +64,6 @@ class PremiumSection extends StatelessWidget {
             ),
           ),
         ],
-      ),
-      // Add an info icon as extra content
-      extraContent: Padding(
-        padding: const EdgeInsets.only(right: 16, bottom: 8),
-        child: Align(
-          alignment: Alignment.centerRight,
-          child: Icon(
-            Icons.info_outline,
-            size: 14,
-            color: AppTheme.textSubtle,
-          ),
-        ),
       ),
     );
   }

--- a/lib/features/order/widgets/price_type_section.dart
+++ b/lib/features/order/widgets/price_type_section.dart
@@ -25,6 +25,7 @@ class PriceTypeSection extends StatelessWidget {
       title: 'Price type',
       icon: priceTypeIcon,
       iconBackgroundColor: AppTheme.purpleAccent.withOpacity(0.3), // Purple color consistent with other sections
+      infoTooltip: '• Select Market Price if you want to use the price that Bitcoin has when someone takes your offer.\n• Select Fixed Price if you want to define the exact amount of Bitcoin you will exchange.',
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -52,18 +53,6 @@ class PriceTypeSection extends StatelessWidget {
             ],
           ),
         ],
-      ),
-      // Add info icon as extra content
-      extraContent: Padding(
-        padding: const EdgeInsets.only(right: 16, bottom: 8),
-        child: Align(
-          alignment: Alignment.centerRight,
-          child: Icon(
-            Icons.info_outline,
-            size: 14,
-            color: AppTheme.textSubtle,
-          ),
-        ),
       ),
     );
   }

--- a/lib/features/order/widgets/price_type_section.dart
+++ b/lib/features/order/widgets/price_type_section.dart
@@ -29,9 +29,9 @@ class PriceTypeSection extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          const Text(
-            'Market price',
-            style: TextStyle(
+          Text(
+            isMarketRate ? 'Market price' : 'Fixed price',
+            style: const TextStyle(
                 color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
           ),
           Row(

--- a/lib/shared/widgets/add_order_button.dart
+++ b/lib/shared/widgets/add_order_button.dart
@@ -34,7 +34,7 @@ class _AddOrderButtonState extends State<AddOrderButton>
     if (_animationController.isAnimating) {
       return;
     }
-    
+
     setState(() {
       _isMenuOpen = !_isMenuOpen;
       if (_isMenuOpen) {
@@ -75,40 +75,62 @@ class _AddOrderButtonState extends State<AddOrderButton>
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  ElevatedButton.icon(
-                    onPressed: _isMenuOpen
-                        ? () => _navigateToCreateOrder(context, 'buy')
-                        : null,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppTheme.buyColor,
-                      foregroundColor: Colors.black,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(50),
+                  Stack(
+                    alignment: Alignment.centerLeft,
+                    children: [
+                      ElevatedButton.icon(
+                        onPressed: _isMenuOpen
+                            ? () => _navigateToCreateOrder(context, 'buy')
+                            : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppTheme.buyColor,
+                          foregroundColor: Colors.black,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(50),
+                          ),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 10),
+                        ),
+                        icon: const SizedBox(width: 16, height: 16),
+                        label: const Text('BUY',
+                            style: TextStyle(fontWeight: FontWeight.bold)),
                       ),
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 16, vertical: 10),
-                    ),
-                    icon: const Icon(Icons.arrow_downward, size: 16),
-                    label: const Text('BUY',
-                        style: TextStyle(fontWeight: FontWeight.bold)),
+                      if (_isMenuOpen)
+                        const Positioned(
+                          left: 16,
+                          child: Icon(Icons.arrow_downward,
+                              size: 16, color: Colors.black),
+                        ),
+                    ],
                   ),
                   const SizedBox(width: 8),
-                  ElevatedButton.icon(
-                    onPressed: _isMenuOpen
-                        ? () => _navigateToCreateOrder(context, 'sell')
-                        : null,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppTheme.sellColor,
-                      foregroundColor: Colors.black,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(50),
+                  Stack(
+                    alignment: Alignment.centerLeft,
+                    children: [
+                      ElevatedButton.icon(
+                        onPressed: _isMenuOpen
+                            ? () => _navigateToCreateOrder(context, 'sell')
+                            : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppTheme.sellColor,
+                          foregroundColor: Colors.black,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(50),
+                          ),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 10),
+                        ),
+                        icon: const SizedBox(width: 16, height: 16),
+                        label: const Text('SELL',
+                            style: TextStyle(fontWeight: FontWeight.bold)),
                       ),
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 16, vertical: 10),
-                    ),
-                    icon: const Icon(Icons.arrow_upward, size: 16),
-                    label: const Text('SELL',
-                        style: TextStyle(fontWeight: FontWeight.bold)),
+                      if (_isMenuOpen)
+                        const Positioned(
+                          left: 16,
+                          child: Icon(Icons.arrow_upward,
+                              size: 16, color: Colors.black),
+                        ),
+                    ],
                   ),
                 ],
               ),

--- a/lib/shared/widgets/add_order_button.dart
+++ b/lib/shared/widgets/add_order_button.dart
@@ -30,7 +30,6 @@ class _AddOrderButtonState extends State<AddOrderButton>
   }
 
   void _toggleMenu() {
-    // Guard: return early if animation is in progress to prevent glitches
     if (_animationController.isAnimating) {
       return;
     }
@@ -57,18 +56,15 @@ class _AddOrderButtonState extends State<AddOrderButton>
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 130, // Altura suficiente para mostrar ambos elementos
-      width: 200, // Ancho suficiente para los botones
+      height: 130,
+      width: 200,
       child: Column(
-        mainAxisAlignment:
-            MainAxisAlignment.end, // Alinea los elementos al final
-        crossAxisAlignment: CrossAxisAlignment.end, // Alinea a la derecha
+        mainAxisAlignment: MainAxisAlignment.end,
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          // Opciones de menú que aparecen sobre el botón principal
           AnimatedContainer(
             duration: const Duration(milliseconds: 200),
-            height:
-                _isMenuOpen ? 45 : 0, // Se expande al abrir, colapsa al cerrar
+            height: _isMenuOpen ? 45 : 0,
             margin: const EdgeInsets.only(bottom: 10),
             child: Opacity(
               opacity: _isMenuOpen ? 1.0 : 0.0,
@@ -136,8 +132,6 @@ class _AddOrderButtonState extends State<AddOrderButton>
               ),
             ),
           ),
-
-          // Botón principal siempre visible
           FloatingActionButton(
             onPressed: _toggleMenu,
             backgroundColor:

--- a/lib/shared/widgets/bottom_nav_bar.dart
+++ b/lib/shared/widgets/bottom_nav_bar.dart
@@ -18,21 +18,23 @@ class BottomNavBar extends ConsumerWidget {
     final int orderNotificationCount =
         ref.watch(orderBookNotificationCountProvider);
 
-    return Container(
-      width: double.infinity,
-      height: 80,
-      decoration: BoxDecoration(
-        color: AppTheme.backgroundNavBar,
-        border: Border(
-          top: BorderSide(
-            color: Colors.white.withOpacity(0.1),
-            width: 1,
+    return SafeArea(
+      top: false,
+      child: Container(
+        width: double.infinity,
+        height: 80,
+        decoration: BoxDecoration(
+          color: AppTheme.backgroundNavBar,
+          border: Border(
+            top: BorderSide(
+              color: Colors.white.withOpacity(0.1),
+              width: 1,
+            ),
           ),
         ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
           _buildNavItem(
             context,
             LucideIcons.book,
@@ -53,7 +55,8 @@ class BottomNavBar extends ConsumerWidget {
             2,
             notificationCount: chatCount,
           ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
This PR addresses issue #105 with the following improvements:
- Moved info icons next to section titles for better visibility
- Made info icons tappable with improved dialog display
- Changed premium slider to display whole numbers only
- Added dynamic text change in price type section (shows "Fixed price" when market is off)
- Enhanced dialog styling with better centering, larger text, and improved button appearance

These changes improve the usability and clarity of the Create Order screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added informational tooltips to form sections, providing users with helpful explanations when tapping the info icon.
- **Improvements**
  - The Add Order button and bottom navigation bar now better respect device safe areas, improving layout on devices with notches or system overlays.
  - Order list items now clearly distinguish between fixed price and market price orders, enhancing clarity in order details.
  - Premium values are now displayed as whole numbers for easier reading.
  - Price type labeling is now dynamic, switching between "Market price" and "Fixed price" as appropriate.
  - Enhanced input validation and digit-only input restriction for the sats amount field when not using market rate.
- **Style**
  - Updated the Add Order menu button layout for improved visual separation of arrow icons and button labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->