### PR TITLE
Display all payment methods in orders

### DIFF
--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -19,7 +19,14 @@ extension NostrEventExtensions on NostrEvent {
   Status get status => Status.fromString(_getTagValue('s')!);
   String? get amount => _getTagValue('amt');
   RangeAmount get fiatAmount => _getAmount('fa');
-  List<String> get paymentMethods => _getTagValue('pm')?.split(',') ?? [];
+  List<String> get paymentMethods {
+    final tag = tags?.firstWhere((t) => t[0] == 'pm', orElse: () => []);
+    if (tag != null && tag.length > 1) {
+      return tag.sublist(1);
+    }
+    return [];
+  }
+
   String? get premium => _getTagValue('premium');
   String? get source => _getTagValue('source');
   Rating? get rating => _getTagValue('rating') != null

--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -220,14 +220,17 @@ class OrderListItem extends ConsumerWidget {
                       '💳 ', // Default emoji
                       style: TextStyle(fontSize: 16),
                     ),
-                    Text(
-                      order.paymentMethods.isNotEmpty
-                          ? order.paymentMethods[0]
-                          : 'tm',
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
+                    Expanded(
+                      child: Text(
+                        order.paymentMethods.isNotEmpty
+                            ? order.paymentMethods.join(', ')
+                            : 'tm',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                        ),
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                   ],

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -60,8 +60,8 @@ class TakeOrderScreen extends ConsumerWidget {
             ? ''
             : 'with a +$premium% premium'
         : 'with a -$premium% discount';
-    final method = order.paymentMethods.isNotEmpty
-        ? order.paymentMethods[0]
+    final methods = order.paymentMethods.isNotEmpty
+        ? order.paymentMethods.join(', ')
         : 'No payment method';
 
     return CustomCard(
@@ -85,7 +85,7 @@ class TakeOrderScreen extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  'The payment method is: $method',
+                  'The payment methods are: $methods',
                   style: textTheme.bodyLarge,
                 ),
               ],


### PR DESCRIPTION
Fix #115: Show all payment methods separated by commas in both order list items and detail view, instead of showing only the first method.

![image](https://github.com/user-attachments/assets/7e8e5339-46f6-48c8-b96c-837f8e5fbebf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated payment method displays to show all payment methods as a comma-separated list instead of just the first one.
  - Enhanced text handling to prevent overflow, ensuring long payment method lists are displayed gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->