### PR TITLE
Bug when selecting the premium or discount for an order

### DIFF
--- a/lib/features/order/widgets/premium_section.dart
+++ b/lib/features/order/widgets/premium_section.dart
@@ -35,7 +35,7 @@ class PremiumSection extends StatelessWidget {
               activeTrackColor: AppTheme.purpleAccent,
               inactiveTrackColor: AppTheme.backgroundInactive,
               thumbColor: AppTheme.textPrimary,
-              overlayColor: AppTheme.purpleAccent.withOpacity(0.2),
+              overlayColor: AppTheme.purpleAccent.withValues(alpha: 0.2),
               trackHeight: 4,
             ),
             child: Slider(
@@ -43,7 +43,7 @@ class PremiumSection extends StatelessWidget {
               value: value,
               min: -10,
               max: 10,
-              divisions: 200,
+              divisions: 20,
               onChanged: onChanged,
             ),
           ),


### PR DESCRIPTION
Fixes #120

The Slider was being set with a range of 200 units but being rounded up to whole numbers as you suspected. The Slider range is now set to 20, constraining the range of values to {-10 ..10}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the slider's thumb interaction effect for a more refined appearance.

- **Refactor**
  - Reduced the number of slider steps for easier adjustment between minimum and maximum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->