### PR TITLE
Fixes: Add confirmation message before starting cooperative cancellation

### DIFF
--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -221,14 +221,22 @@ class OrderState {
         Action.buyerTookOrder: [
           Action.cancel,
           Action.dispute,
+          Action.sendDm,
         ],
         Action.holdInvoicePaymentAccepted: [
           Action.cancel,
           Action.dispute,
+          Action.sendDm,
         ],
         Action.holdInvoicePaymentSettled: [
           Action.cancel,
           Action.dispute,
+          Action.sendDm,
+        ],
+        Action.cooperativeCancelInitiatedByPeer: [
+          Action.cancel,
+          Action.dispute,
+          Action.sendDm,
         ],
       },
       Status.fiatSent: {
@@ -287,21 +295,30 @@ class OrderState {
           Action.fiatSent,
           Action.cancel,
           Action.dispute,
+          Action.sendDm,
         ],
         Action.holdInvoicePaymentSettled: [
           Action.fiatSent,
           Action.cancel,
           Action.dispute,
+          Action.sendDm,
         ],
         Action.buyerTookOrder: [
           Action.cancel,
           Action.dispute,
+          Action.sendDm,
+        ],
+        Action.cooperativeCancelInitiatedByPeer: [
+          Action.cancel,
+          Action.dispute,
+          Action.sendDm,
         ],
       },
       Status.fiatSent: {
         Action.fiatSentOk: [
           Action.cancel,
           Action.dispute,
+          Action.sendDm,
         ],
       },
       Status.success: {

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -224,26 +224,20 @@ class TradeDetailScreen extends ConsumerWidget {
       // FSM-driven action mapping: ensure all actions are handled
       switch (action) {
         case actions.Action.cancel:
-          String buttonText;
-          Color buttonColor;
           String cancelMessage;
 
           if (tradeState.status == Status.active ||
               tradeState.status == Status.fiatSent) {
-            buttonText = 'CANCEL';
-            buttonColor = AppTheme.red1;
             cancelMessage =
                 'If you confirm, you will start a cooperative cancellation with your counterparty.';
           } else {
-            buttonText = 'CANCEL';
-            buttonColor = AppTheme.red1;
             cancelMessage = 'Are you sure you want to cancel this trade?';
           }
 
           widgets.add(_buildNostrButton(
-            buttonText,
+            'CANCEL',
             action: action,
-            backgroundColor: buttonColor,
+            backgroundColor: AppTheme.red1,
             onPressed: () {
               showDialog(
                 context: context,

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -53,7 +53,9 @@ class TradeDetailScreen extends ConsumerWidget {
                 // Detailed info: includes the last Mostro message action text
                 MostroMessageDetail(orderId: orderId),
                 const SizedBox(height: 24),
-                _buildCountDownTime(orderPayload.expiresAt),
+                _buildCountDownTime(orderPayload.expiresAt != null
+                    ? orderPayload.expiresAt! * 1000
+                    : null),
                 const SizedBox(height: 36),
                 Wrap(
                   alignment: WrapAlignment.center,
@@ -104,10 +106,9 @@ class TradeDetailScreen extends ConsumerWidget {
     final method = tradeState.order!.paymentMethod;
     final timestamp = formatDateTime(
       tradeState.order!.createdAt != null && tradeState.order!.createdAt! > 0
-          ? DateTime.fromMillisecondsSinceEpoch(tradeState.order!.createdAt!)
-          : DateTime.fromMillisecondsSinceEpoch(
-              tradeState.order!.createdAt ?? 0,
-            ),
+          ? DateTime.fromMillisecondsSinceEpoch(
+              tradeState.order!.createdAt! * 1000)
+          : session.startTime,
     );
     return CustomCard(
       padding: const EdgeInsets.all(16),
@@ -225,22 +226,48 @@ class TradeDetailScreen extends ConsumerWidget {
         case actions.Action.cancel:
           String buttonText;
           Color buttonColor;
+          String cancelMessage;
 
           if (tradeState.status == Status.active ||
               tradeState.status == Status.fiatSent) {
-            buttonText = 'COOPERATIVE CANCEL';
+            buttonText = 'CANCEL';
             buttonColor = AppTheme.red1;
+            cancelMessage =
+                'If you confirm, you will start a cooperative cancellation with your counterparty.';
           } else {
             buttonText = 'CANCEL';
             buttonColor = AppTheme.red1;
+            cancelMessage = 'Are you sure you want to cancel this trade?';
           }
 
           widgets.add(_buildNostrButton(
             buttonText,
             action: action,
             backgroundColor: buttonColor,
-            onPressed: () =>
-                ref.read(orderNotifierProvider(orderId).notifier).cancelOrder(),
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('Cancel Trade'),
+                  content: Text(cancelMessage),
+                  actions: [
+                    TextButton(
+                      onPressed: () => context.pop(),
+                      child: const Text('Cancel'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        context.pop();
+                        ref
+                            .read(orderNotifierProvider(orderId).notifier)
+                            .cancelOrder();
+                      },
+                      child: const Text('Confirm'),
+                    ),
+                  ],
+                ),
+              );
+            },
           ));
           break;
 
@@ -386,15 +413,11 @@ class TradeDetailScreen extends ConsumerWidget {
           ));
           break;
 
-        case actions.Action.holdInvoicePaymentSettled:
-        case actions.Action.holdInvoicePaymentAccepted:
+        case actions.Action.sendDm:
           widgets.add(_buildContactButton(context));
           break;
 
         case actions.Action.holdInvoicePaymentCanceled:
-          // These are system actions, not user actions, so no button needed
-          break;
-
         case actions.Action.buyerInvoiceAccepted:
         case actions.Action.waitingSellerToPay:
         case actions.Action.waitingBuyerInvoice:
@@ -407,15 +430,11 @@ class TradeDetailScreen extends ConsumerWidget {
         case actions.Action.adminTookDispute:
         case actions.Action.paymentFailed:
         case actions.Action.invoiceUpdated:
-        case actions.Action.sendDm:
         case actions.Action.tradePubkey:
         case actions.Action.cantDo:
         case actions.Action.released:
-          // Not user-facing or not relevant as a button
           break;
-
         default:
-          // Optionally handle unknown or unimplemented actions
           break;
       }
     }
@@ -457,7 +476,7 @@ class TradeDetailScreen extends ConsumerWidget {
   /// CLOSE
   Widget _buildCloseButton(BuildContext context) {
     return OutlinedButton(
-      onPressed: () => context.pop(),
+      onPressed: () => context.go('/order_book'),
       style: AppTheme.theme.outlinedButtonTheme.style,
       child: const Text('CLOSE'),
     );

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -228,8 +228,13 @@ class TradeDetailScreen extends ConsumerWidget {
 
           if (tradeState.status == Status.active ||
               tradeState.status == Status.fiatSent) {
-            cancelMessage =
-                'If you confirm, you will start a cooperative cancellation with your counterparty.';
+            if (tradeState.action == actions.Action.cooperativeCancelInitiatedByPeer) {
+              cancelMessage =
+                  'If you confirm, you will accept the cooperative cancellation initiated by your counterparty.';
+            } else {
+              cancelMessage =
+                  'If you confirm, you will start a cooperative cancellation with your counterparty.';
+            }
           } else {
             cancelMessage = 'Are you sure you want to cancel this trade?';
           }


### PR DESCRIPTION
Now shows a confirmation dialog before cancelling the order for Issue #72

Fix #72
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Countdown timer and creation timestamp formatting were updated for improved accuracy.
  * Cancel action now prompts a confirmation dialog with context-sensitive messaging before proceeding.
  * Added a contact button for direct messaging within the action buttons.
  * Close button now navigates directly to the order book screen for a smoother experience.
  * Expanded availability of direct messaging in various trade states for enhanced communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->