### PR TITLE
Make user-created orders also appear in the order book, not just in My Trades

### DIFF
--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -4,25 +4,20 @@ import 'package:mostro_mobile/data/models/enums/order_type.dart';
 import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
-import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 
 final homeOrderTypeProvider = StateProvider((ref) => OrderType.sell);
 
 final filteredOrdersProvider = Provider<List<NostrEvent>>((ref) {
   final allOrdersAsync = ref.watch(orderEventsProvider);
   final orderType = ref.watch(homeOrderTypeProvider);
-  final sessions = ref.watch(sessionNotifierProvider);
 
   return allOrdersAsync.maybeWhen(
     data: (allOrders) {
-      final orderIds = sessions.map((s) => s.orderId).toSet();
-
       allOrders
           .sort((o1, o2) => o1.expirationDate.compareTo(o2.expirationDate));
 
       final filtered = allOrders.reversed
           .where((o) => o.orderType == orderType)
-          .where((o) => !orderIds.contains(o.orderId))
           .where((o) => o.status == Status.pending)
           .toList();
       return filtered;

--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -37,7 +37,8 @@ class OrderListItem extends ConsumerWidget {
 
     final session = ref.watch(sessionProvider(order.orderId!));
     if (session != null) {
-      orderLabel = 'YOU ARE $orderLabel';
+      final selling = session.role == Role.seller ? 'SELLING' : 'BUYING';
+      orderLabel = 'YOU ARE $selling';
     }
 
     return Container(


### PR DESCRIPTION
This PR ensures that orders created by the user are visible in the main order book, not just under "My Trades."

Additionally, the order label now displays a "YOU ARE" indicator next to user-created orders trade type, making it easy to distinguish which orders belong to the current user at a glance. This improves clarity and helps users quickly identify their own orders in the list.
