### PR TITLE
Create a button to change the language

### DIFF
--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -54,8 +54,7 @@ class _MostroAppState extends ConsumerState<MostroApp> {
           theme: AppTheme.theme,
           darkTheme: AppTheme.theme,
           routerConfig: goRouter,
-          // Force Spanish locale for testing if device is Spanish
-          locale: systemLocale.languageCode == 'es' ? const Locale('es') : null,
+          // Let localeResolutionCallback handle all locale detection
           localizationsDelegates: const [
             S.delegate,
             GlobalMaterialLocalizations.delegate,

--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -10,6 +10,7 @@ import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/features/auth/notifiers/auth_state.dart';
 import 'package:mostro_mobile/services/lifecycle_manager.dart';
 import 'package:mostro_mobile/shared/providers/app_init_provider.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
 
 class MostroApp extends ConsumerStatefulWidget {
   const MostroApp({super.key});
@@ -48,13 +49,17 @@ class _MostroAppState extends ConsumerState<MostroApp> {
         });
 
         final systemLocale = ui.PlatformDispatcher.instance.locale;
+        final settings = ref.watch(settingsProvider);
         
         return MaterialApp.router(
           title: 'Mostro',
           theme: AppTheme.theme,
           darkTheme: AppTheme.theme,
           routerConfig: goRouter,
-          // Let localeResolutionCallback handle all locale detection
+          // Use language override from settings if available, otherwise let callback handle detection
+          locale: settings.selectedLanguage != null 
+              ? Locale(settings.selectedLanguage!) 
+              : null,
           localizationsDelegates: const [
             S.delegate,
             GlobalMaterialLocalizations.delegate,

--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -1,4 +1,4 @@
-import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +11,7 @@ import 'package:mostro_mobile/features/auth/notifiers/auth_state.dart';
 import 'package:mostro_mobile/services/lifecycle_manager.dart';
 import 'package:mostro_mobile/shared/providers/app_init_provider.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/shared/notifiers/locale_notifier.dart';
 
 class MostroApp extends ConsumerStatefulWidget {
   const MostroApp({super.key});
@@ -48,7 +49,8 @@ class _MostroAppState extends ConsumerState<MostroApp> {
           });
         });
 
-        final systemLocale = ui.PlatformDispatcher.instance.locale;
+        // Watch both system locale and settings for changes
+        final systemLocale = ref.watch(systemLocaleProvider);
         final settings = ref.watch(settingsProvider);
         
         return MaterialApp.router(
@@ -59,7 +61,7 @@ class _MostroAppState extends ConsumerState<MostroApp> {
           // Use language override from settings if available, otherwise let callback handle detection
           locale: settings.selectedLanguage != null 
               ? Locale(settings.selectedLanguage!) 
-              : null,
+              : systemLocale,
           localizationsDelegates: const [
             S.delegate,
             GlobalMaterialLocalizations.delegate,
@@ -68,6 +70,7 @@ class _MostroAppState extends ConsumerState<MostroApp> {
           ],
           supportedLocales: S.supportedLocales,
           localeResolutionCallback: (locale, supportedLocales) {
+            // Use the current system locale from our provider
             final deviceLocale = locale ?? systemLocale;
             
             // Check for Spanish language code (es) - includes es_AR, es_ES, etc.
@@ -82,8 +85,8 @@ class _MostroAppState extends ConsumerState<MostroApp> {
               }
             }
             
-            // If no match found, return English as fallback
-            return const Locale('en');
+            // If no match found, return Spanish as fallback
+            return const Locale('es');
           },
         );
       },

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -25,7 +25,7 @@ class Settings {
       fullPrivacyMode: privacyModeSetting ?? fullPrivacyMode,
       mostroPublicKey: mostroInstance ?? mostroPublicKey,
       defaultFiatCode: defaultFiatCode ?? this.defaultFiatCode,
-      selectedLanguage: selectedLanguage ?? this.selectedLanguage,
+      selectedLanguage: selectedLanguage,
     );
   }
 

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -3,12 +3,14 @@ class Settings {
   final List<String> relays;
   final String mostroPublicKey;
   final String? defaultFiatCode;
+  final String? selectedLanguage; // null means use system locale
 
   Settings({
     required this.relays,
     required this.fullPrivacyMode,
     required this.mostroPublicKey,
     this.defaultFiatCode,
+    this.selectedLanguage,
   });
 
   Settings copyWith({
@@ -16,12 +18,14 @@ class Settings {
     bool? privacyModeSetting,
     String? mostroInstance,
     String? defaultFiatCode,
+    String? selectedLanguage,
   }) {
     return Settings(
       relays: relays ?? this.relays,
       fullPrivacyMode: privacyModeSetting ?? fullPrivacyMode,
       mostroPublicKey: mostroInstance ?? mostroPublicKey,
       defaultFiatCode: defaultFiatCode ?? this.defaultFiatCode,
+      selectedLanguage: selectedLanguage ?? this.selectedLanguage,
     );
   }
 
@@ -30,6 +34,7 @@ class Settings {
         'fullPrivacyMode': fullPrivacyMode,
         'mostroPublicKey': mostroPublicKey,
         'defaultFiatCode': defaultFiatCode,
+        'selectedLanguage': selectedLanguage,
       };
 
   factory Settings.fromJson(Map<String, dynamic> json) {
@@ -38,6 +43,7 @@ class Settings {
       fullPrivacyMode: json['fullPrivacyMode'] as bool,
       mostroPublicKey: json['mostroPublicKey'],
       defaultFiatCode: json['defaultFiatCode'],
+      selectedLanguage: json['selectedLanguage'],
     );
   }
 }

--- a/lib/features/settings/settings_notifier.dart
+++ b/lib/features/settings/settings_notifier.dart
@@ -16,6 +16,7 @@ class SettingsNotifier extends StateNotifier<Settings> {
       relays: Config.nostrRelays,
       fullPrivacyMode: Config.fullPrivacyMode,
       mostroPublicKey: Config.mostroPubKey,
+      selectedLanguage: null,
     );
   }
 

--- a/lib/features/settings/settings_notifier.dart
+++ b/lib/features/settings/settings_notifier.dart
@@ -52,6 +52,11 @@ class SettingsNotifier extends StateNotifier<Settings> {
     await _saveToPrefs();
   }
 
+  Future<void> updateSelectedLanguage(String? newValue) async {
+    state = state.copyWith(selectedLanguage: newValue);
+    await _saveToPrefs();
+  }
+
   Future<void> _saveToPrefs() async {
     final jsonString = jsonEncode(state.toJson());
     await _prefs.setString(_storageKey, jsonString);

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:mostro_mobile/features/relays/widgets/relay_selector.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/shared/widgets/currency_combo_box.dart';
 import 'package:mostro_mobile/shared/widgets/custom_card.dart';
+import 'package:mostro_mobile/shared/widgets/language_selector.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class SettingsScreen extends ConsumerWidget {
@@ -44,7 +45,32 @@ class SettingsScreen extends ConsumerWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     spacing: 24,
                     children: [
-                      // General Settings
+                      // Language Settings
+                      CustomCard(
+                        color: AppTheme.dark2,
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          spacing: 16,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              spacing: 8,
+                              children: [
+                                const Icon(
+                                  Icons.language,
+                                  color: AppTheme.mostroGreen,
+                                ),
+                                Text(S.of(context)!.language, style: textTheme.titleLarge),
+                              ],
+                            ),
+                            Text(S.of(context)!.chooseLanguageDescription,
+                                style: textTheme.bodyMedium
+                                    ?.copyWith(color: AppTheme.grey2)),
+                            const LanguageSelector(),
+                          ],
+                        ),
+                      ),
+                      // Currency Settings
                       CustomCard(
                         color: AppTheme.dark2,
                         padding: const EdgeInsets.all(16),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -399,5 +399,10 @@
   "share": "Share",
   "failedToShareInvoice": "Failed to share invoice. Please try copying instead.",
   "openWallet": "OPEN WALLET",
-  "done": "DONE"
+  "language": "Language",
+  "systemDefault": "System Default",
+  "english": "English",
+  "spanish": "Spanish",
+  "italian": "Italian",
+  "chooseLanguageDescription": "Choose your preferred language or use system default"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -399,5 +399,11 @@
   "share": "Compartir",
   "failedToShareInvoice": "Error al compartir factura. Por favor intenta copiarla en su lugar.",
   "openWallet": "ABRIR BILLETERA",
+  "language": "Idioma",
+  "systemDefault": "Predeterminado del sistema",
+  "english": "Inglés",
+  "spanish": "Español",
+  "italian": "Italiano",
+  "chooseLanguageDescription": "Elige tu idioma preferido o usa el predeterminado del sistema",
   "done": "HECHO"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -399,5 +399,11 @@
   "share": "Condividi",
   "failedToShareInvoice": "Errore nel condividere la fattura. Per favore prova a copiarla invece.",
   "openWallet": "APRI PORTAFOGLIO",
+  "language": "Lingua",
+  "systemDefault": "Predefinito di sistema",
+  "english": "Inglese",
+  "spanish": "Spagnolo",
+  "italian": "Italiano",
+  "chooseLanguageDescription": "Scegli la tua lingua preferita o usa il predefinito di sistema",
   "done": "FATTO"
 }

--- a/lib/shared/notifiers/locale_notifier.dart
+++ b/lib/shared/notifiers/locale_notifier.dart
@@ -1,0 +1,30 @@
+import 'dart:ui' as ui;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Notifier that tracks system locale changes
+class LocaleNotifier extends StateNotifier<Locale> {
+  LocaleNotifier() : super(ui.PlatformDispatcher.instance.locale) {
+    // Listen to system locale changes
+    ui.PlatformDispatcher.instance.onLocaleChanged = _onLocaleChanged;
+  }
+
+  void _onLocaleChanged() {
+    final newLocale = ui.PlatformDispatcher.instance.locale;
+    if (state != newLocale) {
+      state = newLocale;
+    }
+  }
+
+  @override
+  void dispose() {
+    // Clean up the listener
+    ui.PlatformDispatcher.instance.onLocaleChanged = null;
+    super.dispose();
+  }
+}
+
+/// Provider for system locale changes
+final systemLocaleProvider = StateNotifierProvider<LocaleNotifier, Locale>((ref) {
+  return LocaleNotifier();
+});

--- a/lib/shared/widgets/language_selector.dart
+++ b/lib/shared/widgets/language_selector.dart
@@ -21,18 +21,17 @@ class LanguageSelector extends ConsumerWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: AppTheme.backgroundInput,
+        color: AppTheme.dark1,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppTheme.grey2, width: 1),
       ),
       child: DropdownButtonHideUnderline(
         child: DropdownButton<String?>(
           value: currentLanguage,
           isExpanded: true,
-          dropdownColor: AppTheme.backgroundInput,
+          dropdownColor: AppTheme.dark1,
           style: const TextStyle(color: AppTheme.cream1),
           icon: const Icon(Icons.arrow_drop_down, color: AppTheme.cream1),
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
           items: _languageKeys.entries.map((entry) {
             final languageCode = entry.key;
             final languageKey = entry.value;
@@ -56,14 +55,6 @@ class LanguageSelector extends ConsumerWidget {
                       fontSize: 16,
                     ),
                   ),
-                  if (languageCode == currentLanguage) ...[
-                    const Spacer(),
-                    const Icon(
-                      Icons.check,
-                      color: AppTheme.mostroGreen,
-                      size: 20,
-                    ),
-                  ],
                 ],
               ),
             );

--- a/lib/shared/widgets/language_selector.dart
+++ b/lib/shared/widgets/language_selector.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+
+
+class LanguageSelector extends ConsumerWidget {
+  const LanguageSelector({super.key});
+
+  static const Map<String?, String> _languageOptions = {
+    null: 'System Default', // Will be localized in build method
+    'en': 'English',
+    'es': 'Español',
+    'it': 'Italiano',
+  };
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(settingsProvider);
+    final currentLanguage = settings.selectedLanguage;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppTheme.backgroundInput,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppTheme.grey2, width: 1),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String?>(
+          value: currentLanguage,
+          isExpanded: true,
+          dropdownColor: AppTheme.backgroundInput,
+          style: const TextStyle(color: AppTheme.cream1),
+          icon: const Icon(Icons.arrow_drop_down, color: AppTheme.cream1),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          items: _languageOptions.entries.map((entry) {
+            final languageCode = entry.key;
+            final languageName = entry.value;
+            
+            // Localize "System Default" text
+            final displayName = languageCode == null 
+                ? 'System Default' // Fallback text since systemDefault may not exist
+                : languageName;
+            
+            return DropdownMenuItem<String?>(
+              value: languageCode,
+              child: Row(
+                children: [
+                  Icon(
+                    languageCode == null ? Icons.phone_android : Icons.language,
+                    color: AppTheme.mostroGreen,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    displayName,
+                    style: const TextStyle(
+                      color: AppTheme.cream1,
+                      fontSize: 16,
+                    ),
+                  ),
+                  if (languageCode == currentLanguage) ...[
+                    const Spacer(),
+                    const Icon(
+                      Icons.check,
+                      color: AppTheme.mostroGreen,
+                      size: 20,
+                    ),
+                  ],
+                ],
+              ),
+            );
+          }).toList(),
+          onChanged: (String? newLanguage) {
+            ref.read(settingsProvider.notifier).updateSelectedLanguage(newLanguage);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/language_selector.dart
+++ b/lib/shared/widgets/language_selector.dart
@@ -2,16 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
-
+import 'package:mostro_mobile/generated/l10n.dart';
 
 class LanguageSelector extends ConsumerWidget {
   const LanguageSelector({super.key});
 
-  static const Map<String?, String> _languageOptions = {
-    null: 'System Default', // Will be localized in build method
-    'en': 'English',
-    'es': 'Español',
-    'it': 'Italiano',
+  static const Map<String?, String> _languageKeys = {
+    null: 'systemDefault',
+    'en': 'english',
+    'es': 'spanish',
+    'it': 'italian',
   };
 
   @override
@@ -33,15 +33,12 @@ class LanguageSelector extends ConsumerWidget {
           style: const TextStyle(color: AppTheme.cream1),
           icon: const Icon(Icons.arrow_drop_down, color: AppTheme.cream1),
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          items: _languageOptions.entries.map((entry) {
+          items: _languageKeys.entries.map((entry) {
             final languageCode = entry.key;
-            final languageName = entry.value;
-            
-            // Localize "System Default" text
-            final displayName = languageCode == null 
-                ? 'System Default' // Fallback text since systemDefault may not exist
-                : languageName;
-            
+            final languageKey = entry.value;
+
+            final displayName = _getLocalizedLanguageName(context, languageKey);
+
             return DropdownMenuItem<String?>(
               value: languageCode,
               child: Row(
@@ -72,10 +69,27 @@ class LanguageSelector extends ConsumerWidget {
             );
           }).toList(),
           onChanged: (String? newLanguage) {
-            ref.read(settingsProvider.notifier).updateSelectedLanguage(newLanguage);
+            ref
+                .read(settingsProvider.notifier)
+                .updateSelectedLanguage(newLanguage);
           },
         ),
       ),
     );
+  }
+
+  String _getLocalizedLanguageName(BuildContext context, String key) {
+    switch (key) {
+      case 'systemDefault':
+        return S.of(context)!.systemDefault;
+      case 'english':
+        return S.of(context)!.english;
+      case 'spanish':
+        return S.of(context)!.spanish;
+      case 'italian':
+        return S.of(context)!.italian;
+      default:
+        return key;
+    }
   }
 }

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -401,7 +401,6 @@ class MockOpenOrdersRepository extends _i1.Mock
 /// A class which mocks [SharedPreferencesAsync].
 ///
 /// See the documentation for Mockito's code generation for more information.
-// ignore: must_be_immutable
 class MockSharedPreferencesAsync extends _i1.Mock
     implements _i11.SharedPreferencesAsync {
   MockSharedPreferencesAsync() {

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -401,6 +401,7 @@ class MockOpenOrdersRepository extends _i1.Mock
 /// A class which mocks [SharedPreferencesAsync].
 ///
 /// See the documentation for Mockito's code generation for more information.
+// ignore: must_be_immutable
 class MockSharedPreferencesAsync extends _i1.Mock
     implements _i11.SharedPreferencesAsync {
   MockSharedPreferencesAsync() {


### PR DESCRIPTION
Implements #67
- Added a language selector to the app settings, allowing users to override the app language or use the device default.
- Integrated all relevant localization strings and resolved ARB file issues.
- The app now updates its language immediately based on user selection or falls back to the system locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a language selection option in the settings, allowing users to choose their preferred app language or use the system default.
  * Introduced a language selector widget with support for English, Spanish, and Italian.
  * Updated the settings screen with a new language section.
  * Improved locale handling to dynamically prioritize user-selected language or system locale with a refined fallback mechanism.

* **Localization**
  * Added new localization strings for language selection in English, Spanish, and Italian.

* **Bug Fixes**
  * The app now correctly uses the user-selected language preference instead of always defaulting to Spanish when the system locale is Spanish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->