### PR TITLE
feat: update app identifier

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.mostro_mobile"
+    namespace = "network.mostro.app"
     compileSdk = 35 // flutter.compileSdkVersion
     ndkVersion = "26.3.11579264" //flutter.ndkVersion
 
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.mostro_mobile"
+        applicationId = "network.mostro.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 23 // flutter.minSdkVersion

--- a/android/app/src/main/kotlin/com/example/mostro_mobile/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mostro_mobile/MainActivity.kt
@@ -1,5 +1,0 @@
-package com.example.mostro_mobile
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity: FlutterActivity()

--- a/android/app/src/main/kotlin/network/mostro/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/network/mostro/app/MainActivity.kt
@@ -1,0 +1,5 @@
+package network.mostro.app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity()

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "mostro_client")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.mostro_mobile")
+set(APPLICATION_ID "network.mostro.app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -480,7 +480,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/mostro_mobile.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mostro_mobile";
@@ -496,7 +496,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/mostro_mobile.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mostro_mobile";
@@ -512,7 +512,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/mostro_mobile.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mostro_mobile";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = Mostro P2P
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.mostroMobile
+PRODUCT_BUNDLE_IDENTIFIER = network.mostro.app
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2024 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2024 network.mostro. All rights reserved.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
+            VALUE "CompanyName", "network.mostro" "\0"
             VALUE "FileDescription", "mostro_mobile" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "mostro_mobile" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2024 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2024 network.mostro. All rights reserved." "\0"
             VALUE "OriginalFilename", "mostro_mobile.exe" "\0"
             VALUE "ProductName", "mostro_mobile" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
Updates application identifier across all platforms:
- Android: namespace and applicationId in build.gradle
- iOS: PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj
- macOS: PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj and AppInfo.xcconfig
- Linux: APPLICATION_ID in CMakeLists.txt
- Windows: CompanyName in Runner.rc

Migrates Android package structure from com.example.mostro_mobile to network.mostro.app