### PR TITLE
fix: resolve cancel button loading state and improve  cancel dialog UX

### DIFF
--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -247,33 +247,40 @@ class TradeDetailScreen extends ConsumerWidget {
             cancelMessage = S.of(context)!.areYouSureCancel;
           }
 
+          final buttonController = MostroReactiveButtonController();
           widgets.add(_buildNostrButton(
             S.of(context)!.cancel,
             action: action,
             backgroundColor: AppTheme.red1,
-            onPressed: () {
-              showDialog(
+            controller: buttonController,
+            onPressed: () async {
+              final result = await showDialog<bool>(
                 context: context,
                 builder: (context) => AlertDialog(
                   title: Text(S.of(context)!.cancelTrade),
                   content: Text(cancelMessage),
                   actions: [
                     TextButton(
-                      onPressed: () => context.pop(),
-                      child: Text(S.of(context)!.cancel),
+                      onPressed: () => context.pop(false),
+                      child: Text(S.of(context)!.no),
                     ),
                     ElevatedButton(
                       onPressed: () {
-                        context.pop();
+                        context.pop(true);
                         ref
                             .read(orderNotifierProvider(orderId).notifier)
                             .cancelOrder();
                       },
-                      child: Text(S.of(context)!.confirm),
+                      child: Text(S.of(context)!.yes),
                     ),
                   ],
                 ),
               );
+              
+              // Reset loading state if dialog was cancelled
+              if (result != true) {
+                buttonController.resetLoading();
+              }
             },
           ));
           break;
@@ -455,8 +462,11 @@ class TradeDetailScreen extends ConsumerWidget {
     required actions.Action action,
     required VoidCallback? onPressed,
     Color? backgroundColor,
+    Key? key,
+    MostroReactiveButtonController? controller,
   }) {
     return MostroReactiveButton(
+      key: key,
       label: label,
       buttonStyle: ButtonStyleType.raised,
       orderId: orderId,
@@ -465,6 +475,7 @@ class TradeDetailScreen extends ConsumerWidget {
       onPressed: onPressed ?? () {}, // Provide empty function when null
       showSuccessIndicator: true,
       timeout: const Duration(seconds: 30),
+      controller: controller,
     );
   }
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -164,6 +164,8 @@
   "cooperativeCancelMessage": "If you confirm, you will start a cooperative cancellation with your counterparty.",
   "acceptCancelMessage": "If you confirm, you will accept the cooperative cancellation initiated by your counterparty.",
   "confirm": "Confirm",
+  "yes": "Yes",
+  "no": "No",
   "buy": "BUY",
   "sell": "SELL",
   "buying": "BUYING",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -164,6 +164,8 @@
   "cooperativeCancelMessage": "Si confirmas, iniciarás una cancelación cooperativa con tu contraparte.",
   "acceptCancelMessage": "Si confirmas, aceptarás la cancelación cooperativa iniciada por tu contraparte.",
   "confirm": "Confirmar",
+  "yes": "Sí",
+  "no": "No",
   "buy": "COMPRAR",
   "sell": "VENDER",
   "buying": "COMPRANDO",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -164,6 +164,8 @@
   "cooperativeCancelMessage": "Se confermi, inizierai un annullamento cooperativo con la tua controparte.",
   "acceptCancelMessage": "Se confermi, accetterai l'annullamento cooperativo iniziato dalla tua controparte.",
   "confirm": "Conferma",
+  "yes": "Sì",
+  "no": "No",
   "buy": "COMPRA",
   "sell": "VENDI",
   "buying": "COMPRANDO",

--- a/lib/shared/widgets/mostro_reactive_button.dart
+++ b/lib/shared/widgets/mostro_reactive_button.dart
@@ -8,6 +8,23 @@ import 'package:mostro_mobile/core/app_theme.dart';
 
 enum ButtonStyleType { raised, outlined, text }
 
+/// Controller for managing MostroReactiveButton state externally
+class MostroReactiveButtonController {
+  _MostroReactiveButtonState? _state;
+  
+  void _attach(_MostroReactiveButtonState state) {
+    _state = state;
+  }
+  
+  void _detach() {
+    _state = null;
+  }
+  
+  void resetLoading() {
+    _state?.resetLoading();
+  }
+}
+
 /// A button specially designed for reactive operations that shows loading state
 /// and handles the unique event-based nature of the mostro protocol.
 class MostroReactiveButton extends ConsumerStatefulWidget {
@@ -21,6 +38,7 @@ class MostroReactiveButton extends ConsumerStatefulWidget {
   final bool showSuccessIndicator;
 
   final Color? backgroundColor;
+  final MostroReactiveButtonController? controller;
 
   const MostroReactiveButton({
     super.key,
@@ -32,6 +50,7 @@ class MostroReactiveButton extends ConsumerStatefulWidget {
     this.timeout = const Duration(seconds: 30),
     this.showSuccessIndicator = false,
     this.backgroundColor,
+    this.controller,
   });
 
   @override
@@ -46,9 +65,24 @@ class _MostroReactiveButtonState extends ConsumerState<MostroReactiveButton> {
   dynamic _lastSeenAction;
 
   @override
+  void initState() {
+    super.initState();
+    widget.controller?._attach(this);
+  }
+
+  @override
   void dispose() {
+    widget.controller?._detach();
     _timeoutTimer?.cancel();
     super.dispose();
+  }
+
+  void resetLoading() {
+    setState(() {
+      _loading = false;
+      _showSuccess = false;
+    });
+    _timeoutTimer?.cancel();
   }
 
   void _startOperation() {


### PR DESCRIPTION
fix #132 
This PR fixes the issue where, after clicking the Cancel button in the order cancellation modal, the app returned to the previous screen but the Cancel button there remained stuck in a loading state.

Additionally, the modal buttons were updated from Cancel / Confirm to No / Yes to improve UX. The previous labels could be confusing for users canceling an order, as seeing "Cancel" twice might lead them to think they need to cancel the action instead of confirming it.
<img width="505" height="715" alt="Captura desde 2025-07-10 15-15-01" src="https://github.com/user-attachments/assets/cac25d1b-c966-4a96-9529-09b11ab7a45b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Yes" and "No" options to confirmation dialogs, with support for English, Spanish, and Italian languages.
  * Introduced a new button controller for improved management of action button states, allowing external reset of loading indicators.

* **Improvements**
  * Confirmation dialogs now use "Yes" and "No" labels for clearer user choices. 
  * Enhanced action button responsiveness after dialog cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->