### PR TITLE
feat: implement simplified mostro: deep linking scheme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,12 +27,12 @@
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 
-			<!-- Deep Link Support for nostr: scheme -->
+			<!-- Deep Link Support for mostro: scheme -->
 			<intent-filter android:autoVerify="true">
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
-				<data android:scheme="nostr" />
+				<data android:scheme="mostro" />
 			</intent-filter>
 		</activity>
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -55,15 +55,15 @@
 			<string>processing</string>
 			<string>remote-notification</string>
 		</array>
-		<!-- Deep Link Support for nostr: scheme -->
+		<!-- Deep Link Support for mostro: scheme -->
 		<key>CFBundleURLTypes</key>
 		<array>
 			<dict>
 				<key>CFBundleURLName</key>
-				<string>nostr.scheme</string>
+				<string>mostro.scheme</string>
 				<key>CFBundleURLSchemes</key>
 				<array>
-					<string>nostr</string>
+					<string>mostro</string>
 				</array>
 				<key>CFBundleTypeRole</key>
 				<string>Editor</string>

--- a/lib/core/app_routes.dart
+++ b/lib/core/app_routes.dart
@@ -23,10 +23,12 @@ import 'package:mostro_mobile/features/walkthrough/screens/walkthrough_screen.da
 import 'package:mostro_mobile/features/walkthrough/providers/first_run_provider.dart';
 import 'package:mostro_mobile/shared/widgets/navigation_listener_widget.dart';
 import 'package:mostro_mobile/shared/widgets/notification_listener_widget.dart';
+import 'package:logger/logger.dart';
 
 GoRouter createRouter(WidgetRef ref) {
   return GoRouter(
     navigatorKey: GlobalKey<NavigatorState>(),
+    initialLocation: '/',
     redirect: (context, state) {
       final firstRunState = ref.read(firstRunProvider);
 
@@ -41,8 +43,31 @@ GoRouter createRouter(WidgetRef ref) {
         error: (_, __) => null,
       );
     },
+    errorBuilder: (context, state) {
+      final logger = Logger();
+      logger.w('GoRouter error: ${state.error}');
+      
+      // For errors, show a generic error page
+      return Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error, size: 64),
+              const SizedBox(height: 16),
+              Text('Navigation Error: ${state.error}'),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => context.go('/'),
+                child: const Text('Go Home'),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
     routes: [
-      ShellRoute(
+    ShellRoute(
         builder: (BuildContext context, GoRouterState state, Widget child) {
           return NotificationListenerWidget(
             child: NavigationListenerWidget(
@@ -227,10 +252,6 @@ GoRouter createRouter(WidgetRef ref) {
         ],
       ),
     ],
-    initialLocation: '/',
-    errorBuilder: (context, state) => Scaffold(
-      body: Center(child: Text(state.error.toString())),
-    ),
   );
 }
 

--- a/lib/core/app_routes.dart
+++ b/lib/core/app_routes.dart
@@ -24,6 +24,7 @@ import 'package:mostro_mobile/features/walkthrough/providers/first_run_provider.
 import 'package:mostro_mobile/shared/widgets/navigation_listener_widget.dart';
 import 'package:mostro_mobile/shared/widgets/notification_listener_widget.dart';
 import 'package:logger/logger.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
 
 GoRouter createRouter(WidgetRef ref) {
   return GoRouter(
@@ -55,11 +56,11 @@ GoRouter createRouter(WidgetRef ref) {
             children: [
               const Icon(Icons.error, size: 64),
               const SizedBox(height: 16),
-              Text('Navigation Error: ${state.error}'),
+              Text(S.of(context)!.deepLinkNavigationError(state.error.toString())),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () => context.go('/'),
-                child: const Text('Go Home'),
+                child: Text(S.of(context)!.deepLinkGoHome),
               ),
             ],
           ),

--- a/lib/core/deep_link_handler.dart
+++ b/lib/core/deep_link_handler.dart
@@ -81,7 +81,7 @@ class DeepLinkHandler {
       final deepLinkService = _ref.read(deepLinkServiceProvider);
 
       // Process the mostro link
-      final result = await deepLinkService.processMostroLink(url, nostrService);
+      final result = await deepLinkService.processMostroLink(url, nostrService, context!);
 
       // Get fresh context after async operation
       final currentContext = router.routerDelegate.navigatorKey.currentContext;

--- a/lib/core/deep_link_handler.dart
+++ b/lib/core/deep_link_handler.dart
@@ -39,9 +39,9 @@ class DeepLinkHandler {
     try {
       _logger.i('Handling deep link: $uri');
 
-      // Check if it's a nostr: scheme
-      if (uri.scheme == 'nostr') {
-        await _handleNostrDeepLink(uri.toString(), router);
+      // Check if it's a mostro: scheme
+      if (uri.scheme == 'mostro') {
+        await _handleMostroDeepLink(uri.toString(), router);
       } else {
         _logger.w('Unsupported deep link scheme: ${uri.scheme}');
         final context = router.routerDelegate.navigatorKey.currentContext;
@@ -58,8 +58,8 @@ class DeepLinkHandler {
     }
   }
 
-  /// Handles nostr: scheme deep links
-  Future<void> _handleNostrDeepLink(
+  /// Handles mostro: scheme deep links
+  Future<void> _handleMostroDeepLink(
     String url,
     GoRouter router,
   ) async {
@@ -75,8 +75,8 @@ class DeepLinkHandler {
       final nostrService = _ref.read(nostrServiceProvider);
       final deepLinkService = _ref.read(deepLinkServiceProvider);
 
-      // Process the nostr link
-      final result = await deepLinkService.processNostrLink(url, nostrService);
+      // Process the mostro link
+      final result = await deepLinkService.processMostroLink(url, nostrService);
 
       // Get fresh context after async operation
       final currentContext = router.routerDelegate.navigatorKey.currentContext;
@@ -96,10 +96,10 @@ class DeepLinkHandler {
           final errorMessage = result.error ?? S.of(errorContext)!.failedToLoadOrder;
           _showErrorSnackBar(errorContext, errorMessage);
         }
-        _logger.w('Failed to process nostr link: ${result.error}');
+        _logger.w('Failed to process mostro link: ${result.error}');
       }
     } catch (e) {
-      _logger.e('Error processing nostr deep link: $e');
+      _logger.e('Error processing mostro deep link: $e');
       final errorContext = router.routerDelegate.navigatorKey.currentContext;
       if (errorContext != null && errorContext.mounted) {
         Navigator.of(errorContext).pop(); // Hide loading if still showing

--- a/lib/core/deep_link_handler.dart
+++ b/lib/core/deep_link_handler.dart
@@ -31,6 +31,11 @@ class DeepLinkHandler {
     );
   }
 
+  /// Handles initial deep link from app launch
+  Future<void> handleInitialDeepLink(Uri uri, GoRouter router) async {
+    await _handleDeepLink(uri, router);
+  }
+
   /// Handles incoming deep links
   Future<void> _handleDeepLink(
     Uri uri,
@@ -87,8 +92,10 @@ class DeepLinkHandler {
       }
 
       if (result.isSuccess && result.orderInfo != null) {
-        // Navigate to the appropriate screen
-        deepLinkService.navigateToOrder(router, result.orderInfo!);
+        // Navigate to the appropriate screen with proper timing
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          deepLinkService.navigateToOrder(router, result.orderInfo!);
+        });
         _logger.i('Successfully navigated to order: ${result.orderInfo!.orderId} (${result.orderInfo!.orderType.value})');
       } else {
         final errorContext = router.routerDelegate.navigatorKey.currentContext;

--- a/lib/core/deep_link_interceptor.dart
+++ b/lib/core/deep_link_interceptor.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'package:flutter/widgets.dart';
+import 'package:logger/logger.dart';
+
+/// A deep link interceptor that prevents custom schemes from reaching GoRouter
+/// This prevents assertion failures when the system tries to parse mostro: URLs
+class DeepLinkInterceptor extends WidgetsBindingObserver {
+  final Logger _logger = Logger();
+  final StreamController<String> _customUrlController = 
+      StreamController<String>.broadcast();
+
+  /// Stream for custom URLs that were intercepted
+  Stream<String> get customUrlStream => _customUrlController.stream;
+
+  /// Initialize the interceptor
+  void initialize() {
+    WidgetsBinding.instance.addObserver(this);
+    _logger.i('DeepLinkInterceptor initialized');
+  }
+
+  @override
+  Future<bool> didPushRouteInformation(RouteInformation routeInformation) async {
+    final uri = routeInformation.uri;
+    _logger.i('Route information received: $uri');
+
+    // Check if this is a custom scheme URL
+    if (_isCustomScheme(uri)) {
+      _logger.i('Custom scheme detected: ${uri.scheme}, intercepting');
+      
+      // Emit the custom URL for processing
+      _customUrlController.add(uri.toString());
+      
+      // Return true to indicate we handled this route, preventing it from
+      // reaching GoRouter and causing assertion failures
+      return true;
+    }
+
+    // Let normal URLs pass through to GoRouter
+    return super.didPushRouteInformation(routeInformation);
+  }
+
+  // Note: didPushRoute is deprecated, but we keep it for compatibility
+  // The main handling is done in didPushRouteInformation above
+
+  /// Check if the URI uses a custom scheme
+  bool _isCustomScheme(Uri uri) {
+    return uri.scheme == 'mostro' || 
+           (!uri.scheme.startsWith('http') && uri.scheme.isNotEmpty);
+  }
+
+  /// Dispose the interceptor
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _customUrlController.close();
+    _logger.i('DeepLinkInterceptor disposed');
+  }
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -452,5 +452,21 @@
   "unsupportedLinkFormat": "Unsupported link format",
   "failedToOpenLink": "Failed to open link",
   "failedToLoadOrder": "Failed to load order",
-  "failedToOpenOrder": "Failed to open order"
+  "failedToOpenOrder": "Failed to open order",
+
+  "@_comment_deep_link_errors": "Deep Link Error Messages",
+  "deepLinkInvalidFormat": "Invalid mostro: URL format",
+  "deepLinkParseError": "Failed to parse mostro: URL",
+  "deepLinkInvalidOrderId": "Invalid order ID format",
+  "deepLinkNoRelays": "No relays specified in URL",
+  "deepLinkOrderNotFound": "Order not found or invalid",
+  "deepLinkNavigationError": "Navigation Error: {error}",
+  "@deepLinkNavigationError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deepLinkGoHome": "Go Home"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -485,6 +485,22 @@
   "unsupportedLinkFormat": "Formato de enlace no compatible",
   "failedToOpenLink": "Error al abrir enlace",
   "failedToLoadOrder": "Error al cargar orden",
-  "failedToOpenOrder": "Error al abrir orden"
+  "failedToOpenOrder": "Error al abrir orden",
+
+  "@_comment_deep_link_errors": "Mensajes de Error de Enlaces Profundos",
+  "deepLinkInvalidFormat": "Formato de URL mostro: inválido",
+  "deepLinkParseError": "Error al analizar la URL mostro:",
+  "deepLinkInvalidOrderId": "Formato de ID de orden inválido",
+  "deepLinkNoRelays": "No se especificaron relés en la URL",
+  "deepLinkOrderNotFound": "Orden no encontrada o inválida",
+  "deepLinkNavigationError": "Error de Navegación: {error}",
+  "@deepLinkNavigationError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deepLinkGoHome": "Ir al Inicio"
 
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -493,6 +493,22 @@
   "unsupportedLinkFormat": "Formato di link non supportato",
   "failedToOpenLink": "Impossibile aprire il link",
   "failedToLoadOrder": "Impossibile caricare l'ordine",
-  "failedToOpenOrder": "Impossibile aprire l'ordine"
+  "failedToOpenOrder": "Impossibile aprire l'ordine",
+
+  "@_comment_deep_link_errors": "Messaggi di Errore per Deep Link",
+  "deepLinkInvalidFormat": "Formato URL mostro: non valido",
+  "deepLinkParseError": "Impossibile analizzare l'URL mostro:",
+  "deepLinkInvalidOrderId": "Formato ID ordine non valido",
+  "deepLinkNoRelays": "Nessun relay specificato nell'URL",
+  "deepLinkOrderNotFound": "Ordine non trovato o non valido",
+  "deepLinkNavigationError": "Errore di Navigazione: {error}",
+  "@deepLinkNavigationError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deepLinkGoHome": "Vai alla Home"
 
 }

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -24,7 +24,8 @@ class DeepLinkService {
   final AppLinks _appLinks = AppLinks();
 
   // Stream controller for deep link events
-  final StreamController<Uri> _deepLinkController = StreamController<Uri>.broadcast();
+  final StreamController<Uri> _deepLinkController =
+      StreamController<Uri>.broadcast();
   Stream<Uri> get deepLinkStream => _deepLinkController.stream;
 
   // Flag to track if service is initialized
@@ -118,7 +119,9 @@ class DeepLinkService {
       // Create a filter to search for NIP-69 order events with the specific order ID
       final filter = NostrFilter(
         kinds: [38383], // NIP-69 order events
-        additionalFilters: {'#d': [orderId]}, // Order ID is stored in 'd' tag
+        additionalFilters: {
+          '#d': [orderId]
+        }, // Order ID is stored in 'd' tag
       );
 
       List<NostrEvent> events = [];
@@ -126,33 +129,32 @@ class DeepLinkService {
       // First try to fetch from specified relays
       if (relays.isNotEmpty) {
         // Use the existing _fetchFromSpecificRelays method pattern
-        final orderEvents = await nostrService.fecthEvents(filter);
+        final orderEvents = await nostrService.fetchEvents(filter);
         events.addAll(orderEvents);
       }
 
       // If no events found and we have default relays, try those
       if (events.isEmpty) {
         _logger.i('Order not found in specified relays, trying default relays');
-        final defaultEvents = await nostrService.fecthEvents(filter);
+        final defaultEvents = await nostrService.fetchEvents(filter);
         events.addAll(defaultEvents);
       }
 
       // Process the first matching event
       if (events.isNotEmpty) {
         final event = events.first;
-        
+
         // Extract order type from 'k' tag
         final kTag = event.tags?.firstWhere(
           (tag) => tag.isNotEmpty && tag[0] == 'k',
           orElse: () => <String>[],
         );
-        
+
         if (kTag != null && kTag.length > 1) {
           final orderTypeValue = kTag[1];
-          final orderType = orderTypeValue == 'sell' 
-              ? OrderType.sell 
-              : OrderType.buy;
-          
+          final orderType =
+              orderTypeValue == 'sell' ? OrderType.sell : OrderType.buy;
+
           return OrderInfo(
             orderId: orderId,
             orderType: orderType,
@@ -166,7 +168,6 @@ class DeepLinkService {
       return null;
     }
   }
-
 
   /// Determines the appropriate navigation route for an order
   String getNavigationRoute(OrderInfo orderInfo) {
@@ -182,7 +183,8 @@ class DeepLinkService {
   /// Navigates to the appropriate screen for the given order
   void navigateToOrder(GoRouter router, OrderInfo orderInfo) {
     final route = getNavigationRoute(orderInfo);
-    _logger.i('Navigating to: $route (Order: ${orderInfo.orderId}, Type: ${orderInfo.orderType.value})');
+    _logger.i(
+        'Navigating to: $route (Order: ${orderInfo.orderId}, Type: ${orderInfo.orderType.value})');
     router.push(route);
   }
 

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -141,8 +141,8 @@ class DeepLinkService {
 
       // First try to fetch from specified relays
       if (relays.isNotEmpty) {
-        // Use the existing _fetchFromSpecificRelays method pattern
-        final orderEvents = await nostrService.fetchEvents(filter);
+        // Use the specific relays from the deep link URL
+        final orderEvents = await nostrService.fetchEvents(filter, specificRelays: relays);
         events.addAll(orderEvents);
       }
 

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -8,6 +8,7 @@ import 'package:logger/logger.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
 
 /// Contains order information extracted from a Nostr event
 class OrderInfo {
@@ -68,19 +69,20 @@ class DeepLinkService {
   Future<DeepLinkResult> processMostroLink(
     String url,
     NostrService nostrService,
+    BuildContext context,
   ) async {
     try {
       _logger.i('Processing mostro link: $url');
 
       // Validate URL format
       if (!NostrUtils.isValidMostroUrl(url)) {
-        return DeepLinkResult.error('Invalid mostro: URL format');
+        return DeepLinkResult.error(S.of(context)!.deepLinkInvalidFormat);
       }
 
       // Parse the mostro URL
       final orderInfo = NostrUtils.parseMostroUrl(url);
       if (orderInfo == null) {
-        return DeepLinkResult.error('Failed to parse mostro: URL');
+        return DeepLinkResult.error(S.of(context)!.deepLinkParseError);
       }
 
       final orderId = orderInfo['orderId'] as String;
@@ -88,12 +90,12 @@ class DeepLinkService {
 
       // Validate order ID format (UUID-like string)
       if (orderId.isEmpty || orderId.length < 10) {
-        return DeepLinkResult.error('Invalid order ID format');
+        return DeepLinkResult.error(S.of(context)!.deepLinkInvalidOrderId);
       }
 
       // Validate relays
       if (relays.isEmpty) {
-        return DeepLinkResult.error('No relays specified in URL');
+        return DeepLinkResult.error(S.of(context)!.deepLinkNoRelays);
       }
 
       _logger.i('Parsed order ID: $orderId, relays: $relays');
@@ -106,7 +108,11 @@ class DeepLinkService {
       );
 
       if (fetchedOrderInfo == null) {
-        return DeepLinkResult.error('Order not found or invalid');
+        if (context.mounted) {
+          return DeepLinkResult.error(S.of(context)!.deepLinkOrderNotFound);
+        } else {
+          return DeepLinkResult.error('Order not found or invalid');
+        }
       }
 
       return DeepLinkResult.success(fetchedOrderInfo);

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -89,11 +89,17 @@ class NostrService {
     }
   }
 
-  Future<List<NostrEvent>> fetchEvents(NostrFilter filter) async {
+  Future<List<NostrEvent>> fetchEvents(NostrFilter filter, {List<String>? specificRelays}) async {
     if (!_isInitialized) {
       throw Exception('Nostr is not initialized. Call init() first.');
     }
 
+    // If specific relays are provided, use the relay-specific fetching logic
+    if (specificRelays != null && specificRelays.isNotEmpty) {
+      return await _fetchFromSpecificRelays(filter, specificRelays);
+    }
+
+    // Default behavior: use all configured relays
     final request = NostrRequest(filters: [filter]);
     return await _nostr.services.relays.startEventsSubscriptionAsync(
       request: request,

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -89,7 +89,7 @@ class NostrService {
     }
   }
 
-  Future<List<NostrEvent>> fecthEvents(NostrFilter filter) async {
+  Future<List<NostrEvent>> fetchEvents(NostrFilter filter) async {
     if (!_isInitialized) {
       throw Exception('Nostr is not initialized. Call init() first.');
     }
@@ -221,7 +221,7 @@ class NostrService {
         events = await _fetchFromSpecificRelays(filter, specificRelays);
       } else {
         // Use default relays
-        events = await fecthEvents(filter);
+        events = await fetchEvents(filter);
       }
 
       if (events.isEmpty) {
@@ -256,8 +256,9 @@ class NostrService {
   }
 
   /// Fetches order information from an event by extracting the 'd' tag (order ID) and 'k' tag (order type)
-  /// This is specifically for deep link handling where the nevent points to an event containing order information
-  Future<OrderInfo?> fetchOrderInfoByEventId(String eventId, [List<String>? specificRelays]) async {
+  /// This is specifically for deep link handling where the mostro: URL provides order information
+  Future<OrderInfo?> fetchOrderInfoByEventId(String eventId,
+      [List<String>? specificRelays]) async {
     try {
       _logger.i('Fetching order ID from event: $eventId');
 
@@ -273,7 +274,7 @@ class NostrService {
         events = await _fetchFromSpecificRelays(filter, specificRelays);
       } else {
         // Use default relays
-        events = await fecthEvents(filter);
+        events = await fetchEvents(filter);
       }
 
       if (events.isEmpty) {
@@ -333,7 +334,8 @@ class NostrService {
         return null;
       }
 
-      _logger.i('Successfully extracted order info - ID: $dTag, Type: ${orderType.value} from event: $eventId');
+      _logger.i(
+          'Successfully extracted order info - ID: $dTag, Type: ${orderType.value} from event: $eventId');
       return OrderInfo(orderId: dTag, orderType: orderType);
     } catch (e) {
       _logger.e('Error fetching order ID from event: $e');
@@ -368,7 +370,7 @@ class NostrService {
         await updateSettings(tempSettings);
 
         // Fetch the events
-        final events = await fecthEvents(filter);
+        final events = await fetchEvents(filter);
 
         // Restore original relays
         await updateSettings(settings);
@@ -376,7 +378,7 @@ class NostrService {
         return events;
       } else {
         // No new relays to add, use normal fetch
-        return await fecthEvents(filter);
+        return await fetchEvents(filter);
       }
     } catch (e) {
       _logger.e('Error fetching from specific relays: $e');

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -401,7 +401,6 @@ class MockOpenOrdersRepository extends _i1.Mock
 /// A class which mocks [SharedPreferencesAsync].
 ///
 /// See the documentation for Mockito's code generation for more information.
-// ignore: must_be_immutable
 class MockSharedPreferencesAsync extends _i1.Mock
     implements _i11.SharedPreferencesAsync {
   MockSharedPreferencesAsync() {

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -401,6 +401,7 @@ class MockOpenOrdersRepository extends _i1.Mock
 /// A class which mocks [SharedPreferencesAsync].
 ///
 /// See the documentation for Mockito's code generation for more information.
+// ignore: must_be_immutable
 class MockSharedPreferencesAsync extends _i1.Mock
     implements _i11.SharedPreferencesAsync {
   MockSharedPreferencesAsync() {

--- a/test/services/mostro_service_test.mocks.dart
+++ b/test/services/mostro_service_test.mocks.dart
@@ -179,11 +179,15 @@ class MockNostrService extends _i1.Mock implements _i6.NostrService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i3.NostrEvent>> fetchEvents(_i3.NostrFilter? filter) =>
+  _i7.Future<List<_i3.NostrEvent>> fetchEvents(
+    _i3.NostrFilter? filter, {
+    List<String>? specificRelays,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchEvents,
           [filter],
+          {#specificRelays: specificRelays},
         ),
         returnValue: _i7.Future<List<_i3.NostrEvent>>.value(<_i3.NostrEvent>[]),
       ) as _i7.Future<List<_i3.NostrEvent>>);

--- a/test/services/mostro_service_test.mocks.dart
+++ b/test/services/mostro_service_test.mocks.dart
@@ -179,10 +179,10 @@ class MockNostrService extends _i1.Mock implements _i6.NostrService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i3.NostrEvent>> fecthEvents(_i3.NostrFilter? filter) =>
+  _i7.Future<List<_i3.NostrEvent>> fetchEvents(_i3.NostrFilter? filter) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fecthEvents,
+          #fetchEvents,
           [filter],
         ),
         returnValue: _i7.Future<List<_i3.NostrEvent>>.value(<_i3.NostrEvent>[]),

--- a/test/utils/nostr_utils_test.dart
+++ b/test/utils/nostr_utils_test.dart
@@ -2,36 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 void main() {
-  group('NostrUtils nevent decoding tests', () {
-    const testNevent = 'nevent1qqs9hcuev4z4frqnn5wagnupzg4dahcwkyy9r3xvsjw6wd7cm4tmh4gprfmhxue69uhhyetvv9ujumt0wd68ymewdejhgam0wf4scqjs3l';
-    const testUrl = 'nostr:$testNevent';
-
-    test('should decode nevent and extract event ID', () {
-      final result = NostrUtils.decodeNevent(testNevent);
-      
-      expect(result, isA<Map<String, dynamic>>());
-      expect(result['eventId'], isA<String>());
-      expect(result['relays'], isA<List<String>>());
-      expect((result['eventId'] as String).isNotEmpty, isTrue);
-      expect(result['eventId'], equals('5be3996545548c139d1dd44f81122adedf0eb10851c4cc849da737d8dd57bbd5'));
-      expect(result['relays'], contains('wss://relay.mostro.network'));
-    });
-
-    test('should validate nostr URL correctly', () {
-      final isValid = NostrUtils.isValidNostrUrl(testUrl);
-      expect(isValid, isTrue);
-    });
-
-    test('should parse nostr URL correctly', () {
-      final result = NostrUtils.parseNostrUrl(testUrl);
-      
-      expect(result, isNotNull);
-      expect(result!['eventId'], isA<String>());
-      expect((result['eventId'] as String).isNotEmpty, isTrue);
-      expect(result['eventId'], equals('5be3996545548c139d1dd44f81122adedf0eb10851c4cc849da737d8dd57bbd5'));
-    });
-
-  });
 
   group('NostrUtils mostro URL tests', () {
     const testOrderId = 'order123456';

--- a/test/utils/nostr_utils_test.dart
+++ b/test/utils/nostr_utils_test.dart
@@ -32,4 +32,57 @@ void main() {
     });
 
   });
+
+  group('NostrUtils mostro URL tests', () {
+    const testOrderId = 'order123456';
+    const testRelays = 'wss://relay.mostro.network,wss://relay.damus.io';
+    const testMostroUrl = 'mostro:$testOrderId?relays=$testRelays';
+
+    test('should validate mostro URL correctly', () {
+      expect(NostrUtils.isValidMostroUrl(testMostroUrl), isTrue);
+    });
+
+    test('should reject invalid mostro URLs', () {
+      expect(NostrUtils.isValidMostroUrl('mostro:'), isFalse);
+      expect(NostrUtils.isValidMostroUrl('mostro:order123'), isFalse); // no relays
+      expect(NostrUtils.isValidMostroUrl('mostro:?relays=wss://relay.com'), isFalse); // no order id
+      expect(NostrUtils.isValidMostroUrl('nostr:order123?relays=wss://relay.com'), isFalse); // wrong scheme
+      expect(NostrUtils.isValidMostroUrl('mostro:order123?relays=http://relay.com'), isFalse); // invalid relay protocol
+    });
+
+    test('should parse mostro URL correctly', () {
+      final result = NostrUtils.parseMostroUrl(testMostroUrl);
+      
+      expect(result, isNotNull);
+      expect(result!['orderId'], equals(testOrderId));
+      expect(result['relays'], isA<List<String>>());
+      expect(result['relays'], contains('wss://relay.mostro.network'));
+      expect(result['relays'], contains('wss://relay.damus.io'));
+      expect((result['relays'] as List).length, equals(2));
+    });
+
+    test('should handle single relay in mostro URL', () {
+      const singleRelayUrl = 'mostro:order789?relays=wss://relay.mostro.network';
+      final result = NostrUtils.parseMostroUrl(singleRelayUrl);
+      
+      expect(result, isNotNull);
+      expect(result!['orderId'], equals('order789'));
+      expect(result['relays'], equals(['wss://relay.mostro.network']));
+    });
+
+    test('should handle relays with spaces', () {
+      const spacedRelaysUrl = 'mostro:order456?relays=wss://relay1.com, wss://relay2.com , wss://relay3.com';
+      final result = NostrUtils.parseMostroUrl(spacedRelaysUrl);
+      
+      expect(result, isNotNull);
+      expect(result!['relays'], equals(['wss://relay1.com', 'wss://relay2.com', 'wss://relay3.com']));
+    });
+
+    test('should return null for invalid mostro URLs', () {
+      expect(NostrUtils.parseMostroUrl('invalid:url'), isNull);
+      expect(NostrUtils.parseMostroUrl('mostro:'), isNull);
+      expect(NostrUtils.parseMostroUrl('mostro:order123'), isNull); // no relays
+    });
+
+  });
 }


### PR DESCRIPTION
Replace nostr: nevent-based deep links with simplified mostro: format.
New format: mostro:order-id?relays=wss://relay1,wss://relay2

- Add mostro URL validation and parsing in NostrUtils
- Update DeepLinkService to fetch orders by ID using NIP-69 filters
- Change DeepLinkHandler to handle mostro: scheme instead of nostr:
- Add comprehensive test coverage for new URL format
- Maintain backward compatibility with existing nevent methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing and processing "mostro:" deep links, including validation and parsing of mostro URLs.
  * Users can now open mostro links containing order IDs and relay information.
  * Deep link handling improved with interception of custom URLs before routing and deferred navigation to ensure smooth user experience.

* **Bug Fixes**
  * Improved error handling and messaging for invalid or unrecognized mostro links.
  * Fixed navigation timing issues to prevent routing errors during app lifecycle transitions.

* **Tests**
  * Introduced new tests to validate and parse mostro URLs, ensuring correct handling of various formats and edge cases.

* **Chores**
  * Updated Android and iOS app configurations to support the "mostro" URL scheme.
  * Corrected method name typos in event fetching for improved code clarity.

* **Refactor**
  * Replaced all references from "nostr" to "mostro" in deep link processing and related services.
  * Enhanced router error handling with a dedicated error screen and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->