### PR TITLE
Replace BUY/SELL BITCOIN by just BUY/SELL

### DIFF
--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -58,7 +58,6 @@ class TakeOrderScreen extends ConsumerWidget {
     );
   }
 
-
   Widget _buildSellerAmount(WidgetRef ref, NostrEvent order) {
     return Builder(
       builder: (context) {
@@ -87,7 +86,6 @@ class TakeOrderScreen extends ConsumerWidget {
                   color: Colors.white,
                   fontSize: 18,
                   fontWeight: FontWeight.w600,
-
                 ),
               ),
               const SizedBox(height: 8),
@@ -193,9 +191,8 @@ class TakeOrderScreen extends ConsumerWidget {
     final orderDetailsNotifier =
         ref.read(orderNotifierProvider(orderId).notifier);
 
-    final buttonText = orderType == OrderType.buy
-        ? S.of(context)!.sellBitcoinButton
-        : S.of(context)!.buyBitcoinButton;
+    final buttonText =
+        orderType == OrderType.buy ? S.of(context)!.sell : S.of(context)!.buy;
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -208,7 +205,6 @@ class TakeOrderScreen extends ConsumerWidget {
           ),
         ),
         const SizedBox(width: 16),
-
         Expanded(
           child: ElevatedButton(
             onPressed: () async {
@@ -275,7 +271,6 @@ class TakeOrderScreen extends ConsumerWidget {
                   },
                 );
 
-
                 if (enteredAmount != null) {
                   if (orderType == OrderType.buy) {
                     await orderDetailsNotifier.takeBuyOrder(
@@ -319,11 +314,13 @@ class TakeOrderScreen extends ConsumerWidget {
   String formatDateTime(DateTime dt, [BuildContext? context]) {
     if (context != null) {
       // Use internationalized date format
-      final dateFormatter = DateFormat.yMMMd(Localizations.localeOf(context).languageCode);
-      final timeFormatter = DateFormat.Hm(Localizations.localeOf(context).languageCode);
+      final dateFormatter =
+          DateFormat.yMMMd(Localizations.localeOf(context).languageCode);
+      final timeFormatter =
+          DateFormat.Hm(Localizations.localeOf(context).languageCode);
       final formattedDate = dateFormatter.format(dt);
       final formattedTime = timeFormatter.format(dt);
-      
+
       // Use the internationalized string for "Created on: date"
       return S.of(context)!.createdOnDate('$formattedDate $formattedTime');
     } else {
@@ -332,7 +329,7 @@ class TakeOrderScreen extends ConsumerWidget {
       final timeFormatter = DateFormat('HH:mm');
       final formattedDate = dateFormatter.format(dt);
       final formattedTime = timeFormatter.format(dt);
-      
+
       return '$formattedDate at $formattedTime';
     }
   }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -155,8 +155,6 @@
   "disputeButton": "DISPUTE",
   "fiatSentButton": "FIAT SENT",
   "completePurchaseButton": "COMPLETE PURCHASE",
-  "sellBitcoinButton": "SELL BITCOIN",
-  "buyBitcoinButton": "BUY BITCOIN",
   "paymentMethodLabel": "Payment Method",
   "createdOnLabel": "Created On",
   "orderIdLabel": "Order ID",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -459,8 +459,6 @@
   "disputeButton": "DISPUTA",
   "fiatSentButton": "FIAT ENVIADO",
   "completePurchaseButton": "COMPLETAR COMPRA",
-  "sellBitcoinButton": "VENDER BITCOIN",
-  "buyBitcoinButton": "COMPRAR BITCOIN",
   "paymentMethodLabel": "Método de Pago",
   "createdOnLabel": "Creado el",
   "orderIdLabel": "ID de Orden",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -469,8 +469,6 @@
   "disputeButton": "DISPUTA",
   "fiatSentButton": "FIAT INVIATO",
   "completePurchaseButton": "COMPLETA ACQUISTO",
-  "sellBitcoinButton": "VENDI BITCOIN",
-  "buyBitcoinButton": "COMPRA BITCOIN",
   "paymentMethodLabel": "Metodo di Pagamento",
   "createdOnLabel": "Creato il",
   "orderIdLabel": "ID Ordine",


### PR DESCRIPTION
Because this is an Bitcoin app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting and removed unnecessary blank lines for cleaner code appearance.
* **New Features**
  * Simplified main action button labels from "SELL BITCOIN"/"BUY BITCOIN" to "SELL"/"BUY" for a more concise user interface.
* **Chores**
  * Removed unused localization strings related to "SELL BITCOIN" and "BUY BITCOIN" in English, Spanish, and Italian language files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->