### PR TITLE
improve add and pay invoice messages

### DIFF
--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -95,16 +95,18 @@ class MostroMessageDetail extends ConsumerWidget {
                 .mostroInstance
                 ?.expirationSeconds ??
             900;
+        final expMinutes = (expSecs / 60).round();
         return S
             .of(context)!
-            .waitingSellerToPay(orderPayload?.id ?? '', expSecs);
+            .waitingSellerToPay(expMinutes, orderPayload?.id ?? '');
       case actions.Action.waitingBuyerInvoice:
         final expSecs = ref
                 .read(orderRepositoryProvider)
                 .mostroInstance
                 ?.expirationSeconds ??
             900;
-        return S.of(context)!.waitingBuyerInvoice(expSecs);
+        final expMinutes = (expSecs / 60).round();
+        return S.of(context)!.waitingBuyerInvoice(expMinutes);
       case actions.Action.buyerInvoiceAccepted:
         return S.of(context)!.buyerInvoiceAccepted;
       case actions.Action.holdInvoicePaymentAccepted:

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -44,8 +44,28 @@
       }
     }
   },
-  "waitingSellerToPay": "Please wait. I’ve sent a payment request to the seller to send the Sats for the order ID {id}. If the seller doesn’t complete the payment within {expiration_seconds}, the trade will be canceled.",
-  "waitingBuyerInvoice": "Payment received! Your Sats are now 'held' in your wallet. I’ve requested the buyer to provide an invoice. If they don’t do so within {expiration_seconds}, your Sats will return to your wallet, and the trade will be canceled.",
+  "waitingSellerToPay": "Please wait. I’ve sent a payment request to the seller to send the Sats for the order ID {id}. If the seller doesn’t complete the payment within {expiration_seconds} minutes, the trade will be canceled.",
+  "@waitingSellerToPay": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "The expiration time in minutes"
+      },
+      "id": {
+        "type": "String",
+        "description": "The order ID"
+      }
+    }
+  },
+  "waitingBuyerInvoice": "Payment received! Your Sats are now 'held' in your wallet. I’ve requested the buyer to provide an invoice. If they don’t do so within {expiration_seconds} minutes, your Sats will return to your wallet, and the trade will be canceled.",
+  "@waitingBuyerInvoice": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "The expiration time in minutes"
+      }
+    }
+  },
   "buyerInvoiceAccepted": "The invoice has been successfully saved.",
   "holdInvoicePaymentAccepted": "Contact the seller at {seller_npub} to arrange how to send {fiat_code} {fiat_amount} using {payment_method}. Once you send the fiat money, please notify me with fiat-sent.",
   "buyerTookOrder": "Contact the buyer at {buyer_npub} to inform them how to send {fiat_code} {fiat_amount} through {payment_method}. You’ll be notified when the buyer confirms the fiat payment. Afterward, verify if it has arrived. If the buyer does not respond, you can initiate a cancellation or a dispute. Remember, an administrator will NEVER contact you to resolve your order unless you open a dispute first.",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -44,8 +44,28 @@
       }
     }
   },
-  "waitingSellerToPay": "Por favor espera. He enviado una solicitud de pago al vendedor para enviar los Sats para la orden ID {id}. Si el vendedor no completa el pago dentro de {expiration_seconds}, el intercambio será cancelado.",
-  "waitingBuyerInvoice": "¡Pago recibido! Tus Sats ahora están 'retenidos' en tu billetera. He solicitado al comprador que proporcione una factura. Si no lo hace dentro de {expiration_seconds}, tus Sats regresarán a tu billetera y el intercambio será cancelado.",
+  "waitingSellerToPay": "Por favor espera. He enviado una solicitud de pago al vendedor para enviar los Sats para la orden con ID {id}. Si el vendedor no completa el pago dentro de {expiration_seconds} minutos, el intercambio será cancelado.",
+  "@waitingSellerToPay": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "El tiempo de expiración en minutos"
+      },
+      "id": {
+        "type": "String",
+        "description": "El ID del pedido"
+      }
+    }
+  },
+  "waitingBuyerInvoice": "¡Pago recibido! Tus Sats ahora están 'retenidos' en tu billetera. He solicitado al comprador que proporcione una factura. Si no lo hace dentro de {expiration_seconds} minutos, tus Sats regresarán a tu billetera y el intercambio será cancelado.",
+  "@waitingBuyerInvoice": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "El tiempo de expiración en minutos"
+      }
+    }
+  },
   "buyerInvoiceAccepted": "La factura ha sido guardada exitosamente.",
   "holdInvoicePaymentAccepted": "Contacta al vendedor en {seller_npub} para acordar cómo enviar {fiat_code} {fiat_amount} usando {payment_method}. Una vez que envíes el dinero fiat, por favor notifícame con fiat-sent.",
   "buyerTookOrder": "Contacta al comprador en {buyer_npub} para informarle cómo enviar {fiat_code} {fiat_amount} a través de {payment_method}. Serás notificado cuando el comprador confirme el pago fiat. Después, verifica si ha llegado. Si el comprador no responde, puedes iniciar una cancelación o una disputa. Recuerda, un administrador NUNCA te contactará para resolver tu orden a menos que abras una disputa primero.",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -45,7 +45,27 @@
     }
   },
   "waitingSellerToPay": "Attendi un momento per favore. Ho inviato una richiesta di pagamento al venditore per rilasciare i Sats per l'ordine ID {id}. Una volta effettuato il pagamento, vi connetterò entrambi. Se il venditore non completa il pagamento entro {expiration_seconds} minuti lo scambio sarà annullato.",
-  "waitingBuyerInvoice": "Pagamento ricevuto! I tuoi Sats sono ora 'custoditi' nel tuo portafoglio. Attendi un momento per favore. Ho richiesto all'acquirente di fornire una invoice lightning. Una volta ricevuta, vi connetterò entrambi, altrimenti se non la riceviamo entro {expiration_seconds} i tuoi Sats saranno nuovamente disponibili nel tuo portafoglio e lo scambio sarà annullato.",
+  "@waitingSellerToPay": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "Il tempo di scadenza in minuti"
+      },
+      "id": {
+        "type": "String",
+        "description": "L'ID dell'ordine"
+      }
+    }
+  },
+  "waitingBuyerInvoice": "Pagamento ricevuto! I tuoi Sats sono ora 'custoditi' nel tuo portafoglio. Attendi un momento per favore. Ho richiesto all'acquirente di fornire una invoice lightning. Una volta ricevuta, vi connetterò entrambi, altrimenti se non la riceviamo entro {expiration_seconds} minuti i tuoi Sats saranno nuovamente disponibili nel tuo portafoglio e lo scambio sarà annullato.",
+  "@waitingBuyerInvoice": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "Il tempo di scadenza in minuti"
+      }
+    }
+  },
   "buyerInvoiceAccepted": "Fattura salvata con successo!",
   "holdInvoicePaymentAccepted": "Contatta il venditore tramite la sua npub {seller_npub} ed ottieni i dettagli per inviare il pagamento di {fiat_amount} {fiat_code} utilizzando {payment_method}. Una volta inviato il pagamento, clicca: Pagamento inviato",
   "buyerTookOrder": "Contatta l'acquirente, ecco il suo npub {buyer_npub}, per informarlo su come inviarti {fiat_amount} {fiat_code} tramite {payment_method}. Riceverai una notifica una volta che l'acquirente indicherà che il pagamento fiat è stato inviato. Successivamente, dovresti verificare se sono arrivati i fondi. Se l'acquirente non risponde, puoi iniziare l'annullamento dell'ordine o una disputa. Ricorda, un amministratore NON ti contatterà per risolvere il tuo ordine a meno che tu non apra prima una disputa.",


### PR DESCRIPTION
fix #53 
Fiat currency and time are now correctly displayed in Add-Invoice and Pay-Invoice messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display of expiration times for invoice actions to consistently show minutes and improved clarity in English, Spanish, and Italian localizations.
  * Fixed the order of currency and amount in Spanish messages to match local conventions.
  * Adjusted phrasing in Spanish to clarify deadlines and in Italian to specify time units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->