### PR TITLE
Add order information when displaying or requesting the invoice

### DIFF
--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -31,6 +31,9 @@ class _AddLightningInvoiceScreenState
       data: (mostroMessage) {
         final orderPayload = mostroMessage?.getPayload<Order>();
         final amount = orderPayload?.amount;
+        final fiatAmount = orderPayload?.fiatAmount.toString() ?? '0';
+        final fiatCode = orderPayload?.fiatCode ?? '';
+        final orderIdValue = orderPayload?.id ?? orderId;
 
         return Scaffold(
           backgroundColor: AppTheme.dark1,
@@ -86,6 +89,9 @@ class _AddLightningInvoiceScreenState
                       }
                     },
                     amount: amount ?? 0,
+                    fiatAmount: fiatAmount,
+                    fiatCode: fiatCode,
+                    orderId: orderIdValue,
                   ),
                 ),
               ),

--- a/lib/features/order/screens/pay_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/pay_lightning_invoice_screen.dart
@@ -22,8 +22,11 @@ class _PayLightningInvoiceScreenState
     extends ConsumerState<PayLightningInvoiceScreen> {
   @override
   Widget build(BuildContext context) {
-    final order = ref.watch(orderNotifierProvider(widget.orderId));
-    final lnInvoice = order.paymentRequest?.lnInvoice ?? '';
+    final orderState = ref.watch(orderNotifierProvider(widget.orderId));
+    final lnInvoice = orderState.paymentRequest?.lnInvoice ?? '';
+    final sats = orderState.order?.amount ?? 0;
+    final fiatAmount = orderState.order?.fiatAmount.toString() ?? '0';
+    final fiatCode = orderState.order?.fiatCode ?? '';
     final orderNotifier =
         ref.watch(orderNotifierProvider(widget.orderId).notifier);
 
@@ -45,7 +48,11 @@ class _PayLightningInvoiceScreenState
                       context.go('/');
                       await orderNotifier.cancelOrder();
                     },
-                    lnInvoice: lnInvoice),
+                    lnInvoice: lnInvoice,
+                    sats: sats,
+                    fiatAmount: fiatAmount,
+                    fiatCode: fiatCode,
+                    orderId: widget.orderId),
               ],
             ),
           ),

--- a/lib/features/order/widgets/lightning_address_section.dart
+++ b/lib/features/order/widgets/lightning_address_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mostro_mobile/features/order/widgets/form_section.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
 
 class LightningAddressSection extends StatelessWidget {
   final TextEditingController controller;
@@ -12,16 +13,16 @@ class LightningAddressSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FormSection(
-      title: 'Lightning Address (optional)',
+      title: S.of(context)!.lightningAddressOptional,
       icon: const Icon(Icons.bolt, color: Colors.amber, size: 18),
       iconBackgroundColor: Colors.amber.withValues(alpha: 0.3),
       child: TextField(
         controller: controller,
         style: const TextStyle(color: Colors.white),
-        decoration: const InputDecoration(
+        decoration: InputDecoration(
           border: InputBorder.none,
-          hintText: 'Enter lightning address',
-          hintStyle: TextStyle(color: Colors.grey),
+          hintText: S.of(context)!.enterLightningAddress,
+          hintStyle: const TextStyle(color: Colors.grey),
         ),
       ),
     );

--- a/lib/features/order/widgets/order_type_header.dart
+++ b/lib/features/order/widgets/order_type_header.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
 
 class OrderTypeHeader extends StatelessWidget {
   final OrderType orderType;
@@ -22,8 +23,8 @@ class OrderTypeHeader extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 8),
         child: Text(
           orderType == OrderType.buy
-              ? 'You want to buy Bitcoin'
-              : 'You want to sell Bitcoin',
+              ? S.of(context)!.youWantToBuyBitcoin
+              : S.of(context)!.youWantToSellBitcoin,
           textAlign: TextAlign.center,
           style: const TextStyle(
             color: Colors.white,

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -319,6 +319,10 @@
   "invoiceExpirationWindow": "Invoice Expiration Window",
   
   "@_comment_order_creation": "Order Creation Form Strings",
+  "youWantToBuyBitcoin": "You want to buy Bitcoin",
+  "youWantToSellBitcoin": "You want to sell Bitcoin",
+  "lightningAddressOptional": "Lightning Address (optional)",
+  "enterLightningAddress": "Enter lightning address",
   "enterFiatAmountBuy": "Enter the fiat amount you want to pay (you can set a range)",
   "enterFiatAmountSell": "Enter the fiat amount you want to receive (you can set a range)",
   "enterAmountHint": "Enter amount (example: 100 or 100-500)",
@@ -477,7 +481,27 @@
   },
   
   "@_comment_lightning_invoice": "Lightning Invoice Widget Strings",
-  "pleaseEnterLightningInvoiceFor": "Please enter a Lightning Invoice for: ",
+  "pleaseEnterLightningInvoiceFor": "Please enter a Lightning Invoice for {sats} Sats equivalent to {fiat_code} {fiat_amount} to continue the exchange for order with ID {order_id}",
+  "@pleaseEnterLightningInvoiceFor": {
+    "placeholders": {
+      "sats": {
+        "type": "String",
+        "description": "The amount of satoshis"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "The fiat currency code"
+      },      
+      "fiat_amount": {
+        "type": "String",
+        "description": "The fiat amount"
+      },
+      "order_id": {
+        "type": "String",
+        "description": "The order ID"
+      }
+    }
+  },
   "sats": " sats",
   "lightningInvoice": "Lightning Invoice",
   "enterInvoiceHere": "Enter invoice here",
@@ -495,7 +519,27 @@
   
   "@_comment_pay_invoice_screen": "Pay Lightning Invoice Screen Strings",
   "payLightningInvoice": "Pay Lightning Invoice",
-  "payInvoiceToContinue": "Pay this invoice to continue the exchange",
+  "payInvoiceToContinue": "Pay this invoice for {sats} Sats equivalent to {fiat_code} {fiat_amount} to continue the exchange for order {order_id}",
+  "@payInvoiceToContinue": {
+    "placeholders": {
+      "sats": {
+        "type": "String",
+        "description": "The amount of satoshis"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "The fiat currency code"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "The fiat amount"
+      },
+      "order_id": {
+        "type": "String",
+        "description": "The order ID"
+      }
+    }
+  },
   "failedToGenerateQR": "Failed to generate QR code",
   "invoiceCopiedToClipboard": "Invoice copied to clipboard",
   "copy": "Copy",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -282,6 +282,10 @@
   "invoiceExpirationWindow": "Ventana de Expiración de Factura",
   
   "@_comment_order_creation": "Cadenas del Formulario de Creación de Orden",
+  "youWantToBuyBitcoin": "Quieres comprar Bitcoin",
+  "youWantToSellBitcoin": "Quieres vender Bitcoin",
+  "lightningAddressOptional": "Lightning Address (opcional)",
+  "enterLightningAddress": "Introduzca una lightning address",
   "enterFiatAmountBuy": "Ingresa la cantidad fiat que quieres pagar (puedes establecer un rango)",
   "enterFiatAmountSell": "Ingresa la cantidad fiat que quieres recibir (puedes establecer un rango)",
   "enterAmountHint": "Ingresa cantidad (ejemplo: 100 o 100-500)",
@@ -442,7 +446,27 @@
   },
   
   "@_comment_lightning_invoice": "Cadenas de Widget de Factura Lightning",
-  "pleaseEnterLightningInvoiceFor": "Por favor ingresa una Factura Lightning para: ",
+  "pleaseEnterLightningInvoiceFor": "Ingresa una Factura Lightning de {sats} Sats equivalentes a {fiat_amount} {fiat_code} para continuar el intercambio de la orden con ID {order_id}",
+  "@pleaseEnterLightningInvoiceFor": {
+    "placeholders": {
+      "sats": {
+        "type": "String",
+        "description": "La cantidad de satoshis"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "La cantidad fiat"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "El código de moneda fiat"
+      },
+      "order_id": {
+        "type": "String",
+        "description": "El ID de la orden"
+      }
+    }
+  },
   "sats": " sats",
   "lightningInvoice": "Factura Lightning",
   "enterInvoiceHere": "Ingresa la factura aquí",
@@ -460,7 +484,27 @@
   
   "@_comment_pay_invoice_screen": "Cadenas de Pantalla de Pago de Factura Lightning",
   "payLightningInvoice": "Pagar Factura Lightning",
-  "payInvoiceToContinue": "Paga esta factura para continuar el intercambio",
+  "payInvoiceToContinue": "Paga esta factura de {sats} Sats equivalentes a {fiat_amount} {fiat_code} para continuar el intercambio de la orden {order_id}",
+  "@payInvoiceToContinue": {
+    "placeholders": {
+      "sats": {
+        "type": "String",
+        "description": "La cantidad de satoshis"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "El código de moneda fiat"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "La cantidad fiat"
+      },
+      "order_id": {
+        "type": "String",
+        "description": "El ID de la orden"
+      }
+    }
+  },
   "failedToGenerateQR": "Error al generar código QR",
   "invoiceCopiedToClipboard": "Factura copiada al portapapeles",
   "copy": "Copiar",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -282,6 +282,10 @@
   "invoiceExpirationWindow": "Finestra Scadenza Fattura",
   
   "@_comment_order_creation": "Stringhe Modulo Creazione Ordine",
+  "youWantToBuyBitcoin": "Vuoi comprare Bitcoin",
+  "youWantToSellBitcoin": "Vuoi vendere Bitcoin",
+  "lightningAddressOptional": "Lightning Address (opzionale)",
+  "enterLightningAddress": "Inserisci lightning address",
   "enterFiatAmountBuy": "Inserisci l'importo fiat che vuoi pagare (puoi impostare un intervallo)",
   "enterFiatAmountSell": "Inserisci l'importo fiat che vuoi ricevere (puoi impostare un intervallo)",
   "enterAmountHint": "Inserisci importo (esempio: 100 o 100-500)",
@@ -442,7 +446,27 @@
   },
   
   "@_comment_lightning_invoice": "Stringhe Widget Fattura Lightning",
-  "pleaseEnterLightningInvoiceFor": "Per favore inserisci una Fattura Lightning per: ",
+  "pleaseEnterLightningInvoiceFor": "Per favore inserisci una Fattura Lightning per {sats} Sats equivalenti a {fiat_amount} {fiat_code} per continuare lo scambio dell'ordine con ID {order_id}",
+  "@pleaseEnterLightningInvoiceFor": {
+    "placeholders": {
+      "sats": {
+        "type": "String",
+        "description": "L'importo in satoshi"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "L'importo fiat"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "Il codice della valuta fiat"
+      },
+      "order_id": {
+        "type": "String",
+        "description": "L'ID dell'ordine"
+      }
+    }
+  },
   "sats": " sats",
   "lightningInvoice": "Fattura Lightning",
   "enterInvoiceHere": "Inserisci la fattura qui",
@@ -460,7 +484,27 @@
   
   "@_comment_pay_invoice_screen": "Stringhe Schermata Pagamento Fattura Lightning",
   "payLightningInvoice": "Paga Fattura Lightning",
-  "payInvoiceToContinue": "Paga questa fattura per continuare lo scambio",
+  "payInvoiceToContinue": "Paga questa fattura di {sats} Sats equivalenti a {fiat_amount} {fiat_code} per continuare lo scambio dell'ordine {order_id}",
+  "@payInvoiceToContinue": {
+    "placeholders": {
+      "sats": {
+        "type": "String",
+        "description": "L'importo in satoshi"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "Il codice della valuta fiat"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "L'importo fiat"
+      },
+      "order_id": {
+        "type": "String",
+        "description": "L'ID dell'ordine"
+      }
+    }
+  },
   "failedToGenerateQR": "Errore nella generazione del codice QR",
   "invoiceCopiedToClipboard": "Fattura copiata negli appunti",
   "copy": "Copia",

--- a/lib/shared/widgets/add_lightning_invoice_widget.dart
+++ b/lib/shared/widgets/add_lightning_invoice_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
-import 'package:mostro_mobile/shared/widgets/clickable_text_widget.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class AddLightningInvoiceWidget extends StatefulWidget {
@@ -8,6 +7,9 @@ class AddLightningInvoiceWidget extends StatefulWidget {
   final VoidCallback onSubmit;
   final VoidCallback onCancel;
   final int amount;
+  final String fiatAmount;
+  final String fiatCode;
+  final String orderId;
 
   const AddLightningInvoiceWidget({
     super.key,
@@ -15,6 +17,9 @@ class AddLightningInvoiceWidget extends StatefulWidget {
     required this.onSubmit,
     required this.onCancel,
     required this.amount,
+    required this.fiatAmount,
+    required this.fiatCode,
+    required this.orderId,
   });
 
   @override
@@ -28,10 +33,17 @@ class _AddLightningInvoiceWidgetState extends State<AddLightningInvoiceWidget> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ClickableText(
-          leftText: S.of(context)!.pleaseEnterLightningInvoiceFor,
-          clickableText: '${widget.amount}',
-          rightText: S.of(context)!.sats,
+        Text(
+          S.of(context)!.pleaseEnterLightningInvoiceFor(
+            widget.amount.toString(),
+            widget.fiatCode,
+            widget.fiatAmount,
+            widget.orderId,
+          ),
+          style: const TextStyle(
+            color: AppTheme.cream1,
+            fontSize: 16,
+          ),
         ),
         const SizedBox(height: 16),
         TextFormField(

--- a/lib/shared/widgets/pay_lightning_invoice_widget.dart
+++ b/lib/shared/widgets/pay_lightning_invoice_widget.dart
@@ -13,12 +13,20 @@ class PayLightningInvoiceWidget extends StatefulWidget {
   final VoidCallback onCancel;
   final Logger logger = Logger();
   final String lnInvoice;
+  final int sats;
+  final String fiatAmount;
+  final String fiatCode;
+  final String orderId;
 
   PayLightningInvoiceWidget({
     super.key,
     required this.onSubmit,
     required this.onCancel,
     required this.lnInvoice,
+    required this.sats,
+    required this.fiatAmount,
+    required this.fiatCode,
+    required this.orderId,
   });
 
   @override
@@ -33,7 +41,12 @@ class _PayLightningInvoiceWidgetState extends State<PayLightningInvoiceWidget> {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
-          S.of(context)!.payInvoiceToContinue,
+          S.of(context)!.payInvoiceToContinue(
+            widget.sats.toString(),
+            widget.fiatCode,
+            widget.fiatAmount,
+            widget.orderId,
+          ),
           style: const TextStyle(color: AppTheme.cream1, fontSize: 18),
           textAlign: TextAlign.center,
         ),


### PR DESCRIPTION
Now more information about the order is displayed when an invoice is requested or when the user has to pay the hold invoice: number of sats, fiat currency and its amount, and the order ID

Additionally, some missing translations were added to the create new order screen (You are selling/buying Bitcoin, and the Lightning address section)
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/7930e3df-8f8f-44b4-8926-a05348c1f5f6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User interface texts for order creation and Lightning invoice actions are now fully localized in English, Spanish, and Italian.
  * Dynamic order and payment details (amounts, currency, order ID) are now displayed in prompts during Lightning invoice entry and payment steps.

* **Improvements**
  * Enhanced prompts for Lightning invoice actions now include specific order details for better clarity.
  * Localization support added for newly introduced prompts and UI elements related to order creation and Lightning payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->