### PR TITLE
Fixed the BUY/SELL button text cutoff

### DIFF
--- a/lib/shared/widgets/add_order_button.dart
+++ b/lib/shared/widgets/add_order_button.dart
@@ -58,7 +58,6 @@ class _AddOrderButtonState extends State<AddOrderButton>
   Widget build(BuildContext context) {
     return SizedBox(
       height: 130,
-      width: 200,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.end,
@@ -69,71 +68,77 @@ class _AddOrderButtonState extends State<AddOrderButton>
             margin: const EdgeInsets.only(bottom: 10),
             child: Opacity(
               opacity: _isMenuOpen ? 1.0 : 0.0,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Stack(
-                    alignment: Alignment.centerLeft,
-                    children: [
-                      ElevatedButton.icon(
-                        key: const Key('buyButton'),
-                        onPressed: _isMenuOpen
-                            ? () => _navigateToCreateOrder(context, 'buy')
-                            : null,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppTheme.buyColor,
-                          foregroundColor: Colors.black,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(50),
+              child: IntrinsicWidth(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Flexible(
+                      child: Stack(
+                        alignment: Alignment.centerLeft,
+                        children: [
+                          ElevatedButton.icon(
+                            key: const Key('buyButton'),
+                            onPressed: _isMenuOpen
+                                ? () => _navigateToCreateOrder(context, 'buy')
+                                : null,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppTheme.buyColor,
+                              foregroundColor: Colors.black,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(50),
+                              ),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 10),
+                            ),
+                            icon: const SizedBox(width: 16, height: 16),
+                            label: Text(S.of(context)!.buy,
+                                style:
+                                    const TextStyle(fontWeight: FontWeight.bold)),
                           ),
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 16, vertical: 10),
-                        ),
-                        icon: const SizedBox(width: 16, height: 16),
-                        label: Text(S.of(context)!.buy,
-                            style:
-                                const TextStyle(fontWeight: FontWeight.bold)),
+                          if (_isMenuOpen)
+                            const Positioned(
+                              left: 12,
+                              child: Icon(Icons.arrow_downward,
+                                  size: 16, color: Colors.black),
+                            ),
+                        ],
                       ),
-                      if (_isMenuOpen)
-                        const Positioned(
-                          left: 16,
-                          child: Icon(Icons.arrow_downward,
-                              size: 16, color: Colors.black),
-                        ),
-                    ],
-                  ),
-                  const SizedBox(width: 8),
-                  Stack(
-                    alignment: Alignment.centerLeft,
-                    children: [
-                      ElevatedButton.icon(
-                        key: const Key('sellButton'),
-                        onPressed: _isMenuOpen
-                            ? () => _navigateToCreateOrder(context, 'sell')
-                            : null,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppTheme.sellColor,
-                          foregroundColor: Colors.black,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(50),
+                    ),
+                    const SizedBox(width: 6),
+                    Flexible(
+                      child: Stack(
+                        alignment: Alignment.centerLeft,
+                        children: [
+                          ElevatedButton.icon(
+                            key: const Key('sellButton'),
+                            onPressed: _isMenuOpen
+                                ? () => _navigateToCreateOrder(context, 'sell')
+                                : null,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppTheme.sellColor,
+                              foregroundColor: Colors.black,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(50),
+                              ),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 10),
+                            ),
+                            icon: const SizedBox(width: 16, height: 16),
+                            label: Text(S.of(context)!.sell,
+                                style:
+                                    const TextStyle(fontWeight: FontWeight.bold)),
                           ),
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 16, vertical: 10),
-                        ),
-                        icon: const SizedBox(width: 16, height: 16),
-                        label: Text(S.of(context)!.sell,
-                            style:
-                                const TextStyle(fontWeight: FontWeight.bold)),
+                          if (_isMenuOpen)
+                            const Positioned(
+                              left: 12,
+                              child: Icon(Icons.arrow_upward,
+                                  size: 16, color: Colors.black),
+                            ),
+                        ],
                       ),
-                      if (_isMenuOpen)
-                        const Positioned(
-                          left: 16,
-                          child: Icon(Icons.arrow_upward,
-                              size: 16, color: Colors.black),
-                        ),
-                    ],
-                  ),
-                ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Fix #158 

  Problem Identified:

  - The buttons were constrained by a fixed width container (width: 200)
  - Spanish "COMPRAR" (7 chars) and "VENDER" (6 chars) were longer than English "BUY" (3 chars) and "SELL" (4 chars)
  - Italian "COMPRA" (6 chars) and "VENDI" (5 chars) were also longer than English
  - The "VENDER" text was being cut off due to space constraints

  Solution Implemented:

  1. Removed fixed width constraint: Changed from SizedBox(width: 200) to just SizedBox(height: 130)
  2. Made layout responsive: Added IntrinsicWidth widget to make the container size based on its contents
  3. Used flexible layout: Wrapped each button in a Flexible widget to allow dynamic space allocation
  4. Optimized spacing:
    - Reduced horizontal padding from 16 to 12 pixels
    - Reduced spacing between buttons from 8 to 6 pixels
    - Adjusted icon positioning from left: 16 to left: 12

  Key Changes Made:

  - Container: Removed fixed width, kept dynamic height
  - Layout: Used IntrinsicWidth + Flexible widgets for responsive sizing
  - Spacing: Reduced padding and spacing to maximize text space
  - Icons: Adjusted positioning to align with reduced padding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and responsiveness of the "buy" and "sell" buttons for better appearance and flexibility across different screen sizes.
  * Reduced button padding and spacing for a more compact design.
  * Adjusted arrow icon positioning for enhanced visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->