### PR TITLE
Improve the clock: Use the time published by the mostro instance

### DIFF
--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -13,6 +13,8 @@ import 'package:mostro_mobile/shared/widgets/order_cards.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
 import 'package:mostro_mobile/shared/widgets/custom_card.dart';
+import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
+import 'package:mostro_mobile/shared/providers/time_provider.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class TakeOrderScreen extends ConsumerWidget {
@@ -49,7 +51,9 @@ class TakeOrderScreen extends ConsumerWidget {
             const SizedBox(height: 16),
             _buildCreatorReputation(order),
             const SizedBox(height: 24),
-            _buildCountDownTime(context, order.expirationDate),
+            _CountdownWidget(
+              expirationDate: order.expirationDate,
+            ),
             const SizedBox(height: 36),
             _buildActionButtons(context, ref, order),
           ],
@@ -121,34 +125,6 @@ class TakeOrderScreen extends ConsumerWidget {
   Widget _buildOrderId(BuildContext context) {
     return OrderIdCard(
       orderId: orderId,
-    );
-  }
-
-  Widget _buildCountDownTime(BuildContext context, DateTime expiration) {
-    Duration countdown = Duration(hours: 0);
-    final now = DateTime.now();
-
-    if (expiration.isAfter(now)) {
-      countdown = expiration.difference(now);
-    }
-
-    final int maxOrderHours = 24;
-    final hoursLeft = countdown.inHours.clamp(0, maxOrderHours);
-    final minutesLeft = countdown.inMinutes % 60;
-    final secondsLeft = countdown.inSeconds % 60;
-
-    final formattedTime =
-        '${hoursLeft.toString().padLeft(2, '0')}:${minutesLeft.toString().padLeft(2, '0')}:${secondsLeft.toString().padLeft(2, '0')}';
-
-    return Column(
-      children: [
-        CircularCountdown(
-          countdownTotal: maxOrderHours,
-          countdownRemaining: hoursLeft,
-        ),
-        const SizedBox(height: 16),
-        Text(S.of(context)!.timeLeftLabel(formattedTime)),
-      ],
     );
   }
 
@@ -332,5 +308,72 @@ class TakeOrderScreen extends ConsumerWidget {
 
       return '$formattedDate at $formattedTime';
     }
+  }
+}
+
+/// Widget that displays a real-time countdown timer for pending orders
+class _CountdownWidget extends ConsumerWidget {
+  final DateTime expirationDate;
+
+  const _CountdownWidget({
+    required this.expirationDate,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Watch the countdown time provider for real-time updates
+    final timeAsync = ref.watch(countdownTimeProvider);
+
+    return timeAsync.when(
+      data: (currentTime) {
+        return _buildCountDownTime(context, ref, expirationDate);
+      },
+      loading: () => const CircularProgressIndicator(),
+      error: (error, stack) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildCountDownTime(
+      BuildContext context, WidgetRef ref, DateTime expiration) {
+    Duration countdown = Duration(hours: 0);
+    final now = DateTime.now();
+
+    // Handle edge case: expiration in the past
+    if (expiration.isBefore(now.subtract(const Duration(hours: 1)))) {
+      // If expiration is more than 1 hour in the past, likely invalid
+      return const SizedBox.shrink();
+    }
+
+    if (expiration.isAfter(now)) {
+      countdown = expiration.difference(now);
+    }
+
+    // Get dynamic expiration hours from Mostro instance
+    final mostroInstance = ref.read(orderRepositoryProvider).mostroInstance;
+    final maxOrderHours =
+        mostroInstance?.expirationHours ?? 24; // fallback to 24 hours
+
+    // Validate expiration hours
+    if (maxOrderHours <= 0 || maxOrderHours > 168) { // Max 1 week
+      return const SizedBox.shrink();
+    }
+
+    final hoursLeft = countdown.inHours.clamp(0, maxOrderHours);
+    final minutesLeft = countdown.inMinutes % 60;
+    final secondsLeft = countdown.inSeconds % 60;
+
+    final formattedTime =
+        '${hoursLeft.toString().padLeft(2, '0')}:${minutesLeft.toString().padLeft(2, '0')}:${secondsLeft.toString().padLeft(2, '0')}';
+
+    return Column(
+      children: [
+        CircularCountdown(
+          countdownTotal: maxOrderHours,
+          countdownRemaining: hoursLeft,
+        ),
+        const SizedBox(height: 16),
+        Text(S.of(context)!.timeLeftLabel(formattedTime)),
+      ],
+    );
   }
 }

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -693,8 +693,8 @@ class _CountdownWidget extends ConsumerWidget {
       final messageTime = DateTime.fromMillisecondsSinceEpoch(messageTimestamp);
       
       // Handle edge case: message timestamp in the future
-      if (messageTime.isAfter(now.add(const Duration(minutes: 5)))) {
-        // If message is more than 5 minutes in the future, likely invalid
+      if (messageTime.isAfter(now.add(const Duration(hours: 1)))) {
+        // If message is more than 1 hour in the future, likely invalid
         return null;
       }
 
@@ -747,7 +747,7 @@ class _CountdownWidget extends ConsumerWidget {
     for (final message in sortedMessages) {
       // Additional validation: ensure timestamp is not in the future
       final messageTime = DateTime.fromMillisecondsSinceEpoch(message.timestamp!);
-      if (messageTime.isAfter(DateTime.now().add(const Duration(minutes: 5)))) {
+      if (messageTime.isAfter(DateTime.now().add(const Duration(hours: 1)))) {
         continue; // Skip messages with future timestamps
       }
 

--- a/lib/shared/providers/time_provider.dart
+++ b/lib/shared/providers/time_provider.dart
@@ -8,3 +8,46 @@ final timeProvider = StreamProvider<DateTime>((ref) {
     (_) => DateTime.now(),
   );
 });
+
+/// Provides a more efficient countdown timer using Timer.periodic
+/// with automatic cleanup and debouncing
+final countdownTimeProvider = StreamProvider<DateTime>((ref) {
+  late StreamController<DateTime> controller;
+  Timer? timer;
+  DateTime? lastEmittedTime;
+
+  controller = StreamController<DateTime>.broadcast(
+    onListen: () {
+      // Start timer when first listener subscribes
+      timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+        final now = DateTime.now();
+        // Debounce: only emit if seconds have actually changed
+        if (lastEmittedTime == null || 
+            now.second != lastEmittedTime!.second ||
+            now.minute != lastEmittedTime!.minute ||
+            now.hour != lastEmittedTime!.hour) {
+          lastEmittedTime = now;
+          controller.add(now);
+        }
+      });
+      // Emit initial value immediately
+      final now = DateTime.now();
+      lastEmittedTime = now;
+      controller.add(now);
+    },
+    onCancel: () {
+      // Cleanup timer when last listener unsubscribes
+      timer?.cancel();
+      timer = null;
+      lastEmittedTime = null;
+    },
+  );
+
+  // Ensure cleanup when provider is disposed
+  ref.onDispose(() {
+    timer?.cancel();
+    controller.close();
+  });
+
+  return controller.stream;
+});

--- a/test/shared/countdown_validation_test.dart
+++ b/test/shared/countdown_validation_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Countdown Validation Tests', () {
+    
+    group('Timestamp Validation', () {
+      test('should reject negative timestamps', () {
+        final timestamp = -1000;
+        expect(timestamp <= 0, isTrue);
+      });
+
+      test('should reject zero timestamps', () {
+        final timestamp = 0;
+        expect(timestamp <= 0, isTrue);
+      });
+
+      test('should accept valid timestamps', () {
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+        expect(timestamp > 0, isTrue);
+      });
+
+      test('should reject future timestamps beyond threshold', () {
+        final now = DateTime.now();
+        final futureTime = now.add(const Duration(minutes: 10));
+        final threshold = now.add(const Duration(minutes: 5));
+        
+        expect(futureTime.isAfter(threshold), isTrue);
+      });
+    });
+
+    group('Expiration Validation', () {
+      test('should reject expiration times too far in the past', () {
+        final now = DateTime.now();
+        final pastExpiration = now.subtract(const Duration(hours: 2));
+        final threshold = now.subtract(const Duration(hours: 1));
+        
+        expect(pastExpiration.isBefore(threshold), isTrue);
+      });
+
+      test('should accept recent expiration times', () {
+        final now = DateTime.now();
+        final recentExpiration = now.subtract(const Duration(minutes: 30));
+        final threshold = now.subtract(const Duration(hours: 1));
+        
+        expect(recentExpiration.isAfter(threshold), isTrue);
+      });
+
+      test('should validate expiration hours range', () {
+        expect(0 <= 0, isTrue); // Invalid: zero hours
+        expect(24 > 0 && 24 <= 168, isTrue); // Valid: 24 hours
+        expect(200 > 168, isTrue); // Invalid: over 1 week
+      });
+    });
+
+    group('Time Calculations', () {
+      test('should calculate hours correctly', () {
+        final duration = const Duration(hours: 5, minutes: 30, seconds: 45);
+        
+        final hours = duration.inHours;
+        final minutes = duration.inMinutes % 60;
+        final seconds = duration.inSeconds % 60;
+        
+        expect(hours, equals(5));
+        expect(minutes, equals(30));
+        expect(seconds, equals(45));
+      });
+
+      test('should clamp hours to maximum', () {
+        final maxHours = 24;
+        final duration = const Duration(hours: 30);
+        
+        final hoursLeft = duration.inHours.clamp(0, maxHours);
+        expect(hoursLeft, equals(24));
+      });
+
+      test('should handle zero duration', () {
+        final duration = const Duration();
+        
+        final hours = duration.inHours;
+        final minutes = duration.inMinutes % 60;
+        final seconds = duration.inSeconds % 60;
+        
+        expect(hours, equals(0));
+        expect(minutes, equals(0));
+        expect(seconds, equals(0));
+      });
+
+      test('should format time correctly', () {
+        final hours = 5;
+        final minutes = 7;
+        final seconds = 9;
+        
+        final formattedTime = '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+        
+        expect(formattedTime, equals('05:07:09'));
+      });
+    });
+
+    group('Edge Cases', () {
+      test('should handle null expiration timestamp', () {
+        final int? timestamp = null;
+        final isValid = timestamp != null && timestamp > 0;
+        
+        expect(isValid, isFalse);
+      });
+
+      test('should convert seconds to minutes correctly', () {
+        final expirationSeconds = 900; // 15 minutes
+        final expectedMinutes = (expirationSeconds / 60).round();
+        
+        expect(expectedMinutes, equals(15));
+      });
+
+      test('should handle fractional minute conversions', () {
+        final expirationSeconds = 930; // 15.5 minutes
+        final expectedMinutes = (expirationSeconds / 60).round();
+        
+        expect(expectedMinutes, equals(16)); // Rounded up
+      });
+    });
+  });
+}

--- a/test/shared/countdown_validation_test.dart
+++ b/test/shared/countdown_validation_test.dart
@@ -1,22 +1,57 @@
 import 'package:flutter_test/flutter_test.dart';
 
+// Validation functions to test real logic instead of constants
+bool isValidTimestamp(int? timestamp) {
+  return timestamp != null && timestamp > 0;
+}
+
+bool isValidExpirationHours(int hours) {
+  return hours > 0 && hours <= 168; // Between 1 hour and 1 week
+}
+
+bool isTimestampInFuture(DateTime timestamp, DateTime threshold) {
+  return timestamp.isAfter(threshold);
+}
+
+bool isExpirationTooFarInPast(DateTime expiration, DateTime threshold) {
+  return expiration.isBefore(threshold);
+}
+
+Duration calculateDurationComponents(int hours, int minutes, int seconds) {
+  return Duration(hours: hours, minutes: minutes, seconds: seconds);
+}
+
+int clampHours(int hours, int maxHours) {
+  return hours.clamp(0, maxHours);
+}
+
+String formatTime(int hours, int minutes, int seconds) {
+  return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+}
+
+int convertSecondsToMinutes(int seconds) {
+  return (seconds / 60).round();
+}
+
 void main() {
   group('Countdown Validation Tests', () {
     
     group('Timestamp Validation', () {
       test('should reject negative timestamps', () {
-        final timestamp = -1000;
-        expect(timestamp <= 0, isTrue);
+        expect(isValidTimestamp(-1000), isFalse);
       });
 
       test('should reject zero timestamps', () {
-        final timestamp = 0;
-        expect(timestamp <= 0, isTrue);
+        expect(isValidTimestamp(0), isFalse);
+      });
+
+      test('should reject null timestamps', () {
+        expect(isValidTimestamp(null), isFalse);
       });
 
       test('should accept valid timestamps', () {
         final timestamp = DateTime.now().millisecondsSinceEpoch;
-        expect(timestamp > 0, isTrue);
+        expect(isValidTimestamp(timestamp), isTrue);
       });
 
       test('should reject future timestamps beyond threshold', () {
@@ -24,7 +59,15 @@ void main() {
         final futureTime = now.add(const Duration(minutes: 10));
         final threshold = now.add(const Duration(minutes: 5));
         
-        expect(futureTime.isAfter(threshold), isTrue);
+        expect(isTimestampInFuture(futureTime, threshold), isTrue);
+      });
+
+      test('should accept timestamps within threshold', () {
+        final now = DateTime.now();
+        final recentTime = now.add(const Duration(minutes: 2));
+        final threshold = now.add(const Duration(minutes: 5));
+        
+        expect(isTimestampInFuture(recentTime, threshold), isFalse);
       });
     });
 
@@ -34,7 +77,7 @@ void main() {
         final pastExpiration = now.subtract(const Duration(hours: 2));
         final threshold = now.subtract(const Duration(hours: 1));
         
-        expect(pastExpiration.isBefore(threshold), isTrue);
+        expect(isExpirationTooFarInPast(pastExpiration, threshold), isTrue);
       });
 
       test('should accept recent expiration times', () {
@@ -42,80 +85,72 @@ void main() {
         final recentExpiration = now.subtract(const Duration(minutes: 30));
         final threshold = now.subtract(const Duration(hours: 1));
         
-        expect(recentExpiration.isAfter(threshold), isTrue);
+        expect(isExpirationTooFarInPast(recentExpiration, threshold), isFalse);
       });
 
       test('should validate expiration hours range', () {
-        expect(0 <= 0, isTrue); // Invalid: zero hours
-        expect(24 > 0 && 24 <= 168, isTrue); // Valid: 24 hours
-        expect(200 > 168, isTrue); // Invalid: over 1 week
+        expect(isValidExpirationHours(0), isFalse); // Invalid: zero hours
+        expect(isValidExpirationHours(24), isTrue); // Valid: 24 hours
+        expect(isValidExpirationHours(168), isTrue); // Valid: 1 week (max)
+        expect(isValidExpirationHours(200), isFalse); // Invalid: over 1 week
+        expect(isValidExpirationHours(-5), isFalse); // Invalid: negative hours
       });
     });
 
     group('Time Calculations', () {
-      test('should calculate hours correctly', () {
-        final duration = const Duration(hours: 5, minutes: 30, seconds: 45);
+      test('should calculate duration components correctly', () {
+        final duration = calculateDurationComponents(5, 30, 45);
         
-        final hours = duration.inHours;
-        final minutes = duration.inMinutes % 60;
-        final seconds = duration.inSeconds % 60;
-        
-        expect(hours, equals(5));
-        expect(minutes, equals(30));
-        expect(seconds, equals(45));
+        expect(duration.inHours, equals(5));
+        expect(duration.inMinutes % 60, equals(30));
+        expect(duration.inSeconds % 60, equals(45));
       });
 
       test('should clamp hours to maximum', () {
-        final maxHours = 24;
-        final duration = const Duration(hours: 30);
-        
-        final hoursLeft = duration.inHours.clamp(0, maxHours);
-        expect(hoursLeft, equals(24));
+        expect(clampHours(30, 24), equals(24));
+        expect(clampHours(10, 24), equals(10));
+        expect(clampHours(-5, 24), equals(0));
+        expect(clampHours(168, 24), equals(24));
       });
 
       test('should handle zero duration', () {
-        final duration = const Duration();
+        final duration = calculateDurationComponents(0, 0, 0);
         
-        final hours = duration.inHours;
-        final minutes = duration.inMinutes % 60;
-        final seconds = duration.inSeconds % 60;
-        
-        expect(hours, equals(0));
-        expect(minutes, equals(0));
-        expect(seconds, equals(0));
+        expect(duration.inHours, equals(0));
+        expect(duration.inMinutes, equals(0));
+        expect(duration.inSeconds, equals(0));
       });
 
       test('should format time correctly', () {
-        final hours = 5;
-        final minutes = 7;
-        final seconds = 9;
-        
-        final formattedTime = '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
-        
-        expect(formattedTime, equals('05:07:09'));
+        expect(formatTime(5, 7, 9), equals('05:07:09'));
+        expect(formatTime(0, 0, 0), equals('00:00:00'));
+        expect(formatTime(23, 59, 59), equals('23:59:59'));
+        expect(formatTime(100, 5, 3), equals('100:05:03'));
       });
     });
 
     group('Edge Cases', () {
       test('should handle null expiration timestamp', () {
-        final int? timestamp = null;
-        final isValid = timestamp != null && timestamp > 0;
-        
-        expect(isValid, isFalse);
+        expect(isValidTimestamp(null), isFalse);
       });
 
       test('should convert seconds to minutes correctly', () {
-        final expirationSeconds = 900; // 15 minutes
-        final expectedMinutes = (expirationSeconds / 60).round();
-        
-        expect(expectedMinutes, equals(15));
+        expect(convertSecondsToMinutes(900), equals(15)); // 15 minutes
+        expect(convertSecondsToMinutes(60), equals(1)); // 1 minute
+        expect(convertSecondsToMinutes(0), equals(0)); // 0 minutes
+        expect(convertSecondsToMinutes(3600), equals(60)); // 60 minutes
       });
 
       test('should handle fractional minute conversions', () {
-        final expirationSeconds = 930; // 15.5 minutes
-        final expectedMinutes = (expirationSeconds / 60).round();
-        
-        expect(expectedMinutes, equals(16)); // Rounded up
+        expect(convertSecondsToMinutes(930), equals(16)); // 15.5 minutes rounded up
+        expect(convertSecondsToMinutes(870), equals(15)); // 14.5 minutes rounded up
+        expect(convertSecondsToMinutes(450), equals(8)); // 7.5 minutes rounded up
+      });
+
+      test('should validate edge cases for expiration hours', () {
+        expect(isValidExpirationHours(1), isTrue); // Minimum valid
+        expect(isValidExpirationHours(168), isTrue); // Maximum valid
+        expect(isValidExpirationHours(169), isFalse); // Just over maximum
       });
     });
   });

--- a/test/shared/providers/time_provider_test.dart
+++ b/test/shared/providers/time_provider_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/shared/providers/time_provider.dart';
+
+void main() {
+  group('TimeProvider Tests', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('timeProvider provides DateTime values', () async {
+      final provider = container.read(timeProvider);
+      
+      // Test that provider is AsyncValue<DateTime>
+      expect(provider, isA<AsyncValue<DateTime>>());
+      
+      // Test when it has data
+      provider.when(
+        data: (value) {
+          expect(value, isA<DateTime>());
+          final now = DateTime.now();
+          final difference = now.difference(value).abs();
+          expect(difference.inSeconds, lessThan(60)); // Within 1 minute
+        },
+        loading: () => expect(true, isTrue), // Loading is ok
+        error: (error, stack) => fail('Should not have error'),
+      );
+    });
+
+    test('countdownTimeProvider provides DateTime values', () async {
+      final provider = container.read(countdownTimeProvider);
+      
+      // Test that provider is AsyncValue<DateTime>
+      expect(provider, isA<AsyncValue<DateTime>>());
+      
+      // Test when it has data
+      provider.when(
+        data: (value) {
+          expect(value, isA<DateTime>());
+          final now = DateTime.now();
+          final difference = now.difference(value).abs();
+          expect(difference.inSeconds, lessThan(60)); // Within 1 minute
+        },
+        loading: () => expect(true, isTrue), // Loading is ok
+        error: (error, stack) => fail('Should not have error'),
+      );
+    });
+
+    test('countdownTimeProvider debouncing logic', () async {
+      // Test debouncing logic conceptually
+      final now = DateTime.now();
+      final sameSecond = DateTime(now.year, now.month, now.day, now.hour, now.minute, now.second);
+      final nextSecond = sameSecond.add(const Duration(seconds: 1));
+      
+      // Should be different seconds
+      expect(nextSecond.second != sameSecond.second, isTrue);
+      
+      // Test time comparison logic
+      final lastEmittedTime = DateTime.now();
+      final currentTime = DateTime.now().add(const Duration(seconds: 1));
+      
+      final shouldEmit = lastEmittedTime.second != currentTime.second ||
+          lastEmittedTime.minute != currentTime.minute ||
+          lastEmittedTime.hour != currentTime.hour;
+      
+      expect(shouldEmit, isTrue);
+    });
+
+    test('countdownTimeProvider cleanup works correctly', () async {
+      // Create new container to test cleanup
+      final testContainer = ProviderContainer();
+      final provider = testContainer.read(countdownTimeProvider);
+      
+      // Should be able to get a provider
+      expect(provider, isA<AsyncValue<DateTime>>());
+      
+      // Dispose container (triggers cleanup)
+      testContainer.dispose();
+      
+      // Test passed if no exceptions thrown
+      expect(true, isTrue);
+    });
+
+    test('providers are independent', () async {
+      final timeProvider1 = container.read(timeProvider);
+      final countdownProvider1 = container.read(countdownTimeProvider);
+      
+      // Both should be valid AsyncValue<DateTime>
+      expect(timeProvider1, isA<AsyncValue<DateTime>>());
+      expect(countdownProvider1, isA<AsyncValue<DateTime>>());
+      
+      // Test that they are different providers (not the same reference)
+      expect(identical(timeProvider1, countdownProvider1), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
fix #155 
Use expiration_hours for the pending orders counter, and expiration_seconds for orders in waiting-buyer-invoice and waiting-payment. It also displays a more efficient countdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Countdown timers on order and trade detail screens now update in real time and handle more edge cases, offering clearer expiration information.
* **Refactor**
  * Countdown timer logic has been modularized into dedicated widgets for improved maintainability and dynamic behavior.
* **Tests**
  * Added comprehensive tests to validate countdown logic, time calculations, and provider behavior for more reliable timer displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->