### PR TITLE
Fix/Privacy switch UX confusion

### DIFF
--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -132,7 +132,8 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
       ),
       backgroundColor: AppTheme.backgroundDark,
       body: _loading
-          ? const Center(child: CircularProgressIndicator(color: AppTheme.activeColor))
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.activeColor))
           : Column(
               children: [
                 Expanded(
@@ -363,7 +364,7 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
                         const SizedBox(height: 4),
                         Text(
                           settings.fullPrivacyMode
-                              ? 'Maximum anonymity'
+                              ? S.of(context)!.maximumAnonymity
                               : S.of(context)!.standardPrivacyWithReputation,
                           style: const TextStyle(
                             color: AppTheme.textSecondary,
@@ -374,11 +375,11 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
                     ),
                   ),
                   Switch(
-                    value: !settings.fullPrivacyMode,
+                    value: settings.fullPrivacyMode,
                     onChanged: (value) {
                       ref
                           .watch(settingsProvider.notifier)
-                          .updatePrivacyMode(!value);
+                          .updatePrivacyMode(value);
                     },
                     activeColor: AppTheme.activeColor,
                     inactiveThumbColor: AppTheme.textSecondary,
@@ -523,7 +524,8 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
       child: OutlinedButton(
         onPressed: null, // Keep disabled as requested
         style: OutlinedButton.styleFrom(
-          side: BorderSide(color: AppTheme.textSecondary.withValues(alpha: 0.3)),
+          side:
+              BorderSide(color: AppTheme.textSecondary.withValues(alpha: 0.3)),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
           ),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -647,5 +647,6 @@
   "hide": "Hide",
   "reputationMode": "Reputation mode",
   "fullPrivacyMode": "Full privacy mode",
+  "maximumAnonymity": "Maximum anonymity",
   "standardPrivacyWithReputation": "Standard privacy with reputation"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -679,5 +679,6 @@
   "hide": "Ocultar",
   "reputationMode": "Modo reputación",
   "fullPrivacyMode": "Modo privacidad completa",
+  "maximumAnonymity": "Máximo anonimato",
   "standardPrivacyWithReputation": "Privacidad estándar con reputación"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -687,5 +687,6 @@
   "hide": "Nascondi",
   "reputationMode": "Modalità reputazione",
   "fullPrivacyMode": "Modalità privacy completa",
+  "maximumAnonymity": "Massimo anonimato",
   "standardPrivacyWithReputation": "Privacy standard con reputazione"
 }


### PR DESCRIPTION
🔧 Fixed Logic:

Before (confusing):
- Switch ON (green) = Reputation Mode = Less Privacy ❌
- Switch OFF (gray) = Full Privacy Mode = More Privacy ❌

After (intuitive):
- Switch ON (green) = Full Privacy Mode = More Privacy ✅
- Switch OFF (gray) = Reputation Mode = Less Privacy ✅

📝 Code Changes:

1. Switch Value: Changed from !settings.fullPrivacyMode to settings.fullPrivacyMode
2. OnChanged Logic: Changed from updatePrivacyMode(!value) to updatePrivacyMode(value)

✅ Verification:

- Flutter analyze: No issues found
- All tests passing
- UX now follows intuitive expectations where turning a privacy switch ON increases privacy

The switch now behaves as users would naturally expect - turning it ON activates the higher privacy mode (Full Privacy) and turning it OFF uses the lower privacy mode (Reputation Mode) where users can build reputation through visible trading history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the privacy mode toggle to accurately reflect the selected privacy setting.
  * Updated privacy mode description text to use localized strings for improved language support.

* **Documentation**
  * Added new translations for "Maximum anonymity" in English, Spanish, and Italian. 

* **Style**
  * Improved formatting for loading indicators and button styling for better code readability (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->