### PR TITLE
Added currency flag to the currency card

### DIFF
--- a/lib/shared/widgets/currency_combo_box.dart
+++ b/lib/shared/widgets/currency_combo_box.dart
@@ -42,9 +42,9 @@ class CurrencyComboBox extends ConsumerWidget {
           ],
         ),
         data: (currencyCodes) {
-          // Create a list of string labels like "USD - United States Dollar"
+          // Create a list of string labels like "🇺🇸 USD - United States Dollar"
           final entries = currencyCodes.entries
-              .map((e) => '${e.key} - ${e.value.name}')
+              .map((e) => '${e.value.emoji.isNotEmpty ? e.value.emoji : '🏳️'} ${e.key} - ${e.value.name}')
               .toList();
 
           return Autocomplete<String>(
@@ -59,12 +59,18 @@ class CurrencyComboBox extends ConsumerWidget {
               );
             },
             onSelected: (String selection) {
-              // Extract the ISO code (the part before " - ")
-              final code = selection.split(' - ').first;
-              // Update Riverpod state
-              ref.read(selectedFiatCodeProvider.notifier).state = code;
-              // Notify parent via callback if provided
-              onSelected?.call(code);
+              // Extract the ISO code (the part after flag and space, before " - ")
+              // Format is "🇺🇸 USD - United States Dollar"
+              final parts = selection.split(' - ');
+              if (parts.isNotEmpty) {
+                // Get the first part "🇺🇸 USD" and extract just "USD"
+                final codeWithFlag = parts.first.trim();
+                final code = codeWithFlag.split(' ').last; // Get the last part after splitting by space
+                // Update Riverpod state
+                ref.read(selectedFiatCodeProvider.notifier).state = code;
+                // Notify parent via callback if provided
+                onSelected?.call(code);
+              }
             },
             fieldViewBuilder:
                 (context, textEditingController, focusNode, onFieldSubmitted) {
@@ -72,8 +78,9 @@ class CurrencyComboBox extends ConsumerWidget {
               // so it shows up when the user opens the screen
               final existingLabel = currencyCodes[selectedFiatCode];
               if (existingLabel != null) {
+                final flag = existingLabel.emoji.isNotEmpty ? existingLabel.emoji : '🏳️';
                 textEditingController.text =
-                    '$selectedFiatCode - ${existingLabel.name}';
+                    '$flag $selectedFiatCode - ${existingLabel.name}';
               }
 
               return TextFormField(

--- a/lib/shared/widgets/currency_combo_box.dart
+++ b/lib/shared/widgets/currency_combo_box.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
 
 class CurrencyComboBox extends ConsumerWidget {
   final String label;
@@ -34,17 +35,18 @@ class CurrencyComboBox extends ConsumerWidget {
         ),
         error: (error, stackTrace) => Row(
           children: [
-            const Text('Failed to load currencies'),
+            Text(S.of(context)!.errorLoadingCurrencies),
             TextButton(
               onPressed: () => ref.refresh(currencyCodesProvider),
-              child: const Text('Retry'),
+              child: Text(S.of(context)!.retry),
             ),
           ],
         ),
         data: (currencyCodes) {
           // Create a list of string labels like "🇺🇸 USD - United States Dollar"
           final entries = currencyCodes.entries
-              .map((e) => '${e.value.emoji.isNotEmpty ? e.value.emoji : '🏳️'} ${e.key} - ${e.value.name}')
+              .map((e) =>
+                  '${e.value.emoji.isNotEmpty ? e.value.emoji : '🏳️'} ${e.key} - ${e.value.name}')
               .toList();
 
           return Autocomplete<String>(
@@ -65,7 +67,9 @@ class CurrencyComboBox extends ConsumerWidget {
               if (parts.isNotEmpty) {
                 // Get the first part "🇺🇸 USD" and extract just "USD"
                 final codeWithFlag = parts.first.trim();
-                final code = codeWithFlag.split(' ').last; // Get the last part after splitting by space
+                final code = codeWithFlag
+                    .split(' ')
+                    .last; // Get the last part after splitting by space
                 // Update Riverpod state
                 ref.read(selectedFiatCodeProvider.notifier).state = code;
                 // Notify parent via callback if provided
@@ -78,7 +82,9 @@ class CurrencyComboBox extends ConsumerWidget {
               // so it shows up when the user opens the screen
               final existingLabel = currencyCodes[selectedFiatCode];
               if (existingLabel != null) {
-                final flag = existingLabel.emoji.isNotEmpty ? existingLabel.emoji : '🏳️';
+                final flag = existingLabel.emoji.isNotEmpty
+                    ? existingLabel.emoji
+                    : '🏳️';
                 textEditingController.text =
                     '$flag $selectedFiatCode - ${existingLabel.name}';
               }


### PR DESCRIPTION
🔧 Technical Implementation:

1. Updated Currency Display Format
  - Modified entries creation to include emoji: ${e.value.emoji} ${e.key} - ${e.value.name}
  - Added fallback for missing emojis: 🏳️ (white flag)
2. Updated Text Field Initialization
  - Shows flag in the input field when screen loads
  - Format: ${flag} ${selectedFiatCode} - ${existingLabel.name}
3. Enhanced Selection Logic
  - Updated parsing logic to handle flag prefix in selections
  - Extracts currency code correctly from format: 🇺🇸 USD - United States Dollar
4. Preserved All Functionality
  - Kept exact same callback logic (onSelected)
  - Maintained state management with Riverpod
  - No changes to settings screen itself - only the CurrencyComboBox widget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Currency selection now displays flag emojis alongside currency codes for improved visual identification.

* **Bug Fixes**
  * Improved handling of currency code extraction to ensure accurate selection with the new emoji labels.

* **Style**
  * Updated currency labels throughout the interface to consistently include flag emojis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->