### PR TITLE
Fix Order Status Hydration Bug issue #219

### DIFF
--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -166,6 +166,7 @@ class OrderState {
       case Action.buyerTookOrder:
       case Action.holdInvoicePaymentAccepted:
       case Action.holdInvoicePaymentSettled:
+      case Action.buyerInvoiceAccepted:
         return Status.active;
 
       // Actions that should set status to fiat-sent
@@ -176,14 +177,18 @@ class OrderState {
       // Actions that should set status to success (completed)
       case Action.purchaseCompleted:
       case Action.released:
+      case Action.release:
       case Action.rate:
       case Action.rateReceived:
         return Status.success;
 
       // Actions that should set status to canceled
       case Action.canceled:
+      case Action.cancel:
       case Action.adminCanceled:
+      case Action.adminCancel:
       case Action.cooperativeCancelAccepted:
+      case Action.holdInvoicePaymentCanceled:
         return Status.canceled;
 
       // Actions that should set status to cooperatively canceled (pending cancellation)
@@ -195,7 +200,23 @@ class OrderState {
       case Action.disputeInitiatedByYou:
       case Action.disputeInitiatedByPeer:
       case Action.dispute:
+      case Action.adminTakeDispute:
+      case Action.adminTookDispute:
         return Status.dispute;
+
+      // Actions that should set status to admin settled
+      case Action.adminSettle:
+      case Action.adminSettled:
+        return Status.settledByAdmin;
+
+      // Informational actions that should preserve current status
+      case Action.rateUser:
+      case Action.paymentFailed:
+      case Action.invoiceUpdated:
+      case Action.sendDm:
+      case Action.tradePubkey:
+      case Action.adminAddSolver:
+        return payloadStatus ?? status;
 
       // For actions that include Order payload, use the payload status
       case Action.newOrder:

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -112,9 +112,11 @@ class OrderState {
       _logger.i('👤 New Peer found in message');
     } else if (message.payload is Order) {
       if (message.getPayload<Order>()!.buyerTradePubkey != null) {
-        newPeer = Peer(publicKey: message.getPayload<Order>()!.buyerTradePubkey!);
+        newPeer =
+            Peer(publicKey: message.getPayload<Order>()!.buyerTradePubkey!);
       } else if (message.getPayload<Order>()!.sellerTradePubkey != null) {
-        newPeer = Peer(publicKey: message.getPayload<Order>()!.sellerTradePubkey!);
+        newPeer =
+            Peer(publicKey: message.getPayload<Order>()!.sellerTradePubkey!);
       }
       _logger.i('👤 New Peer found in message');
     } else {
@@ -183,6 +185,17 @@ class OrderState {
       case Action.adminCanceled:
       case Action.cooperativeCancelAccepted:
         return Status.canceled;
+
+      // Actions that should set status to cooperatively canceled (pending cancellation)
+      case Action.cooperativeCancelInitiatedByYou:
+      case Action.cooperativeCancelInitiatedByPeer:
+        return Status.cooperativelyCanceled;
+
+      // Actions that should set status to dispute
+      case Action.disputeInitiatedByYou:
+      case Action.disputeInitiatedByPeer:
+      case Action.dispute:
+        return Status.dispute;
 
       // For actions that include Order payload, use the payload status
       case Action.newOrder:


### PR DESCRIPTION
Fixes #219 

Orders with cooperative cancellation or dispute were incorrectly showing as pending, waiting-buyer-invoice, or waiting-payment after app restart, instead of their actual cooperative cancellation or dispute states.

#### Root Cause
The OrderState._getStatusFromAction() method was missing explicit mappings for several critical actions, causing them to fall through to the default case during order hydration from storage when the app restarts.

#### Solution
Added comprehensive action-to-status mappings for all missing actions:

#### Critical Fixes:
cooperativeCancelInitiatedByYou/ByPeer → Status.cooperativelyCanceled
disputeInitiatedByYou/ByPeer → Status.dispute
Additional Completeness Fixes:

release → Status.success
cancel → Status.canceled
buyerInvoiceAccepted → Status.active
holdInvoicePaymentCanceled → Status.canceled
Admin actions → appropriate statuses (adminSettle → settledByAdmin, etc.)
Informational actions → preserve current status
