### PR TITLE
Fix currency flag inconsistency between selection menu and order book

### DIFF
--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -8,6 +8,7 @@ import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/shared/providers/time_provider.dart';
+import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
@@ -19,6 +20,7 @@ class OrderListItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(timeProvider);
+    final currencyData = ref.watch(currencyCodesProvider).asData?.value;
 
     // Determine if this is a fixed order (has specific sats amount and is not zero)
     final bool isFixedOrder =
@@ -165,9 +167,8 @@ class OrderListItem extends ConsumerWidget {
                         Text(
                           () {
                             final String currencyCode = order.currency ?? 'CUP';
-                            return CurrencyUtils.getFlagFromCurrency(
-                                    currencyCode) ??
-                                '';
+                            return CurrencyUtils.getFlagFromCurrencyData(
+                                currencyCode, currencyData);
                           }(),
                           style: const TextStyle(fontSize: 18),
                         ),

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -11,6 +11,7 @@ import 'package:mostro_mobile/features/order/providers/order_notifier_provider.d
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/shared/widgets/order_cards.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
+import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
 import 'package:mostro_mobile/shared/widgets/custom_card.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
@@ -65,7 +66,8 @@ class TakeOrderScreen extends ConsumerWidget {
   Widget _buildSellerAmount(WidgetRef ref, NostrEvent order) {
     return Builder(
       builder: (context) {
-        final currencyFlag = CurrencyUtils.getFlagFromCurrency(order.currency!);
+        final currencyData = ref.watch(currencyCodesProvider).asData?.value;
+        final currencyFlag = CurrencyUtils.getFlagFromCurrencyData(order.currency!, currencyData);
         final amountString =
             '${order.fiatAmount} ${order.currency} $currencyFlag';
         final priceText =

--- a/lib/features/trades/widgets/trades_list_item.dart
+++ b/lib/features/trades/widgets/trades_list_item.dart
@@ -10,6 +10,7 @@ import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/shared/providers/time_provider.dart';
+import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
@@ -21,6 +22,7 @@ class TradesListItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(timeProvider);
+    final currencyData = ref.watch(currencyCodesProvider).asData?.value;
     final session = ref.watch(sessionProvider(trade.orderId!));
     final role = session?.role;
     final isBuying = role == Role.buyer;
@@ -101,9 +103,8 @@ class TradesListItem extends ConsumerWidget {
                     Row(
                       children: [
                         Text(
-                          CurrencyUtils.getFlagFromCurrency(
-                                  trade.currency ?? '') ??
-                              '',
+                          CurrencyUtils.getFlagFromCurrencyData(
+                              trade.currency ?? '', currencyData),
                           style: const TextStyle(
                             fontSize: 16,
                           ),

--- a/lib/shared/utils/currency_utils.dart
+++ b/lib/shared/utils/currency_utils.dart
@@ -1,3 +1,5 @@
+import 'package:mostro_mobile/data/models/currency.dart';
+
 class CurrencyUtils {
   static String getFlagEmoji(String countryCode) {
     return countryCode
@@ -11,5 +13,21 @@ class CurrencyUtils {
   static String? getFlagFromCurrency(String currencyCode) {
     String? countryCode = currencyCode.toUpperCase().substring(0, 2);
     return getFlagEmoji(countryCode);
+  }
+
+  /// Get flag emoji from currency data - uses correct emoji from fiat.json
+  static String getFlagFromCurrencyData(String currencyCode, Map<String, Currency>? currencyData) {
+    if (currencyData == null) {
+      // Fallback to old method if data not available
+      return getFlagFromCurrency(currencyCode) ?? '🏳️';
+    }
+    
+    final currency = currencyData[currencyCode.toUpperCase()];
+    if (currency != null && currency.emoji.isNotEmpty) {
+      return currency.emoji;
+    }
+    
+    // Fallback to generic flag if currency not found
+    return '🏳️';
   }
 }

--- a/lib/shared/widgets/order_cards.dart
+++ b/lib/shared/widgets/order_cards.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/shared/widgets/custom_card.dart';
+import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 /// Card that displays the order amount information (selling/buying sats for amount)
-class OrderAmountCard extends StatelessWidget {
+class OrderAmountCard extends ConsumerWidget {
   final String title;
   final String amount;
   final String currency;
@@ -23,8 +25,9 @@ class OrderAmountCard extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    final currencyFlag = CurrencyUtils.getFlagFromCurrency(currency);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currencyData = ref.watch(currencyCodesProvider).asData?.value;
+    final currencyFlag = CurrencyUtils.getFlagFromCurrencyData(currency, currencyData);
     final amountString = '$amount $currency $currencyFlag';
 
     return CustomCard(


### PR DESCRIPTION
  - Add getFlagFromCurrencyData() method to CurrencyUtils that uses correct emoji data from fiat.json
  - Update order book cards to use proper currency flags from JSON data instead of algorithmic generation
  - Convert OrderAmountCard to ConsumerWidget for currency provider access
  - Update all order-related screens to use consistent flag display logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced currency flag display to use up-to-date currency data throughout order and trade screens.
* **Refactor**
  * Updated several widgets to retrieve currency flags using external currency data for improved accuracy.
  * Changed the OrderAmountCard widget to support state management for dynamic currency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->