### PR TITLE
feat: display premium/discount in order details and omit 0%

### DIFF
--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -188,26 +188,35 @@ class OrderListItem extends ConsumerWidget {
                                 fontWeight: FontWeight.w500,
                               ),
                             )
-                          : Row(
-                              children: [
-                                Text(
-                                  '${S.of(context)!.marketPrice} ',
+                          : premiumValue == 0
+                              ? Text(
+                                  S.of(context)!.marketPrice,
                                   style: TextStyle(
                                     fontSize: 14,
                                     color: Colors.white70,
                                     fontWeight: FontWeight.w500,
                                   ),
+                                )
+                              : Row(
+                                  children: [
+                                    Text(
+                                      '${S.of(context)!.marketPrice} ',
+                                      style: TextStyle(
+                                        fontSize: 14,
+                                        color: Colors.white70,
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                    Text(
+                                      premiumText,
+                                      style: TextStyle(
+                                        fontSize: 14,
+                                        color: premiumColor,
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                  ],
                                 ),
-                                Text(
-                                  premiumText,
-                                  style: TextStyle(
-                                    fontSize: 14,
-                                    color: premiumColor,
-                                    fontWeight: FontWeight.w500,
-                                  ),
-                                ),
-                              ],
-                            ),
                     ),
                   ],
                 ),

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -70,8 +70,23 @@ class TakeOrderScreen extends ConsumerWidget {
         final currencyFlag = CurrencyUtils.getFlagFromCurrencyData(order.currency!, currencyData);
         final amountString =
             '${order.fiatAmount} ${order.currency} $currencyFlag';
-        final priceText =
-            order.amount == '0' ? S.of(context)!.atMarketPrice : '';
+        String priceText = '';
+        if (order.amount == '0') {
+          final premium = order.premium;
+          final premiumValue = premium != null ? double.tryParse(premium) ?? 0.0 : 0.0;
+          
+          if (premiumValue == 0) {
+            // No premium - show only market price
+            priceText = S.of(context)!.atMarketPrice;
+          } else {
+            // Has premium/discount - show market price with percentage
+            final isPremiumPositive = premiumValue >= 0;
+            final premiumDisplay = isPremiumPositive
+                ? '(+$premiumValue%)'
+                : '($premiumValue%)';
+            priceText = '${S.of(context)!.atMarketPrice} $premiumDisplay';
+          }
+        }
 
         final hasFixedSatsAmount = order.amount != null && order.amount != '0';
 

--- a/lib/features/order/widgets/payment_methods_section.dart
+++ b/lib/features/order/widgets/payment_methods_section.dart
@@ -202,6 +202,8 @@ class PaymentMethodsSection extends ConsumerWidget {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: AppTheme.activeColor,
                     foregroundColor: Colors.black,
+                    padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+                    minimumSize: const Size(0, 52),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(8),
                     ),

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -111,7 +111,24 @@ class TradeDetailScreen extends ConsumerWidget {
 
       // If `orderPayload.amount` is 0, the trade is "at market price"
       final isZeroAmount = (tradeState.order!.amount == 0);
-      final priceText = isZeroAmount ? S.of(context)!.atMarketPrice : '';
+      String priceText = '';
+      
+      if (isZeroAmount) {
+        final premium = tradeState.order!.premium;
+        final premiumValue = premium.toDouble();
+        
+        if (premiumValue == 0) {
+          // No premium - show only market price
+          priceText = S.of(context)!.atMarketPrice;
+        } else {
+          // Has premium/discount - show market price with percentage
+          final isPremiumPositive = premiumValue >= 0;
+          final premiumDisplay = isPremiumPositive
+              ? '(+$premiumValue%)'
+              : '($premiumValue%)';
+          priceText = '${S.of(context)!.atMarketPrice} $premiumDisplay';
+        }
+      }
 
       final paymentMethod = tradeState.order!.paymentMethod;
       final createdOn = formatDateTime(
@@ -164,14 +181,26 @@ class TradeDetailScreen extends ConsumerWidget {
 
     final hasFixedSatsAmount = tradeState.order!.amount != 0;
     final satAmount = hasFixedSatsAmount ? ' ${tradeState.order!.amount}' : '';
-    final priceText = !hasFixedSatsAmount ? S.of(context)!.atMarketPrice : '';
-
-    final premium = tradeState.order!.premium;
-    final premiumText = premium == 0
-        ? ''
-        : (premium > 0)
-            ? S.of(context)!.withPremiumPercent(premium.toString())
-            : S.of(context)!.withDiscountPercent(premium.abs().toString());
+    
+    // For market price orders, show premium in the same format as order book
+    String priceText = '';
+    
+    if (!hasFixedSatsAmount) {
+      final premium = tradeState.order!.premium;
+      final premiumValue = premium.toDouble();
+      
+      if (premiumValue == 0) {
+        // No premium - show only market price
+        priceText = S.of(context)!.atMarketPrice;
+      } else {
+        // Has premium/discount - show market price with percentage
+        final isPremiumPositive = premiumValue >= 0;
+        final premiumDisplay = isPremiumPositive
+            ? '(+$premiumValue%)'
+            : '($premiumValue%)';
+        priceText = '${S.of(context)!.atMarketPrice} $premiumDisplay';
+      }
+    }
 
     // Payment method
     final method = tradeState.order!.paymentMethod;
@@ -196,7 +225,6 @@ class TradeDetailScreen extends ConsumerWidget {
               : tradeState.order!.fiatAmount.toString(),
           currency: tradeState.order!.fiatCode,
           priceText: priceText,
-          premiumText: premiumText,
         ),
         const SizedBox(height: 16),
         PaymentMethodCard(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced display of market price and premium/discount information for orders and trades, now clearly indicating when a premium or discount is present.
* **Style**
  * Improved button appearance in the payment methods confirmation dialog with increased padding and minimum height for better usability.
* **Bug Fixes**
  * Ensured premium values of zero are no longer redundantly displayed, resulting in a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->