### PR TITLE
Add bottom padding to prevent navigation bar overlap

### DIFF
--- a/lib/features/chat/screens/chat_rooms_list.dart
+++ b/lib/features/chat/screens/chat_rooms_list.dart
@@ -59,6 +59,9 @@ class ChatRoomsScreen extends ConsumerWidget {
     }
     return ListView.builder(
       itemCount: state.length,
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewPadding.bottom + 16,
+      ),
       itemBuilder: (context, index) {
         return ChatListItem(
           orderId: state[index].orderId,

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -118,7 +118,12 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
               Expanded(
                 child: SingleChildScrollView(
                   controller: _scrollController,
-                  padding: const EdgeInsets.all(16),
+                  padding: EdgeInsets.fromLTRB(
+                    16,
+                    16,
+                    16,
+                    16 + MediaQuery.of(context).viewPadding.bottom,
+                  ),
                   child: Form(
                     key: _formKey,
                     child: Column(

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -38,7 +38,12 @@ class TakeOrderScreen extends ConsumerWidget {
               ? S.of(context)!.buyOrderDetailsTitle
               : S.of(context)!.sellOrderDetailsTitle),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
+        padding: EdgeInsets.fromLTRB(
+          16.0,
+          16.0,
+          16.0,
+          16.0 + MediaQuery.of(context).viewPadding.bottom,
+        ),
         child: Column(
           children: [
             const SizedBox(height: 16),

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -55,7 +55,12 @@ class TradeDetailScreen extends ConsumerWidget {
       body: Builder(
         builder: (context) {
           return SingleChildScrollView(
-            padding: const EdgeInsets.all(16.0),
+            padding: EdgeInsets.fromLTRB(
+              16.0,
+              16.0,
+              16.0,
+              16.0 + MediaQuery.of(context).viewPadding.bottom,
+            ),
             child: Column(
               children: [
                 const SizedBox(height: 16),

--- a/lib/features/trades/widgets/trades_list.dart
+++ b/lib/features/trades/widgets/trades_list.dart
@@ -11,6 +11,9 @@ class TradesList extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListView.builder(
       itemCount: trades.length,
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewPadding.bottom + 16,
+      ),
       itemBuilder: (context, index) {
         return TradesListItem(trade: trades[index]);
       },


### PR DESCRIPTION
fix #37 
Adds MediaQuery.viewPadding.bottom to SingleChildScrollView padding in order screens to ensure buttons remain visible above system navigation bars on all devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved bottom padding in various screens and lists to account for device safe areas and system UI elements. This ensures that content is no longer obscured by navigation bars or notches at the bottom of the screen, providing a more consistent and accessible user experience across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->