### PR TITLE
fix time created at

### DIFF
--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -67,7 +67,7 @@ extension NostrEventExtensions on NostrEvent {
     if (timestamp != null && timestamp > 0) {
       final DateTime eventTime =
           DateTime.fromMillisecondsSinceEpoch(timestamp * 1000)
-              .subtract(Duration(hours: 36));
+              .subtract(Duration(hours: 48));
 
       // Use provided locale or fallback to Spanish
       final effectiveLocale = locale ?? 'es';


### PR DESCRIPTION
Update the time an event expires from when it is Pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of event time displays by adjusting the "time ago" calculation to use a 48-hour reference window instead of 36 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->