### PR TITLE
Hide Current Trade Index

### DIFF
--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -150,9 +151,12 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
                         _buildPrivacyCard(context, settings),
                         const SizedBox(height: 16),
 
-                        // Current Trade Index Card
-                        _buildCurrentTradeIndexCard(context),
-                        const SizedBox(height: 24),
+                        // Current Trade Index Card (Debug only)
+                        if (kDebugMode) ...[
+                          _buildCurrentTradeIndexCard(context),
+                          const SizedBox(height: 16),
+                        ],
+                        const SizedBox(height: 8),
 
                         // Generate New User Button
                         _buildGenerateNewUserButton(context),


### PR DESCRIPTION
✅ Added flutter/foundation.dart import to access kDebugMode ✅ Wrapped the card with if
(kDebugMode) conditional display
✅ Used spread operator ...[] to conditionally include both he card and its spacing ✅ Maintained proper spacing with a small spacer regardless of debug mode

How it works:
- Debug builds: The Current Trade Index Card will be visible as before
- Release builds: The card will be completely hidden from users
- Spacing: Proper spacing is maintained in both scenarios

The kDebugMode constant is true only in debug builds and false in release builds, making this the perfect solution for hiding debug-only information from production users while keeping it available for developers during testing.