### PR TITLE
feat: add basic support for PaymentFailure and NextTrade payload types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0+4]
+
+### Added
+- Comprehensive relay URL validation with proper WebSocket protocol checking
+- Real-time relay connectivity testing using direct WebSocket connections
+- Loading indicators during relay validation and testing process
+- Enhanced error messages for invalid relay URLs with helpful formatting hints
+- Debug-only display mode for Current Trade Index Card (hidden in release builds)
+
+### Fixed
+- Relay connectivity testing now accurately detects non-existent or unreachable relays
+- Invalid relay URLs (like "holahola" or "wss://xrelay.damus.io") now properly show as unhealthy
+- Relay health status now reflects actual Nostr protocol compatibility
+- False positive connectivity results for non-working relays eliminated
+- Proper cleanup of WebSocket connections during relay testing
+
+### Changed
+- Replaced dart_nostr library-based testing with direct WebSocket implementation
+- Improved relay validation logic with ws:// and wss:// protocol requirements
+- Enhanced relay testing with real Nostr REQ/response message cycles
+- Updated relay health checking to use actual connectivity verification
+- Optimized relay testing timeouts for better user experience
+
+### Security
+- Current Trade Index Card now hidden in production builds for enhanced privacy
+- Relay testing isolated from main app Nostr connections to prevent interference
+
 ## [1.0.0+3]
 
 ### Fixed

--- a/lib/core/mostro_fsm.dart
+++ b/lib/core/mostro_fsm.dart
@@ -102,10 +102,26 @@ class MostroFSM {
     Status.waitingPayment: {
       Role.seller: {
         Action.payInvoice: Status.active,
+        Action.paymentFailed: Status.paymentFailed,
         Action.cancel: Status.canceled,
       },
       Role.buyer: {
+        Action.paymentFailed: Status.paymentFailed,
         Action.cancel: Status.canceled,
+      },
+      Role.admin: {},
+    },
+    // ───────────────────────── PAYMENT FAILED ────────────────────
+    Status.paymentFailed: {
+      Role.buyer: {
+        Action.addInvoice: Status.waitingPayment,
+        Action.cancel: Status.canceled,
+        Action.dispute: Status.dispute,
+      },
+      Role.seller: {
+        Action.payInvoice: Status.active,
+        Action.cancel: Status.canceled,
+        Action.dispute: Status.dispute,
       },
       Role.admin: {},
     },

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -10,3 +10,5 @@ export 'package:mostro_mobile/data/models/peer.dart';
 export 'package:mostro_mobile/data/models/rating_user.dart';
 export 'package:mostro_mobile/data/models/rating.dart';
 export 'package:mostro_mobile/data/models/session.dart';
+export 'package:mostro_mobile/data/models/payment_failed.dart';
+export 'package:mostro_mobile/data/models/next_trade.dart';

--- a/lib/data/models/enums/status.dart
+++ b/lib/data/models/enums/status.dart
@@ -12,6 +12,7 @@ enum Status {
   success('success'),
   waitingBuyerInvoice('waiting-buyer-invoice'),
   waitingPayment('waiting-payment'),
+  paymentFailed('payment-failed'),
   cooperativelyCanceled('cooperatively-canceled'),
   inProgress('in-progress');
 

--- a/lib/data/models/next_trade.dart
+++ b/lib/data/models/next_trade.dart
@@ -1,0 +1,26 @@
+import 'package:mostro_mobile/data/models/payload.dart';
+
+class NextTrade implements Payload {
+  final String key;
+  final int index;
+
+  NextTrade({required this.key, required this.index});
+
+  @override
+  String get type => 'next_trade';
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      type: {'key': key, 'index': index},
+    };
+  }
+
+  factory NextTrade.fromJson(Map<String, dynamic> json) {
+    return NextTrade(
+      key: json['key'] as String,
+      index: json['index'] as int,
+    );
+  }
+  
+}

--- a/lib/data/models/payload.dart
+++ b/lib/data/models/payload.dart
@@ -1,6 +1,8 @@
 import 'package:mostro_mobile/data/models/cant_do.dart';
 import 'package:mostro_mobile/data/models/dispute.dart';
+import 'package:mostro_mobile/data/models/next_trade.dart';
 import 'package:mostro_mobile/data/models/order.dart';
+import 'package:mostro_mobile/data/models/payment_failed.dart';
 import 'package:mostro_mobile/data/models/payment_request.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
 import 'package:mostro_mobile/data/models/rating_user.dart';
@@ -22,6 +24,10 @@ abstract class Payload {
       return Dispute.fromJson(json);
     } else if (json.containsKey('rating_user')) {
       return RatingUser.fromJson(json['rating_user']);
+    } else if (json.containsKey('payment_failed')) {
+      return PaymentFailed.fromJson(json['payment_failed']);
+    } else if (json.containsKey('next_trade')) {
+      return NextTrade.fromJson(json['next_trade']);
     } else {
       throw UnsupportedError('Unknown payload type');
     }

--- a/lib/data/models/payment_failed.dart
+++ b/lib/data/models/payment_failed.dart
@@ -1,0 +1,31 @@
+import 'package:mostro_mobile/data/models/payload.dart';
+
+class PaymentFailed implements Payload {
+  final int paymentAttempts;
+  final int paymentRetriesInterval;
+
+  PaymentFailed({
+    required this.paymentAttempts,
+    required this.paymentRetriesInterval,
+  });
+
+  factory PaymentFailed.fromJson(Map<String, dynamic> json) {
+    return PaymentFailed(
+      paymentAttempts: json['payment_attempts'] as int,
+      paymentRetriesInterval: json['payment_retries_interval'] as int,
+    );
+  }
+
+  @override
+  String get type => 'payment_failed';
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      type: {
+        'payment_attempts': paymentAttempts,
+        'payment_retries_interval': paymentRetriesInterval,
+      },
+    };
+  }
+}

--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -655,6 +655,7 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
                 textAlign: TextAlign.center,
               ),
             ),
+            const SizedBox(width: 12),
             ElevatedButton(
               onPressed: () {
                 Navigator.of(dialogContext).pop();

--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -643,43 +643,38 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
             ),
           ),
           actions: [
-            Flexible(
-              child: TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(),
-                child: Text(
-                  S.of(context)!.cancel,
-                  style: const TextStyle(
-                    color: AppTheme.textSecondary,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                  textAlign: TextAlign.center,
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(
+                S.of(context)!.cancel,
+                style: const TextStyle(
+                  color: AppTheme.textSecondary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
                 ),
+                textAlign: TextAlign.center,
               ),
             ),
-            const SizedBox(width: 8),
-            Flexible(
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.of(dialogContext).pop();
-                  _generateNewMasterKey();
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppTheme.activeColor,
-                  foregroundColor: Colors.black,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+                _generateNewMasterKey();
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.activeColor,
+                foregroundColor: Colors.black,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
                 ),
-                child: Text(
-                  S.of(context)!.continueButton,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                  textAlign: TextAlign.center,
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              ),
+              child: Text(
+                S.of(context)!.continueButton,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
                 ),
+                textAlign: TextAlign.center,
               ),
             ),
           ],

--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -139,7 +139,12 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
               children: [
                 Expanded(
                   child: SingleChildScrollView(
-                    padding: const EdgeInsets.all(16),
+                    padding: EdgeInsets.only(
+                      left: 16,
+                      right: 16,
+                      top: 16,
+                      bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+                    ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -368,6 +368,12 @@ class OrderState {
           Action.release,
         ],
       },
+      Status.settledHoldInvoice: {
+        Action.addInvoice: [
+          Action.addInvoice,
+          Action.cancel,
+        ],
+      },
     },
     Role.buyer: {
       Status.pending: {
@@ -481,6 +487,12 @@ class OrderState {
         ],
         Action.disputeInitiatedByPeer: [
           Action.sendDm,
+          Action.cancel,
+        ],
+      },
+      Status.settledHoldInvoice: {
+        Action.addInvoice: [
+          Action.addInvoice,
           Action.cancel,
         ],
       },

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -158,7 +158,14 @@ class OrderState {
 
       // Actions that should set status to waiting-buyer-invoice
       case Action.waitingBuyerInvoice:
+        return Status.waitingBuyerInvoice;
+      
       case Action.addInvoice:
+        // If current status is paymentFailed, maintain it for UI consistency
+        // Otherwise, transition to waitingBuyerInvoice for normal flow
+        if (status == Status.paymentFailed) {
+          return Status.paymentFailed;
+        }
         return Status.waitingBuyerInvoice;
 
       // ✅ FIX: Cuando alguien toma una orden, debe cambiar el status inmediatamente
@@ -276,9 +283,8 @@ class OrderState {
       },
       Status.paymentFailed: {
         Action.paymentFailed: [
+          // Only allow payment retry, no cancel or dispute during retrying
           Action.payInvoice,
-          Action.cancel,
-          Action.dispute,
         ],
       },
       Status.active: {
@@ -403,9 +409,8 @@ class OrderState {
       },
       Status.paymentFailed: {
         Action.paymentFailed: [
+          // Only allow add invoice, no cancel or dispute during retrying
           Action.addInvoice,
-          Action.cancel,
-          Action.dispute,
         ],
       },
       Status.active: {

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -1,7 +1,6 @@
 import 'package:logger/logger.dart';
 import 'package:mostro_mobile/data/models.dart';
 import 'package:mostro_mobile/data/enums.dart';
-import 'package:mostro_mobile/data/models/payment_failed.dart';
 
 class OrderState {
   final Status status;

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -408,10 +408,11 @@ class OrderState {
         ],
       },
       Status.paymentFailed: {
-        Action.paymentFailed: [
+        Action.addInvoice: [
           // Only allow add invoice, no cancel or dispute during retrying
           Action.addInvoice,
         ],
+        Action.paymentFailed: [],
       },
       Status.active: {
         Action.holdInvoicePaymentAccepted: [

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -1,6 +1,7 @@
 import 'package:logger/logger.dart';
 import 'package:mostro_mobile/data/models.dart';
 import 'package:mostro_mobile/data/enums.dart';
+import 'package:mostro_mobile/data/models/payment_failed.dart';
 
 class OrderState {
   final Status status;
@@ -10,6 +11,7 @@ class OrderState {
   final CantDo? cantDo;
   final Dispute? dispute;
   final Peer? peer;
+  final PaymentFailed? paymentFailed;
   final _logger = Logger();
 
   OrderState({
@@ -20,6 +22,7 @@ class OrderState {
     this.cantDo,
     this.dispute,
     this.peer,
+    this.paymentFailed,
   });
 
   factory OrderState.fromMostroMessage(MostroMessage message) {
@@ -31,12 +34,13 @@ class OrderState {
       cantDo: message.getPayload<CantDo>(),
       dispute: message.getPayload<Dispute>(),
       peer: message.getPayload<Peer>(),
+      paymentFailed: message.getPayload<PaymentFailed>(),
     );
   }
 
   @override
   String toString() =>
-      'OrderState(status: $status, action: $action, order: $order, paymentRequest: $paymentRequest, cantDo: $cantDo, dispute: $dispute, peer: $peer)';
+      'OrderState(status: $status, action: $action, order: $order, paymentRequest: $paymentRequest, cantDo: $cantDo, dispute: $dispute, peer: $peer, paymentFailed: $paymentFailed)';
 
   @override
   bool operator ==(Object other) =>
@@ -48,6 +52,7 @@ class OrderState {
           other.paymentRequest == paymentRequest &&
           other.cantDo == cantDo &&
           other.dispute == dispute &&
+          other.paymentFailed == paymentFailed &&
           other.peer == peer;
 
   @override
@@ -59,6 +64,7 @@ class OrderState {
         cantDo,
         dispute,
         peer,
+        paymentFailed,
       );
 
   OrderState copyWith({
@@ -69,6 +75,7 @@ class OrderState {
     CantDo? cantDo,
     Dispute? dispute,
     Peer? peer,
+    PaymentFailed? paymentFailed,
   }) {
     return OrderState(
       status: status ?? this.status,
@@ -78,6 +85,7 @@ class OrderState {
       cantDo: cantDo ?? this.cantDo,
       dispute: dispute ?? this.dispute,
       peer: peer ?? this.peer,
+      paymentFailed: paymentFailed ?? this.paymentFailed,
     );
   }
 
@@ -135,6 +143,7 @@ class OrderState {
       cantDo: message.getPayload<CantDo>() ?? cantDo,
       dispute: message.getPayload<Dispute>() ?? dispute,
       peer: newPeer,
+      paymentFailed: message.getPayload<PaymentFailed>() ?? paymentFailed,
     );
 
     return newState;

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -217,9 +217,12 @@ class OrderState {
       case Action.adminSettled:
         return Status.settledByAdmin;
 
+      // Actions that should set status to payment failed
+      case Action.paymentFailed:
+        return Status.paymentFailed;
+
       // Informational actions that should preserve current status
       case Action.rateUser:
-      case Action.paymentFailed:
       case Action.invoiceUpdated:
       case Action.sendDm:
       case Action.tradePubkey:
@@ -269,6 +272,13 @@ class OrderState {
         ],
         Action.takeBuy: [
           Action.cancel,
+        ],
+      },
+      Status.paymentFailed: {
+        Action.paymentFailed: [
+          Action.payInvoice,
+          Action.cancel,
+          Action.dispute,
         ],
       },
       Status.active: {
@@ -383,6 +393,13 @@ class OrderState {
         ],
         Action.waitingBuyerInvoice: [
           Action.cancel,
+        ],
+      },
+      Status.paymentFailed: {
+        Action.paymentFailed: [
+          Action.addInvoice,
+          Action.cancel,
+          Action.dispute,
         ],
       },
       Status.active: {

--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -2,7 +2,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models.dart';
-import 'package:mostro_mobile/data/models/payment_failed.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';

--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models.dart';
+import 'package:mostro_mobile/data/models/payment_failed.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
@@ -213,9 +214,10 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         notifProvider.showInformation(event.action, values: {});
         break;
       case Action.paymentFailed:
+        final paymentFailed = event.getPayload<PaymentFailed>();
         notifProvider.showInformation(event.action, values: {
-          'payment_attempts': -1,
-          'payment_retries_interval': -1000
+          'payment_attempts': paymentFailed?.paymentAttempts,
+          'payment_retries_interval': paymentFailed?.paymentRetriesInterval,
         });
         break;
       default:

--- a/lib/features/relays/widgets/relay_selector.dart
+++ b/lib/features/relays/widgets/relay_selector.dart
@@ -115,6 +115,7 @@ class RelaySelector extends ConsumerWidget {
               textAlign: TextAlign.center,
             ),
           ),
+          const SizedBox(width: 12),
           ElevatedButton(
             onPressed: () {
               final url = controller.text.trim();
@@ -196,6 +197,7 @@ class RelaySelector extends ConsumerWidget {
                 textAlign: TextAlign.center,
               ),
             ),
+            const SizedBox(width: 12),
             ElevatedButton(
               onPressed: () {
                 final newUrl = controller.text.trim();

--- a/lib/features/relays/widgets/relay_selector.dart
+++ b/lib/features/relays/widgets/relay_selector.dart
@@ -101,49 +101,44 @@ class RelaySelector extends ConsumerWidget {
           ),
         ),
         actions: [
-          Flexible(
-            child: TextButton(
-              onPressed: () {
-                Navigator.pop(dialogContext);
-              },
-              child: Text(
-                S.of(context)!.cancel,
-                style: const TextStyle(
-                  color: AppTheme.textSecondary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-                textAlign: TextAlign.center,
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+            },
+            child: Text(
+              S.of(context)!.cancel,
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
               ),
+              textAlign: TextAlign.center,
             ),
           ),
-          const SizedBox(width: 8),
-          Flexible(
-            child: ElevatedButton(
-              onPressed: () {
-                final url = controller.text.trim();
-                if (url.isNotEmpty) {
-                  final newRelay = Relay(url: url, isHealthy: true);
-                  ref.read(relaysProvider.notifier).addRelay(newRelay);
-                  Navigator.pop(dialogContext);
-                }
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppTheme.activeColor,
-                foregroundColor: Colors.black,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          ElevatedButton(
+            onPressed: () {
+              final url = controller.text.trim();
+              if (url.isNotEmpty) {
+                final newRelay = Relay(url: url, isHealthy: true);
+                ref.read(relaysProvider.notifier).addRelay(newRelay);
+                Navigator.pop(dialogContext);
+              }
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppTheme.activeColor,
+              foregroundColor: Colors.black,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
               ),
-              child: Text(
-                S.of(context)!.add,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-                textAlign: TextAlign.center,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            ),
+            child: Text(
+              S.of(context)!.add,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
               ),
+              textAlign: TextAlign.center,
             ),
           ),
         ],
@@ -189,49 +184,44 @@ class RelaySelector extends ConsumerWidget {
             ),
           ),
           actions: [
-            Flexible(
-              child: TextButton(
-                onPressed: () => Navigator.pop(dialogContext),
-                child: Text(
-                  S.of(context)!.cancel,
-                  style: const TextStyle(
-                    color: AppTheme.textSecondary,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                  textAlign: TextAlign.center,
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: Text(
+                S.of(context)!.cancel,
+                style: const TextStyle(
+                  color: AppTheme.textSecondary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
                 ),
+                textAlign: TextAlign.center,
               ),
             ),
-            const SizedBox(width: 8),
-            Flexible(
-              child: ElevatedButton(
-                onPressed: () {
-                  final newUrl = controller.text.trim();
-                  if (newUrl.isNotEmpty && newUrl != relay.url) {
-                    final updatedRelay = relay.copyWith(url: newUrl);
-                    ref
-                        .read(relaysProvider.notifier)
-                        .updateRelay(relay, updatedRelay);
-                  }
-                  Navigator.pop(dialogContext);
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppTheme.activeColor,
-                  foregroundColor: Colors.black,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            ElevatedButton(
+              onPressed: () {
+                final newUrl = controller.text.trim();
+                if (newUrl.isNotEmpty && newUrl != relay.url) {
+                  final updatedRelay = relay.copyWith(url: newUrl);
+                  ref
+                      .read(relaysProvider.notifier)
+                      .updateRelay(relay, updatedRelay);
+                }
+                Navigator.pop(dialogContext);
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.activeColor,
+                foregroundColor: Colors.black,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
                 ),
-                child: Text(
-                  S.of(context)!.save,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                  ),
-                  textAlign: TextAlign.center,
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              ),
+              child: Text(
+                S.of(context)!.save,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
                 ),
+                textAlign: TextAlign.center,
               ),
             ),
           ],

--- a/lib/features/settings/about_screen.dart
+++ b/lib/features/settings/about_screen.dart
@@ -43,7 +43,12 @@ class AboutScreen extends ConsumerWidget {
         children: [
           Expanded(
             child: SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
+              padding: EdgeInsets.only(
+                left: 16,
+                right: 16,
+                top: 16,
+                bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+              ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -43,7 +43,12 @@ class SettingsScreen extends ConsumerWidget {
         children: [
           Expanded(
             child: SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
+              padding: EdgeInsets.only(
+                left: 16,
+                right: 16,
+                top: 16,
+                bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+              ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -504,15 +504,8 @@ class TradeDetailScreen extends ConsumerWidget {
           break;
 
         case actions.Action.paymentFailed:
-          // Add Invoice button for payment failed state
-          if (userRole == Role.buyer) {
-            widgets.add(_buildNostrButton(
-              S.of(context)!.addInvoiceButton,
-              action: actions.Action.addInvoice,
-              backgroundColor: AppTheme.mostroGreen,
-              onPressed: () => context.push('/add_invoice/$orderId'),
-            ));
-          }
+          // Payment failed - Mostro is still retrying, only show Close button
+          // No additional buttons (Add Invoice, Cancel, Dispute) should appear
           break;
 
         case actions.Action.holdInvoicePaymentCanceled:

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -610,6 +610,7 @@ class TradeDetailScreen extends ConsumerWidget {
                   textAlign: TextAlign.center,
                 ),
               ),
+              const SizedBox(width: 12),
               ElevatedButton(
                 onPressed: () => Navigator.of(dialogContext).pop(true),
                 style: ElevatedButton.styleFrom(

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -598,40 +598,35 @@ class TradeDetailScreen extends ConsumerWidget {
               ),
             ),
             actions: [
-              Flexible(
-                child: TextButton(
-                  onPressed: () => Navigator.of(dialogContext).pop(false),
-                  child: Text(
-                    S.of(context)!.no,
-                    style: const TextStyle(
-                      color: AppTheme.textSecondary,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                    ),
-                    textAlign: TextAlign.center,
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                child: Text(
+                  S.of(context)!.no,
+                  style: const TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
                   ),
+                  textAlign: TextAlign.center,
                 ),
               ),
-              const SizedBox(width: 8),
-              Flexible(
-                child: ElevatedButton(
-                  onPressed: () => Navigator.of(dialogContext).pop(true),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppTheme.activeColor,
-                    foregroundColor: Colors.black,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.of(dialogContext).pop(true),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppTheme.activeColor,
+                  foregroundColor: Colors.black,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
                   ),
-                  child: Text(
-                    S.of(context)!.yes,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    textAlign: TextAlign.center,
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                ),
+                child: Text(
+                  S.of(context)!.yes,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
                   ),
+                  textAlign: TextAlign.center,
                 ),
               ),
             ],

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -503,6 +503,18 @@ class TradeDetailScreen extends ConsumerWidget {
           widgets.add(_buildContactButton(context));
           break;
 
+        case actions.Action.paymentFailed:
+          // Add Invoice button for payment failed state
+          if (userRole == Role.buyer) {
+            widgets.add(_buildNostrButton(
+              S.of(context)!.addInvoiceButton,
+              action: actions.Action.addInvoice,
+              backgroundColor: AppTheme.mostroGreen,
+              onPressed: () => context.push('/add_invoice/$orderId'),
+            ));
+          }
+          break;
+
         case actions.Action.holdInvoicePaymentCanceled:
         case actions.Action.buyerInvoiceAccepted:
         case actions.Action.waitingSellerToPay:
@@ -514,7 +526,6 @@ class TradeDetailScreen extends ConsumerWidget {
         case actions.Action.adminAddSolver:
         case actions.Action.adminTakeDispute:
         case actions.Action.adminTookDispute:
-        case actions.Action.paymentFailed:
         case actions.Action.invoiceUpdated:
         case actions.Action.tradePubkey:
         case actions.Action.cantDo:

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -184,7 +184,11 @@ class MostroMessageDetail extends ConsumerWidget {
       case actions.Action.adminSettled:
         return S.of(context)!.adminSettledUsers(orderPayload!.id ?? '');
       case actions.Action.paymentFailed:
-        return S.of(context)!.paymentFailed('{attempts}', '{retries}');
+        final payload = ref.read(orderNotifierProvider(orderId)).paymentFailed;
+        return S.of(context)!.paymentFailed(
+              payload?.paymentAttempts ?? 0,
+              payload?.paymentRetriesInterval ?? 0,
+            );
       case actions.Action.invoiceUpdated:
         return S.of(context)!.invoiceUpdated;
       case actions.Action.holdInvoicePaymentCanceled:

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -185,9 +185,10 @@ class MostroMessageDetail extends ConsumerWidget {
         return S.of(context)!.adminSettledUsers(orderPayload!.id ?? '');
       case actions.Action.paymentFailed:
         final payload = ref.read(orderNotifierProvider(orderId)).paymentFailed;
+        final intervalInMinutes = ((payload?.paymentRetriesInterval ?? 0) / 60).round();
         return S.of(context)!.paymentFailed(
               payload?.paymentAttempts ?? 0,
-              payload?.paymentRetriesInterval ?? 0,
+              intervalInMinutes,
             );
       case actions.Action.invoiceUpdated:
         return S.of(context)!.invoiceUpdated;

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -84,6 +84,14 @@ class MostroMessageDetail extends ConsumerWidget {
                 ?.expirationSeconds ??
             900;
         final expMinutes = (expSecs / 60).round();
+        // Check if we're in payment-failed state to show different message
+        if (tradeState.status == Status.paymentFailed) {
+          return S.of(context)!.addInvoicePaymentFailed(
+                orderPayload?.amount.toString() ?? '',
+                orderPayload?.fiatAmount.toString() ?? '',
+                orderPayload?.fiatCode ?? '',
+              );
+        }
         return S.of(context)!.addInvoice(
               orderPayload?.amount.toString() ?? '',
               expMinutes,

--- a/lib/features/trades/widgets/trades_list_item.dart
+++ b/lib/features/trades/widgets/trades_list_item.dart
@@ -212,6 +212,12 @@ class TradesListItem extends ConsumerWidget {
         textColor = AppTheme.statusWaitingText;
         label = S.of(context)!.waitingInvoice;
         break;
+      case Status.paymentFailed:
+        backgroundColor =
+            AppTheme.statusInactiveBackground.withValues(alpha: 0.3);
+        textColor = AppTheme.statusInactiveText;
+        label = S.of(context)!.paymentFailedText;
+        break;
       case Status.fiatSent:
         backgroundColor =
             AppTheme.statusSuccessBackground.withValues(alpha: 0.3);

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -89,6 +89,7 @@
   "adminSettledAdmin": "You have completed the order ID: {id}.",
   "adminSettledUsers": "Admin has completed the order ID: {id}.",
   "paymentFailed": "I couldn’t send the Sats. I will try {payment_attempts} more times in {payment_retries_interval} minutes. Please ensure your node or wallet is online.",
+  "paymentFailedText": "Payment Failed",
   "invoiceUpdated": "The invoice has been successfully updated!",
   "holdInvoicePaymentCanceled": "The invoice was canceled; your Sats are available in your wallet again.",
   "cantDo": "You are not allowed to {action} for this order!",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -45,6 +45,23 @@
       }
     }
   },
+  "addInvoicePaymentFailed": "The payment to your previous invoice could not be completed. Please send me a new invoice for {amount} satoshis equivalent to {fiat_amount} {fiat_code} to complete the payment.",
+  "@addInvoicePaymentFailed": {
+    "placeholders": {
+      "amount": {
+        "type": "String",
+        "description": "The amount of satoshis"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "The fiat amount"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "The fiat currency code"
+      }
+    }
+  },
   "waitingSellerToPay": "Please wait. I’ve sent a payment request to the seller to send the Sats for the order ID {id}. If the seller doesn’t complete the payment within {expiration_seconds} minutes, the trade will be canceled.",
   "@waitingSellerToPay": {
     "placeholders": {
@@ -88,7 +105,7 @@
   "adminCanceledUsers": "Admin has canceled the order ID: {id}.",
   "adminSettledAdmin": "You have completed the order ID: {id}.",
   "adminSettledUsers": "Admin has completed the order ID: {id}.",
-  "paymentFailed": "I couldn’t send the Sats. I will try {payment_attempts} more times in {payment_retries_interval} minutes. Please ensure your node or wallet is online.",
+  "paymentFailed": "The payment attempt to your invoice has failed. I will retry {payment_attempts} more times, with an interval of {payment_retries_interval} minutes between each attempt. Please ensure your wallet is online to complete the payment.",
   "paymentFailedText": "Payment Failed",
   "invoiceUpdated": "The invoice has been successfully updated!",
   "holdInvoicePaymentCanceled": "The invoice was canceled; your Sats are available in your wallet again.",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -89,6 +89,7 @@
   "adminSettledAdmin": "Has completado la orden ID: {id}.",
   "adminSettledUsers": "El administrador ha completado la orden ID: {id}.",
   "paymentFailed": "No pude enviar los Sats. Intentaré {payment_attempts} veces más en {payment_retries_interval} minutos. Por favor asegúrate de que tu nodo o billetera esté en línea.",
+  "paymentFailedText": "Pago Fallido",
   "invoiceUpdated": "¡La factura ha sido actualizada exitosamente!",
   "holdInvoicePaymentCanceled": "La factura fue cancelada; tus Sats están disponibles en tu billetera nuevamente.",
   "cantDo": "¡No tienes permitido {action} para esta orden!",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -45,6 +45,23 @@
       }
     }
   },
+  "addInvoicePaymentFailed": "No fue posible completar el pago a tu factura anterior. Por favor, envíame una nueva factura por {amount} satoshis, equivalente a {fiat_amount} {fiat_code}, para realizar el pago.",
+  "@addInvoicePaymentFailed": {
+    "placeholders": {
+      "amount": {
+        "type": "String",
+        "description": "La cantidad de satoshis"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "La cantidad fiat"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "El código de moneda fiat"
+      }
+    }
+  },
   "waitingSellerToPay": "Por favor espera. He enviado una solicitud de pago al vendedor para enviar los Sats para la orden con ID {id}. Si el vendedor no completa el pago dentro de {expiration_seconds} minutos, el intercambio será cancelado.",
   "@waitingSellerToPay": {
     "placeholders": {
@@ -88,7 +105,7 @@
   "adminCanceledUsers": "El administrador ha cancelado la orden ID: {id}.",
   "adminSettledAdmin": "Has completado la orden ID: {id}.",
   "adminSettledUsers": "El administrador ha completado la orden ID: {id}.",
-  "paymentFailed": "No pude enviar los Sats. Intentaré {payment_attempts} veces más en {payment_retries_interval} minutos. Por favor asegúrate de que tu nodo o billetera esté en línea.",
+  "paymentFailed": "El intento de pago a tu factura ha fallado. Volveré a intentarlo {payment_attempts} veces más, con un intervalo de {payment_retries_interval} minutos entre cada intento. Por favor, asegúrate de que tu billetera esté en línea para poder completar el pago.",
   "paymentFailedText": "Pago Fallido",
   "invoiceUpdated": "¡La factura ha sido actualizada exitosamente!",
   "holdInvoicePaymentCanceled": "La factura fue cancelada; tus Sats están disponibles en tu billetera nuevamente.",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -45,6 +45,23 @@
       }
     }
   },
+  "addInvoicePaymentFailed": "Non è stato possibile completare il pagamento alla tua fattura precedente. Ti prego di inviarmi una nuova fattura per {amount} satoshi equivalente a {fiat_amount} {fiat_code} per completare il pagamento.",
+  "@addInvoicePaymentFailed": {
+    "placeholders": {
+      "amount": {
+        "type": "String",
+        "description": "L'importo in satoshi"
+      },
+      "fiat_amount": {
+        "type": "String",
+        "description": "L'importo fiat"
+      },
+      "fiat_code": {
+        "type": "String",
+        "description": "Il codice della valuta fiat"
+      }
+    }
+  },
   "waitingSellerToPay": "Attendi un momento per favore. Ho inviato una richiesta di pagamento al venditore per rilasciare i Sats per l'ordine ID {id}. Una volta effettuato il pagamento, vi connetterò entrambi. Se il venditore non completa il pagamento entro {expiration_seconds} minuti lo scambio sarà annullato.",
   "@waitingSellerToPay": {
     "placeholders": {
@@ -88,7 +105,7 @@
   "adminCanceledUsers": "L'amministratore ha annullato l'ordine ID: {id}!",
   "adminSettledAdmin": "Hai completato l'ordine ID: {id}!",
   "adminSettledUsers": "L'amministratore ha completato l'ordine ID: {id}!",
-  "paymentFailed": "Ho provato a inviarti i Sats ma il pagamento della tua invoice è fallito. Tenterò {payment_attempts} volte ancora ogni {payment_retries_interval} minuti. Per favore assicurati che il tuo nodo/portafoglio lightning sia online.",
+  "paymentFailed": "Il tentativo di pagamento alla tua fattura è fallito. Riproverò {payment_attempts} volte ancora, con un intervallo di {payment_retries_interval} minuti tra ogni tentativo. Per favore, assicurati che il tuo portafoglio sia online per completare il pagamento.",
   "paymentFailedText": "Pagamento Fallito",
   "invoiceUpdated": "Invoice aggiornata con successo!",
   "holdInvoicePaymentCanceled": "Invoice annullata; i tuoi Sats saranno nuovamente disponibili nel tuo portafoglio.",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -89,6 +89,7 @@
   "adminSettledAdmin": "Hai completato l'ordine ID: {id}!",
   "adminSettledUsers": "L'amministratore ha completato l'ordine ID: {id}!",
   "paymentFailed": "Ho provato a inviarti i Sats ma il pagamento della tua invoice è fallito. Tenterò {payment_attempts} volte ancora ogni {payment_retries_interval} minuti. Per favore assicurati che il tuo nodo/portafoglio lightning sia online.",
+  "paymentFailedText": "Pagamento Fallito",
   "invoiceUpdated": "Invoice aggiornata con successo!",
   "holdInvoicePaymentCanceled": "Invoice annullata; i tuoi Sats saranno nuovamente disponibili nel tuo portafoglio.",
   "cantDo": "Non sei autorizzato a {action} per questo ordine!",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+3
+version: 1.0.0+4
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
This PR adds basic support for the PaymentFailure and NextTrade payload types recently added to the mostro protocol

Users notifications and the Order Details views will now display the number of retry attempts correctly in the event of a PaymentFailure

These changes should be backwards compatible with earlier mostrod versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying detailed information when a payment fails, including the number of attempts and retry intervals.
  * Introduced new message types for handling upcoming trades and failed payments.
  * Added a new "Payment Failed" status with corresponding actions for buyers and sellers.

* **Improvements**
  * Payment failure messages now show actual attempt and retry values instead of placeholders, providing more accurate and informative feedback to users.
  * Updated order status indicators and transitions to reflect payment failure state.
  * Action buttons are now suppressed during payment failure state, showing only the Close button to avoid confusion.
  * Enhanced UI padding to better accommodate device safe areas across multiple screens.
  * Refined dialog button layouts and spacing for a cleaner and more consistent user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->