### PR TITLE
Fixes #217 - Buy order taken by user disappears after app restart

### DIFF
--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -79,6 +79,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         if (event.payload is PaymentRequest) {
           navProvider.go('/pay_invoice/${event.id!}');
         }
+        ref.read(sessionNotifierProvider.notifier).saveSession(session);
         break;
       case Action.fiatSentOk:
         final peer = event.getPayload<Peer>();


### PR DESCRIPTION
Orders in `waiting-payment` state are now saved to the session storage and persisted across app restarts when the app receives a message with the `pay-invoice` action