### PR TITLE
feat: improve maker UX when order is taken by counterpart

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -75,6 +75,15 @@
       }
     }
   },
+  "orderTakenWaitingCounterpart": "Your order has been taken by another user. You must wait for them to decide if they want to continue. If they accept, I will notify you to complete your part. For now you don't need to do anything.\nIf they don't respond in {expiration_seconds} minutes, the order will be available again for other users to take.",
+  "@orderTakenWaitingCounterpart": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "The expiration time in minutes"
+      }
+    }
+  },
   "waitingBuyerInvoice": "Payment received! Your Sats are now 'held' in your wallet. I’ve requested the buyer to provide an invoice. If they don’t do so within {expiration_seconds} minutes, your Sats will return to your wallet, and the trade will be canceled.",
   "@waitingBuyerInvoice": {
     "placeholders": {

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -75,6 +75,15 @@
       }
     }
   },
+  "orderTakenWaitingCounterpart": "Tu orden ha sido tomada por otro usuario. Debes esperar a que decida si desea continuar. Si acepta, te avisaré para que completes tu parte. Por ahora no necesitas hacer nada.\nSi no responde en {expiration_seconds} minutos, la orden volverá a estar disponible para que otros usuarios puedan tomarla.",
+  "@orderTakenWaitingCounterpart": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "El tiempo de expiración en minutos"
+      }
+    }
+  },
   "waitingBuyerInvoice": "¡Pago recibido! Tus Sats ahora están 'retenidos' en tu billetera. He solicitado al comprador que proporcione una factura. Si no lo hace dentro de {expiration_seconds} minutos, tus Sats regresarán a tu billetera y el intercambio será cancelado.",
   "@waitingBuyerInvoice": {
     "placeholders": {

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -75,6 +75,15 @@
       }
     }
   },
+  "orderTakenWaitingCounterpart": "Il tuo ordine è stato preso da un altro utente. Ora devi aspettare che decida se vuole continuare. Se accetta, ti avviserò per completare la tua parte. Per ora non devi fare nulla.\nSe non risponde in {expiration_seconds} minuti, l'ordine sarà nuovamente disponibile per altri utenti.",
+  "@orderTakenWaitingCounterpart": {
+    "placeholders": {
+      "expiration_seconds": {
+        "type": "int",
+        "description": "Il tempo di scadenza in minuti"
+      }
+    }
+  },
   "waitingBuyerInvoice": "Pagamento ricevuto! I tuoi Sats sono ora 'custoditi' nel tuo portafoglio. Attendi un momento per favore. Ho richiesto all'acquirente di fornire una invoice lightning. Una volta ricevuta, vi connetterò entrambi, altrimenti se non la riceviamo entro {expiration_seconds} minuti i tuoi Sats saranno nuovamente disponibili nel tuo portafoglio e lo scambio sarà annullato.",
   "@waitingBuyerInvoice": {
     "placeholders": {


### PR DESCRIPTION
 - Prevent auto-navigation and show waiting message for makers when their orders are taken, while preserving original behavior for takers.
  - Add personalized message for makers waiting for counterpart response