### PR TITLE
Disabled filter functionality in order list screen

### DIFF
--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -8,7 +8,6 @@ import 'package:mostro_mobile/features/home/widgets/order_list_item.dart';
 import 'package:mostro_mobile/shared/widgets/add_order_button.dart';
 import 'package:mostro_mobile/shared/widgets/bottom_nav_bar.dart';
 import 'package:mostro_mobile/shared/widgets/mostro_app_bar.dart';
-import 'package:mostro_mobile/shared/widgets/order_filter.dart';
 import 'package:mostro_mobile/shared/widgets/custom_drawer_overlay.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
@@ -196,68 +195,54 @@ class HomeScreen extends ConsumerWidget {
       color: const Color(0xFF1D212C),
       child: Align(
         alignment: Alignment.centerLeft,
-        child: GestureDetector(
-          onTap: () {
-            showModalBottomSheet(
-              context: context,
-              backgroundColor: Colors.transparent,
-              builder: (BuildContext context) {
-                return const Padding(
-                  padding: EdgeInsets.all(16.0),
-                  child: OrderFilter(),
-                );
-              },
-            );
-          },
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            decoration: BoxDecoration(
-              color: AppTheme.backgroundInput,
-              borderRadius: BorderRadius.circular(30),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.05)),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.2),
-                  blurRadius: 4,
-                  offset: const Offset(0, 2),
-                ),
-              ],
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const HeroIcon(
-                  HeroIcons.funnel,
-                  style: HeroIconStyle.outline,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: AppTheme.backgroundInput,
+            borderRadius: BorderRadius.circular(30),
+            border: Border.all(color: Colors.white.withValues(alpha: 0.05)),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.2),
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const HeroIcon(
+                HeroIcons.funnel,
+                style: HeroIconStyle.outline,
+                color: Colors.white70,
+                size: 18,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                S.of(context)!.filter,
+                style: const TextStyle(
                   color: Colors.white70,
-                  size: 18,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  letterSpacing: 0.5,
                 ),
-                const SizedBox(width: 8),
-                Text(
-                  S.of(context)!.filter,
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w500,
-                    letterSpacing: 0.5,
-                  ),
+              ),
+              Container(
+                margin: const EdgeInsets.symmetric(horizontal: 8),
+                height: 16,
+                width: 1,
+                color: Colors.white.withValues(alpha: 0.2),
+              ),
+              Text(
+                S.of(context)!.offersCount(filteredOrders.length.toString()),
+                style: const TextStyle(
+                  color: Colors.grey,
+                  fontSize: 12,
+                  fontWeight: FontWeight.normal,
                 ),
-                Container(
-                  margin: const EdgeInsets.symmetric(horizontal: 8),
-                  height: 16,
-                  width: 1,
-                  color: Colors.white.withValues(alpha: 0.2),
-                ),
-                Text(
-                  S.of(context)!.offersCount(filteredOrders.length.toString()),
-                  style: const TextStyle(
-                    color: Colors.grey,
-                    fontSize: 12,
-                    fontWeight: FontWeight.normal,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
Changes Made:

1. Removed Tap Functionality: Removed the GestureDetector wrapper and onTap callback that opened the filter modal
2. Preserved Visual Design: Kept all original styling including:
  - Container background, border radius, shadows
  - Funnel icon and "FILTER" text
  - Order count display showing "X offers"
  - Visual separator between filter text and count
3. Cleaned Up Code: Removed unused order_filter.dart import

Result:

- Filter button still appears visually identical
- Shows dynamic order count: "🔽 FILTER | X offers"
- No longer responds to taps (no modal opens)
- All analyzer checks pass (0 issues)
- Orders continue to be filtered by existing logic (buy/sell tabs + pending status)

The filter button now functions as a read-only counter that provides useful information about
  the number of available offers without the complexity of filter interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The filter button on the home screen is now static and no longer opens a filter modal when tapped. The button continues to display the funnel icon, "filter" label, and filtered order count with updated styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->