### PR TITLE
Added condition to display Range Order badge

### DIFF
--- a/lib/features/order/widgets/amount_section.dart
+++ b/lib/features/order/widgets/amount_section.dart
@@ -34,6 +34,9 @@ class _AmountSectionState extends State<AmountSection> {
     // Listen to min amount changes to show/hide second input
     _minAmountController.addListener(_onMinAmountChanged);
 
+    // Listen to max amount changes to update badge display
+    _maxAmountController.addListener(_onMaxAmountChanged);
+
     // Listen to focus changes on max amount field to enter range mode
     _maxAmountFocusNode.addListener(_onMaxAmountFocusChanged);
   }
@@ -59,6 +62,12 @@ class _AmountSectionState extends State<AmountSection> {
         }
       });
     }
+    _notifyAmountChanged();
+  }
+
+  void _onMaxAmountChanged() {
+    // Trigger rebuild to show/hide badge when max amount content changes
+    setState(() {});
     _notifyAmountChanged();
   }
 
@@ -89,7 +98,7 @@ class _AmountSectionState extends State<AmountSection> {
   }
 
   Widget? _getTopRightWidget() {
-    if (_isRangeMode) {
+    if (_isRangeMode && _maxAmountController.text.isNotEmpty) {
       return Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         decoration: BoxDecoration(
@@ -191,7 +200,6 @@ class _AmountSectionState extends State<AmountSection> {
                     keyboardType: TextInputType.number,
                     inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                     validator: _validateMaxAmount,
-                    onChanged: (_) => _notifyAmountChanged(),
                   ),
                 ),
               ],


### PR DESCRIPTION
Changes Made:

1. Updated Badge Display Logic: Modified _getTopRightWidget() to check both conditions:
  - _isRangeMode (user has focused the second input)
  - _maxAmountController.text.isNotEmpty (second input has actual content)
2. Added Real-time Updates:
  - Added listener to _maxAmountController in initState()
  - Created _onMaxAmountChanged() method to trigger rebuilds when max amount content changes
  - Removed redundant onChanged callback from max amount TextFormField

User Experience Flow:

1. User types in first input → second input appears
2. User taps/focuses second input → range mode activates but badge doesn't show yet
3. User types in second input → "Range Order" badge appears
4. User deletes content from second input → badge disappears (indicates regular order)
5. User types again in second input → badge reappears

Technical Implementation:

- Badge only shows when _isRangeMode && _maxAmountController.text.isNotEmpty
- Real-time updates through controller listener ensure immediate visual feedback
- Clean separation between focus detection (range mode) and content validation (badge display)

The Range Order badge now provides accurate visual feedback that reflects the actual order type being created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI updates when changing the max amount input to ensure accurate and timely feedback.
  * Adjusted display logic so the "range order" badge only appears when in range mode and the max amount field is filled, preventing premature badge display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->