### PR TITLE
Added an info icon to the Lightning Address card in settings,

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -256,6 +256,23 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
+                const Spacer(),
+                InkWell(
+                  onTap: () => _showInfoDialog(
+                    context,
+                    S.of(context)!.defaultLightningAddress,
+                    S.of(context)!.lightningAddressInfoText,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                  child: const Padding(
+                    padding: EdgeInsets.all(8.0),
+                    child: Icon(
+                      Icons.info_outline,
+                      size: 20,
+                      color: AppTheme.textSecondary,
+                    ),
+                  ),
+                ),
               ],
             ),
             const SizedBox(height: 20),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -725,6 +725,7 @@
   "@_comment_settings_info_dialogs": "Settings Info Dialog Text",
   "languageInfoText": "Choose your preferred language for the application interface.",
   "currencyInfoText": "Choose the default currency for your orders.",
+  "lightningAddressInfoText": "A Lightning Address is an email-like identifier (e.g., user@domain.com) that simplifies receiving Bitcoin payments. Setting a default one here will automatically populate it when creating buy orders, making the process faster and more convenient.",
   "relaysInfoText": "• Relays are servers that help distribute your messages across the Nostr network.\n\n• Adding more relays can improve connectivity and redundancy.\n\n• Relays don't sync with each other, so only those you're connected to will receive your messages.",
   "mostroInfoText": "• The Mostro you select will be the one where you post your offers.\n\n• In case of a dispute, a human assigned to that Mostro will be the one to resolve it.",
   

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -754,6 +754,7 @@
   "@_comment_settings_info_dialogs": "Texto de Diálogos de Información de Configuración",
   "languageInfoText": "Elige tu idioma preferido para la interfaz de la aplicación.",
   "currencyInfoText": "Elige la moneda predeterminada para tus órdenes.",
+  "lightningAddressInfoText": "Una Dirección Lightning es un identificador similar a un email (ej., usuario@dominio.com) que simplifica recibir pagos de Bitcoin. Establecer una predeterminada aquí la completará automáticamente al crear órdenes de compra, haciendo el proceso más rápido y conveniente.",
   "relaysInfoText": "• Los relays son servidores que ayudan a distribuir tus mensajes a través de la red Nostr.\n\n• Agregar más relays puede mejorar la conectividad y redundancia.\n\n• Los relays no se sincronizan entre sí, por lo que solo aquellos a los que estés conectado recibirán tus mensajes.",
   "mostroInfoText": "• El Mostro que selecciones será donde publiques tus ofertas.\n\n• En caso de disputa, una persona asignada a ese Mostro será quien la resuelva.",
   

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -762,6 +762,7 @@
   "@_comment_settings_info_dialogs": "Testo Dialoghi Informazioni Impostazioni",
   "languageInfoText": "Scegli la tua lingua preferita per l'interfaccia dell'applicazione.",
   "currencyInfoText": "Scegli la valuta predefinita per i tuoi ordini.",
+  "lightningAddressInfoText": "Un Indirizzo Lightning è un identificatore simile a un'email (es., utente@dominio.com) che semplifica la ricezione di pagamenti Bitcoin. Impostarne uno predefinito qui lo completerà automaticamente durante la creazione di ordini di acquisto, rendendo il processo più veloce e conveniente.",
   "relaysInfoText": "• I relay sono server che aiutano a distribuire i tuoi messaggi attraverso la rete Nostr.\n\n• Aggiungere più relay può migliorare la connettività e la ridondanza.\n\n• I relay non si sincronizzano tra loro, quindi solo quelli a cui sei connesso riceveranno i tuoi messaggi.",
   "mostroInfoText": "• Il Mostro che selezioni sarà quello dove pubblicherai le tue offerte.\n\n• In caso di disputa, una persona assegnata a quel Mostro sarà quella che la risolverà.",
   


### PR DESCRIPTION
Added lightningAddressInfoText to all three languages:

2. UI Consistency Maintained 🎨

Added the info icon with identical styling to other cards:
- ✅ Same icon: Icons.info_outline
- ✅ Same size: 20
- ✅ Same color: AppTheme.textSecondary
- ✅ Same positioning: After Spacer() in the Row
- ✅ Same interaction: InkWell with BorderRadius.circular(12)
- ✅ Same padding: EdgeInsets.all(8.0)

3. Functionality Perfect ⚡

- ✅ Info dialog works: Tapping the icon shows explanation dialog
- ✅ Multi-language support: Shows appropriate text based on user's language
- ✅ Consistent behavior: Matches language, currency, relays, and mostro cards exactly