### PR TITLE
fix: handle out_of_range_sats_amount cantDo with session cleanup and retry mechanism

### DIFF
--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -219,6 +219,17 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         break;
       case Action.cantDo:
         final cantDo = event.getPayload<CantDo>();
+        
+        // Handle specific case of out_of_range_sats_amount
+        if (cantDo?.cantDoReason.toString() == 'out_of_range_sats_amount') {
+          logger.i('Received out_of_range_sats_amount, cleaning up session for retry');
+          
+          // Clean up temporary session if it exists by requestId
+          if (event.requestId != null) {
+            ref.read(sessionNotifierProvider.notifier).cleanupRequestSession(event.requestId!);
+          }
+        }
+        
         ref.read(notificationProvider.notifier).showInformation(
           event.action,
           values: {

--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -221,7 +221,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         final cantDo = event.getPayload<CantDo>();
         
         // Handle specific case of out_of_range_sats_amount
-        if (cantDo?.cantDoReason.toString() == 'out_of_range_sats_amount') {
+        if (cantDo?.cantDoReason == CantDoReason.outOfRangeSatsAmount) {
           logger.i('Received out_of_range_sats_amount, cleaning up session for retry');
           
           // Clean up temporary session if it exists by requestId

--- a/lib/features/order/notfiers/add_order_notifier.dart
+++ b/lib/features/order/notfiers/add_order_notifier.dart
@@ -44,7 +44,7 @@ class AddOrderNotifier extends AbstractMostroNotifier {
                 
                 // Reset for retry if out_of_range_sats_amount
                 final cantDo = msg.getPayload<CantDo>();
-                if (cantDo?.cantDoReason.toString() == 'out_of_range_sats_amount') {
+                if (cantDo?.cantDoReason == CantDoReason.outOfRangeSatsAmount) {
                   _resetForRetry();
                 }
               }

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -160,6 +160,18 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     state = sessions;
   }
 
+  /// Clean up temporary session by requestId
+  /// Used when order creation fails and needs retry
+  void cleanupRequestSession(int requestId) {
+    final session = _requestIdToSession.remove(requestId);
+    if (session != null) {
+      // Remove from state list if it was a temporary session
+      final updatedSessions = sessions.where((s) => s != session).toList();
+      state = updatedSessions;
+      _logger.d('Cleaned up temporary session for requestId: $requestId');
+    }
+  }
+
   NostrKeyPairs calculateSharedKey(
       String tradePrivateKey, String counterpartyPublicKey) {
     try {


### PR DESCRIPTION
  - Add specific handling for out_of_range_sats_amount cant_do messages
  - Implement session cleanup to remove temporary sessions on retry
  - Add reset functionality in AddOrderNotifier for failed order attempts
  - Generate new requestId and trade key for each retry attempt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of "out of range sats amount" errors by cleaning up temporary sessions to prevent stale data.
* **New Features**
  * Added automatic reset and retry for order submission when encountering invalid sats amount errors, improving order processing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->