### PR TITLE
feat: enhance walkthrough highlighting and localize payment methods

### DIFF
--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -296,12 +296,11 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
         if (_showCustomPaymentMethod &&
             _customPaymentMethodController.text.isNotEmpty) {
 
-          // Remove translated "Other" text from the list
-          paymentMethods.removeWhere((method) => 
-              method == S.of(context)!.other || 
-              method == "Other" || 
-              method == "Otro" || 
-              method == "Altro");
+          // Remove localized "Other" (case-insensitive, trimmed) from the list
+          final localizedOther = S.of(context)!.other.trim().toLowerCase();
+          paymentMethods.removeWhere(
+            (method) => method.trim().toLowerCase() == localizedOther,
+          );
           
           String sanitizedPaymentMethod = _customPaymentMethodController.text;
           

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -296,7 +296,12 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
         if (_showCustomPaymentMethod &&
             _customPaymentMethodController.text.isNotEmpty) {
 
-          paymentMethods.remove("Other");
+          // Remove translated "Other" text from the list
+          paymentMethods.removeWhere((method) => 
+              method == S.of(context)!.other || 
+              method == "Other" || 
+              method == "Otro" || 
+              method == "Altro");
           
           String sanitizedPaymentMethod = _customPaymentMethodController.text;
           

--- a/lib/features/order/widgets/payment_methods_section.dart
+++ b/lib/features/order/widgets/payment_methods_section.dart
@@ -132,7 +132,11 @@ class PaymentMethodsSection extends ConsumerWidget {
       availableMethods = [...availableMethods, translatedOther];
     }
 
-    List<String> dialogSelectedMethods = List<String>.from(selectedMethods);
+    // Normalize to current locale so checkbox states align with localized labels
+    final localizedSelected = selectedMethods
+        .map((m) => _translatePaymentMethod(m, context))
+        .toList();
+    List<String> dialogSelectedMethods = List<String>.from(localizedSelected);
     bool dialogShowOtherField = dialogSelectedMethods.contains(translatedOther);
 
     showDialog(

--- a/lib/features/order/widgets/payment_methods_section.dart
+++ b/lib/features/order/widgets/payment_methods_section.dart
@@ -12,6 +12,20 @@ class PaymentMethodsSection extends ConsumerWidget {
   final TextEditingController customController;
   final Function(List<String>, bool) onMethodsChanged;
 
+  /// Helper function to translate payment method names
+  String _translatePaymentMethod(String method, BuildContext context) {
+    switch (method) {
+      case 'Bank Transfer':
+        return S.of(context)!.bankTransfer;
+      case 'Cash in person':
+        return S.of(context)!.cashInPerson;
+      case 'Other':
+        return S.of(context)!.other;
+      default:
+        return method;
+    }
+  }
+
   const PaymentMethodsSection({
     super.key,
     required this.selectedMethods,
@@ -63,10 +77,13 @@ class PaymentMethodsSection extends ConsumerWidget {
 
           List<String> availableMethods = [];
           if (data.containsKey(selectedFiatCode)) {
-            availableMethods = List<String>.from(data[selectedFiatCode]);
+            availableMethods = List<String>.from(data[selectedFiatCode])
+                .map((method) => _translatePaymentMethod(method, context))
+                .toList();
           } else {
-            availableMethods = List<String>.from(data['default'] ??
-                ['Bank Transfer', 'Cash in person', 'Other']);
+            availableMethods = List<String>.from(data['default'] ?? ['Bank Transfer', 'Cash in person', 'Other'])
+                .map((method) => _translatePaymentMethod(method, context))
+                .toList();
           }
 
           return InkWell(
@@ -110,12 +127,13 @@ class PaymentMethodsSection extends ConsumerWidget {
     Function(List<String>, bool) onMethodsChanged,
     TextEditingController customController,
   ) {
-    if (!availableMethods.contains('Other')) {
-      availableMethods = [...availableMethods, 'Other'];
+    final translatedOther = _translatePaymentMethod('Other', context);
+    if (!availableMethods.contains(translatedOther)) {
+      availableMethods = [...availableMethods, translatedOther];
     }
 
     List<String> dialogSelectedMethods = List<String>.from(selectedMethods);
-    bool dialogShowOtherField = dialogSelectedMethods.contains('Other');
+    bool dialogShowOtherField = dialogSelectedMethods.contains(translatedOther);
 
     showDialog(
       context: context,
@@ -145,12 +163,12 @@ class PaymentMethodsSection extends ConsumerWidget {
                               setDialogState(() {
                                 if (selected == true) {
                                   dialogSelectedMethods.add(method);
-                                  if (method == 'Other') {
+                                  if (method == translatedOther) {
                                     dialogShowOtherField = true;
                                   }
                                 } else {
                                   dialogSelectedMethods.remove(method);
-                                  if (method == 'Other') {
+                                  if (method == translatedOther) {
                                     dialogShowOtherField = false;
                                   }
                                 }

--- a/lib/features/walkthrough/screens/walkthrough_screen.dart
+++ b/lib/features/walkthrough/screens/walkthrough_screen.dart
@@ -44,7 +44,11 @@ class _WalkthroughScreenState extends ConsumerState<WalkthroughScreen> {
                         ? HighlightConfig.createOffer
                         : HighlightConfig.firstStep;
 
-    final RegExp highlightRegex = RegExp(config.pattern, caseSensitive: true);
+    final RegExp highlightRegex = RegExp(
+      config.pattern,
+      caseSensitive: false,
+      unicode: true,
+    );
 
     int start = 0;
     for (final match in highlightRegex.allMatches(text)) {

--- a/lib/features/walkthrough/screens/walkthrough_screen.dart
+++ b/lib/features/walkthrough/screens/walkthrough_screen.dart
@@ -20,6 +20,7 @@ class _WalkthroughScreenState extends ConsumerState<WalkthroughScreen> {
     bool isSecurityStep = false,
     bool isChatStep = false,
     bool isOrderBookStep = false,
+    bool isCreateOfferStep = false,
   }) {
     const defaultStyle = TextStyle(fontSize: 16, color: Color(0xFF9aa1b6));
     const highlightStyle = TextStyle(
@@ -39,7 +40,9 @@ class _WalkthroughScreenState extends ConsumerState<WalkthroughScreen> {
                 ? HighlightConfig.chat
                 : isOrderBookStep
                     ? HighlightConfig.orderBook
-                    : HighlightConfig.firstStep;
+                    : isCreateOfferStep
+                        ? HighlightConfig.createOffer
+                        : HighlightConfig.firstStep;
 
     final RegExp highlightRegex = RegExp(config.pattern, caseSensitive: true);
 
@@ -149,7 +152,8 @@ class _WalkthroughScreenState extends ConsumerState<WalkthroughScreen> {
       ),
       PageViewModel(
         title: S.of(context)!.cantFindWhatYouNeed,
-        bodyWidget: _buildHighlightedText(S.of(context)!.createYourOwnOffer),
+        bodyWidget: _buildHighlightedText(S.of(context)!.createYourOwnOffer,
+            isCreateOfferStep: true),
         image: buildPageImage("assets/images/wt-6.png"),
         decoration: pageDecoration,
       ),

--- a/lib/features/walkthrough/utils/highlight_config.dart
+++ b/lib/features/walkthrough/utils/highlight_config.dart
@@ -13,7 +13,7 @@ class HighlightConfig {
   );
 
   static const security = HighlightConfig(
-    pattern: r'\b(Hold Invoices|Facturas de Retención|Fatture di Blocco)\b',
+    pattern: r'\b(Hold Invoices|Facturas Retenidas|Fatture di Blocco)\b',
   );
 
   static const chat = HighlightConfig(
@@ -23,5 +23,9 @@ class HighlightConfig {
 
   static const orderBook = HighlightConfig(
     pattern: r'\b(order book|libro de órdenes|libro ordini)\b',
+  );
+
+  static const createOffer = HighlightConfig(
+    pattern: r'\b(create your own offer|crear tu propia oferta|creare la tua offerta)\b',
   );
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -275,6 +275,8 @@
   "buyingBitcoin": "Buying Bitcoin",
   "sellingBitcoin": "Selling Bitcoin",
   "bankTransfer": "Bank Transfer",
+  "cashInPerson": "Cash in person",
+  "other": "Other",
   "createdByYou": "Created by you",
   "takenByYou": "Taken by you",
   "active": "Active",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -227,6 +227,8 @@
   "buyingBitcoin": "Comprando Bitcoin",
   "sellingBitcoin": "Vendiendo Bitcoin",
   "bankTransfer": "Transferencia Bancaria",
+  "cashInPerson": "Efectivo",
+  "other": "Otro",
   "createdByYou": "Creado por ti",
   "takenByYou": "Tomado por ti",
   "active": "Activo",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -236,6 +236,8 @@
   "buyingBitcoin": "Comprando Bitcoin",
   "sellingBitcoin": "Vendendo Bitcoin",
   "bankTransfer": "Bonifico Bancario",
+  "cashInPerson": "Contanti di persona",
+  "other": "Altro",
   "createdByYou": "Creato da te",
   "takenByYou": "Preso da te",
   "active": "Attivo",


### PR DESCRIPTION
  - Add green highlighting for "create your own offer" text in walkthrough across all languages
  - Fix Spanish walkthrough highlighting: "Facturas Retenidas" now displays correctly
  - Localize payment method selection to display and send user's language to Mostro
  - Add Spanish/Italian translations for "Cash in person" ("Efectivo"/"Contanti di persona") and "Other" ("Otro"/"Altro")
  - Payment methods now sent to Mostro in user's selected language instead of English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Walkthrough now highlights the “Create Offer” step on the final page.
  * Payment method names localized across the UI; added “Cash in person” and “Other” translations (EN/ES/IT).
* **Bug Fixes**
  * Correct handling of the localized “Other” payment method during order submission and selection to ensure consistent removal and selection across languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->