### PR TITLE
Added the configuration step to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,12 @@ jobs:
           flutter-version: '3.32.2'
           channel: 'stable'
 
+      - name: Configure Flutter minSdkVersion
+        if: steps.should_build.outputs.SHOULD_BUILD == 'true'
+        run: |
+          # Ensure flutter.minSdkVersion is set to prevent build.gradle auto-modifications
+          echo "flutter.minSdkVersion=23" >> android/local.properties
+
       - name: Cache Dart & Pub artifacts
         if: steps.should_build.outputs.SHOULD_BUILD == 'true'
         uses: actions/cache@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,6 +431,12 @@ For complete technical documentation, see `RELAY_SYNC_IMPLEMENTATION.md`.
 - `lib/core/app_routes.dart` - Navigation configuration
 - `lib/core/app_theme.dart` - UI theme and styling
 
+### Android Configuration Files
+- `android/local.properties` - Flutter/Android build configuration (includes `flutter.minSdkVersion=23` to prevent build.gradle auto-modifications)
+- `android/app/build.gradle` - Android app-specific build configuration
+- `android/gradle.properties` - Gradle build properties and JVM settings
+- `android/key.properties` - Keystore configuration for APK signing (generated during CI/CD)
+
 ### Key Directories
 - `lib/features/` - Feature-based organization
 - `lib/shared/` - Shared utilities and components

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ android {
         applicationId = "network.mostro.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk 23 // Required by flutter_secure_storage
+        minSdkVersion flutter.minSdkVersion // Required by flutter_secure_storage
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName


### PR DESCRIPTION
New step (after "Set Up Flutter", before "Cache Dart & Pub artifacts"):
- name: Configure Flutter minSdkVersion if: steps.should_build.outputs.SHOULD_BUILD == 'true' run: | # Ensure flutter.minSdkVersion is set to prevent build.gradle auto-modifications echo "flutter.minSdkVersion=23" >> android/local.properties

How This Works

1. CI generates its own local.properties with correct CI SDK paths
2. Our step appends flutter.minSdkVersion=23 to that file
3. Flutter build finds the setting and doesn't modify build.gradle
4. Both local and CI now have consistent minSdk configuration

Update CLAUDE.md file