### PR TITLE
Send right payload on range order release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,8 @@ android {
         applicationId = "network.mostro.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdkVersion flutter.minSdkVersion // Required by flutter_secure_storage
+        // Required by flutter_secure_storage (needs API 23+)
+        minSdkVersion Math.max(flutter.minSdkVersion as int, 23)
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ android {
         applicationId = "network.mostro.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdkVersion 23 // Required by flutter_secure_storage
+        minSdkVersion flutter.minSdkVersion // Required by flutter_secure_storage
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,7 +84,12 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         // Required by flutter_secure_storage (needs API 23+)
-        minSdkVersion Math.max(flutter.minSdkVersion as int, 23)
+        def _requested = flutter.minSdkVersion as int
+        def _effective = Math.max(_requested, 23)
+        if (_effective > _requested) {
+            logger.lifecycle("minSdkVersion raised from ${_requested} to ${_effective} to satisfy flutter_secure_storage (API 23+).")
+        }
+        minSdkVersion _effective
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/lib/data/models/next_trade.dart
+++ b/lib/data/models/next_trade.dart
@@ -12,15 +12,18 @@ class NextTrade implements Payload {
   @override
   Map<String, dynamic> toJson() {
     return {
-      type: {'key': key, 'index': index},
+      type: [key, index],
     };
   }
 
-  factory NextTrade.fromJson(Map<String, dynamic> json) {
-    return NextTrade(
-      key: json['key'] as String,
-      index: json['index'] as int,
-    );
+  factory NextTrade.fromJson(dynamic json) {
+    if (json is List && json.length == 2) {
+      return NextTrade(
+        key: json[0] as String,
+        index: json[1] as int,
+      );
+    } else {
+      throw FormatException('Invalid NextTrade format: $json');
+    }
   }
-  
 }

--- a/lib/features/key_manager/key_manager.dart
+++ b/lib/features/key_manager/key_manager.dart
@@ -107,6 +107,13 @@ class KeyManager {
     return await _storage.readTradeKeyIndex();
   }
 
+  Future<int> getNextKeyIndex() async {
+    final currentIndex = await getCurrentKeyIndex();
+    await setCurrentKeyIndex(currentIndex + 1);
+
+    return currentIndex + 1;
+  }
+
   Future<void> setCurrentKeyIndex(int index) async {
     if (index < 1) {
       throw InvalidTradeKeyIndexException(

--- a/lib/features/order/notfiers/order_notifier.dart
+++ b/lib/features/order/notfiers/order_notifier.dart
@@ -12,8 +12,8 @@ import 'package:mostro_mobile/services/mostro_service.dart';
 class OrderNotifier extends AbstractMostroNotifier {
   late final MostroService mostroService;
   ProviderSubscription<AsyncValue<List<NostrEvent>>>? _publicEventsSubscription;
-  bool _isSyncing = false;              // Only for sync() method
-  bool _isProcessingTimeout = false;     // Only for public event processing
+  bool _isSyncing = false; // Only for sync() method
+  bool _isProcessingTimeout = false; // Only for public event processing
   OrderNotifier(super.orderId, super.ref) {
     mostroService = ref.read(mostroServiceProvider);
     sync();
@@ -23,21 +23,25 @@ class OrderNotifier extends AbstractMostroNotifier {
 
   @override
   void handleEvent(MostroMessage event) {
-    logger.i('OrderNotifier received event: ${event.action} for order $orderId');
-    
+    logger
+        .i('OrderNotifier received event: ${event.action} for order $orderId');
+
     // First handle the event normally
     super.handleEvent(event);
-    
+
     // Skip timeout detection if order is being canceled
     if (event.action == Action.canceled) {
       logger.i('Skipping timeout detection for canceled order $orderId');
       return;
     }
-    
+
     // Then check for timeout if we're in waiting states
     // Only check if we have a valid session (this is a taker scenario)
     final currentSession = ref.read(sessionProvider(orderId));
-    if (mounted && currentSession != null && (state.status == Status.waitingBuyerInvoice || state.status == Status.waitingPayment)) {
+    if (mounted &&
+        currentSession != null &&
+        (state.status == Status.waitingBuyerInvoice ||
+            state.status == Status.waitingPayment)) {
       // Schedule the async timeout check without blocking
       Future.microtask(() async {
         final shouldCleanup = await _checkTimeoutAndCleanup(state, event);
@@ -51,33 +55,33 @@ class OrderNotifier extends AbstractMostroNotifier {
 
   Future<void> sync() async {
     if (_isSyncing) return;
-    
+
     try {
       _isSyncing = true;
-      
+
       final storage = ref.read(mostroStorageProvider);
       final messages = await storage.getAllMessagesForOrderId(orderId);
       if (messages.isEmpty) {
         logger.w('No messages found for order $orderId');
         return;
       }
-      
+
       messages.sort((a, b) {
         final timestampA = a.timestamp ?? 0;
         final timestampB = b.timestamp ?? 0;
         return timestampA.compareTo(timestampB);
       });
-      
+
       OrderState currentState = state;
-      
+
       for (final message in messages) {
         if (message.action != Action.cantDo) {
           currentState = currentState.updateWith(message);
         }
       }
-      
+
       state = currentState;
-      
+
       logger.i(
           'Synced order $orderId to state: ${state.status} - ${state.action}');
     } catch (e, stack) {
@@ -154,7 +158,8 @@ class OrderNotifier extends AbstractMostroNotifier {
 
   /// Check if session should be cleaned up due to timeout or cancellation
   /// Returns true if session was cleaned up, false otherwise
-  Future<bool> _checkTimeoutAndCleanup(OrderState currentState, MostroMessage? latestGiftWrap) async {
+  Future<bool> _checkTimeoutAndCleanup(
+      OrderState currentState, MostroMessage? latestGiftWrap) async {
     if (latestGiftWrap == null) {
       return false;
     }
@@ -168,114 +173,123 @@ class OrderNotifier extends AbstractMostroNotifier {
       }
 
       final publicEvent = publicEventAsync;
-      
+
       // FIRST: Check if order was canceled (independent of timestamps)
       if (publicEvent.status == Status.canceled) {
         logger.i('CANCELLATION detected for order $orderId via public event');
-        
+
         // Only delete session if local state was pending or waiting
         if (currentState.status == Status.pending ||
             currentState.status == Status.waitingBuyerInvoice ||
             currentState.status == Status.waitingPayment) {
-          
           // CANCELED: Delete session for pending/waiting orders
           final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
           await sessionNotifier.deleteSession(orderId);
-          logger.i('Session deleted for canceled order $orderId (was in ${currentState.status})');
-          
+          logger.i(
+              'Session deleted for canceled order $orderId (was in ${currentState.status})');
+
           // Show cancellation notification
           final notifProvider = ref.read(notificationProvider.notifier);
           notifProvider.showCustomMessage('orderCanceled');
-          
+
           // Navigate to order book
           final navProvider = ref.read(navigationProvider.notifier);
           navProvider.go('/order_book');
-          
+
           return true; // Session was cleaned up
         } else {
           // For active/completed orders - keep session but update state to canceled
-          logger.i('Order canceled but keeping session due to ${currentState.status} state');
-          
+          logger.i(
+              'Order canceled but keeping session due to ${currentState.status} state');
+
           // Update local state to canceled
           state = state.copyWith(
             status: Status.canceled,
             action: Action.canceled,
           );
-          
+
           // Show cancellation notification
           final notifProvider = ref.read(notificationProvider.notifier);
           notifProvider.showCustomMessage('orderCanceled');
-          
+
           return false; // Session preserved
         }
       }
-      
+
       // SECOND: Check for timeout - simplified logic without timestamps
-      if (publicEvent.status == Status.pending && 
-          (currentState.status == Status.waitingBuyerInvoice || 
-           currentState.status == Status.waitingPayment)) {
+      if (publicEvent.status == Status.pending &&
+          (currentState.status == Status.waitingBuyerInvoice ||
+              currentState.status == Status.waitingPayment)) {
         // Timeout detected: Order returned to pending but local state is still waiting
-        logger.i('Timeout detected for order $orderId: Public shows pending but local is ${currentState.status}');
-      
+        logger.i(
+            'Timeout detected for order $orderId: Public shows pending but local is ${currentState.status}');
+
         // Determine if this is a maker (created by user) or taker (taken by user)
         final currentSession = ref.read(sessionProvider(orderId));
         if (currentSession == null) {
           return false;
         }
-        
+
         final isCreatedByUser = _isCreatedByUser(currentSession, publicEvent);
-        
+
         if (isCreatedByUser) {
           // MAKER SCENARIO: Keep session but update state to pending
-          logger.i('Order created by user - updating state to pending while keeping session');
-          
+          logger.i(
+              'Order created by user - updating state to pending while keeping session');
+
           // Show notification: counterpart didn't respond, order will be republished
           _showTimeoutNotification(isCreatedByUser: true);
-          
+
           // CRITICAL: Persist the timeout reversal to maintain pending status after app restart
           try {
             final storage = ref.read(mostroStorageProvider);
-            final publicTimestamp = publicEvent.createdAt?.millisecondsSinceEpoch ?? DateTime.now().millisecondsSinceEpoch;
+            final publicTimestamp =
+                publicEvent.createdAt?.millisecondsSinceEpoch ??
+                    DateTime.now().millisecondsSinceEpoch;
             final timeoutMessage = MostroMessage.createTimeoutReversal(
               orderId: orderId,
               timestamp: publicTimestamp,
               originalStatus: currentState.status,
               publicEvent: publicEvent,
             );
-            
+
             // Use a unique key that includes timestamp to avoid conflicts
             final messageKey = '${orderId}_timeout_$publicTimestamp';
-            await storage.addMessage(messageKey, timeoutMessage)
+            await storage
+                .addMessage(messageKey, timeoutMessage)
                 .timeout(Config.messageStorageTimeout, onTimeout: () {
-                  logger.w('Timeout persisting timeout reversal message for order $orderId - continuing anyway');
-                });
-            
+              logger.w(
+                  'Timeout persisting timeout reversal message for order $orderId - continuing anyway');
+            });
+
             logger.i('Timeout reversal message persisted for order $orderId');
           } catch (e, stack) {
-            logger.e('Failed to persist timeout reversal message for order $orderId', 
-                     error: e, stackTrace: stack);
+            logger.e(
+                'Failed to persist timeout reversal message for order $orderId',
+                error: e,
+                stackTrace: stack);
             // Continue execution even if persistence fails
           }
-          
+
           // Update state to pending without removing session
           state = state.copyWith(
             status: Status.pending,
             action: Action.timeoutReversal,
           );
-          
+
           // Return false to indicate no cleanup (session preserved)
           return false;
-          
         } else {
           // TAKER SCENARIO: Remove session completely
-          logger.i('Order taken by user - cleaning up session as order will be removed from My Trades');
-          
+          logger.i(
+              'Order taken by user - cleaning up session as order will be removed from My Trades');
+
           // Show notification: user didn't respond
           _showTimeoutNotification(isCreatedByUser: false);
-          
+
           final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
           await sessionNotifier.deleteSession(orderId);
-          
+
           // Return true to indicate session was cleaned up
           return true;
         }
@@ -283,7 +297,6 @@ class OrderNotifier extends AbstractMostroNotifier {
 
       // No timeout/cancellation detected, no cleanup needed
       return false;
-      
     } catch (e, stack) {
       logger.e(
         'Error checking timeout for order $orderId',
@@ -299,16 +312,16 @@ class OrderNotifier extends AbstractMostroNotifier {
   bool _isCreatedByUser(Session session, NostrEvent publicEvent) {
     final userRole = session.role;
     final orderType = publicEvent.orderType;
-    
+
     // Logic from TradesListItem: user is creator if role matches order type
     if (userRole == Role.buyer && orderType == OrderType.buy) {
       return true; // User created a buy order as buyer
     }
-    
+
     if (userRole == Role.seller && orderType == OrderType.sell) {
       return true; // User created a sell order as seller
     }
-    
+
     return false; // User took someone else's order (taker)
   }
 
@@ -322,45 +335,52 @@ class OrderNotifier extends AbstractMostroNotifier {
           logger.d('Timeout processing already in progress for order $orderId');
           return;
         }
-        
+
         try {
           _isProcessingTimeout = true;
-          
+
           // Verify current state AFTER setting flag to ensure cleanup
           final currentSession = ref.read(sessionProvider(orderId));
           if (!mounted || currentSession == null) {
             return;
           }
-          
+
           // Verify state - include pending for cancellation detection
           if (state.status != Status.pending &&
-              state.status != Status.waitingBuyerInvoice && 
+              state.status != Status.waitingBuyerInvoice &&
               state.status != Status.waitingPayment) {
             return;
           }
-          
+
           final storage = ref.read(mostroStorageProvider);
-          final messages = await storage.getAllMessagesForOrderId(orderId)
+          final messages = await storage
+              .getAllMessagesForOrderId(orderId)
               .timeout(Config.timeoutDetectionTimeout, onTimeout: () {
-                logger.w('Timeout getting messages for timeout detection in order $orderId - skipping cleanup');
-                return <MostroMessage>[];
-              });
-          
+            logger.w(
+                'Timeout getting messages for timeout detection in order $orderId - skipping cleanup');
+            return <MostroMessage>[];
+          });
+
           if (messages.isNotEmpty) {
-            messages.sort((a, b) => (a.timestamp ?? 0).compareTo(b.timestamp ?? 0));
+            messages
+                .sort((a, b) => (a.timestamp ?? 0).compareTo(b.timestamp ?? 0));
             final latestGiftWrap = messages.last;
-            
+
             // Verify state one more time before cleanup - include pending for cancellation
-            if (mounted && (state.status == Status.pending ||
-                state.status == Status.waitingBuyerInvoice || 
-                state.status == Status.waitingPayment)) {
-              final shouldCleanup = await _checkTimeoutAndCleanup(state, latestGiftWrap)
-                  .timeout(Config.timeoutDetectionTimeout, onTimeout: () {
-                    logger.w('Timeout in cleanup detection for order $orderId - assuming no cleanup needed');
-                    return false;
-                  });
+            if (mounted &&
+                (state.status == Status.pending ||
+                    state.status == Status.waitingBuyerInvoice ||
+                    state.status == Status.waitingPayment)) {
+              final shouldCleanup =
+                  await _checkTimeoutAndCleanup(state, latestGiftWrap)
+                      .timeout(Config.timeoutDetectionTimeout, onTimeout: () {
+                logger.w(
+                    'Timeout in cleanup detection for order $orderId - assuming no cleanup needed');
+                return false;
+              });
               if (shouldCleanup) {
-                logger.i('Real-time timeout detected - cleaning up session for order $orderId');
+                logger.i(
+                    'Real-time timeout detected - cleaning up session for order $orderId');
                 ref.invalidateSelf();
               }
             }
@@ -376,7 +396,7 @@ class OrderNotifier extends AbstractMostroNotifier {
   void _showTimeoutNotification({required bool isCreatedByUser}) {
     try {
       final notificationNotifier = ref.read(notificationProvider.notifier);
-      
+
       // Show appropriate message based on user role
       if (isCreatedByUser) {
         // User is maker - counterpart didn't respond
@@ -388,7 +408,8 @@ class OrderNotifier extends AbstractMostroNotifier {
         notificationNotifier.showCustomMessage('orderTimeoutTaker');
       }
     } catch (e, stack) {
-      logger.e('Error showing timeout notification', error: e, stackTrace: stack);
+      logger.e('Error showing timeout notification',
+          error: e, stackTrace: stack);
     }
   }
 

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -13,7 +13,6 @@ import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
-import 'package:mostro_mobile/data/models/next_trade.dart';
 
 class MostroService {
   final Ref ref;

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -11,6 +11,9 @@ import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
+import 'package:mostro_mobile/data/models/next_trade.dart';
 
 class MostroService {
   final Ref ref;
@@ -53,8 +56,8 @@ class MostroService {
 
     final sessions = ref.read(sessionNotifierProvider);
     final matchingSession = sessions.firstWhereOrNull(
-        (s) => s.tradeKey.public == event.recipient,
-      );
+      (s) => s.tradeKey.public == event.recipient,
+    );
     if (matchingSession == null) {
       _logger.w('No matching session found for recipient: ${event.recipient}');
       return;
@@ -149,10 +152,35 @@ class MostroService {
   }
 
   Future<void> releaseOrder(String orderId) async {
+    // Get the current order state to check if it's a range order
+    final orderState = ref.read(orderNotifierProvider(orderId));
+    final order = orderState.order;
+
+    // Check if this is a range order (has min and max amounts that are different and valid)
+    final isRangeOrder = order?.minAmount != null &&
+        order?.maxAmount != null &&
+        order!.minAmount! < order.maxAmount!;
+
+    Payload? payload;
+
+    if (isRangeOrder) {
+      // For range orders, we need to generate the next trade key and index
+      final keyManager = ref.read(keyManagerProvider);
+      final nextKeyIndex = await keyManager.getNextKeyIndex();
+      final nextTradeKey =
+          await keyManager.deriveTradeKeyFromIndex(nextKeyIndex);
+
+      payload = NextTrade(
+        key: nextTradeKey.public,
+        index: nextKeyIndex,
+      );
+    }
+
     await publishOrder(
       MostroMessage(
         action: Action.release,
         id: orderId,
+        payload: payload,
       ),
     );
   }
@@ -178,14 +206,15 @@ class MostroService {
 
   Future<void> publishOrder(MostroMessage order) async {
     final session = await _getSession(order);
-    
+
     final event = await order.wrap(
       tradeKey: session.tradeKey,
       recipientPubKey: _settings.mostroPublicKey,
       masterKey: session.fullPrivacy ? null : session.masterKey,
       keyIndex: session.fullPrivacy ? null : session.keyIndex,
     );
-    _logger.i('Sending DM, Event ID: ${event.id} with payload: ${order.toJson()}');
+    _logger
+        .i('Sending DM, Event ID: ${event.id} with payload: ${order.toJson()}');
     await ref.read(nostrServiceProvider).publishEvent(event);
   }
 

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -17,6 +17,8 @@ import 'package:mostro_mobile/features/subscriptions/subscription.dart';
 import 'package:mostro_mobile/services/mostro_service.dart';
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/features/order/models/order_state.dart';
+import 'package:mostro_mobile/features/order/notfiers/order_notifier.dart';
 import 'package:sembast/sembast.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -35,6 +37,9 @@ import 'mocks.mocks.dart';
   Ref,
   ProviderSubscription,
   RelaysNotifier,
+  OrderState,
+  OrderNotifier,
+  NostrKeyPairs,
 ])
 
 // Custom mock for SettingsNotifier that returns a specific Settings object

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -6,29 +6,34 @@
 import 'dart:async' as _i5;
 
 import 'package:dart_nostr/dart_nostr.dart' as _i3;
-import 'package:dart_nostr/nostr/model/relay_informations.dart' as _i12;
+import 'package:dart_nostr/nostr/model/relay_informations.dart' as _i15;
 import 'package:flutter_riverpod/flutter_riverpod.dart' as _i4;
+import 'package:logger/logger.dart' as _i13;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i13;
+import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mostro_mobile/data/enums.dart' as _i27;
 import 'package:mostro_mobile/data/models.dart' as _i7;
-import 'package:mostro_mobile/data/models/order.dart' as _i14;
-import 'package:mostro_mobile/data/repositories/mostro_storage.dart' as _i22;
+import 'package:mostro_mobile/data/models/order.dart' as _i17;
+import 'package:mostro_mobile/data/repositories/mostro_storage.dart' as _i24;
 import 'package:mostro_mobile/data/repositories/open_orders_repository.dart'
-    as _i17;
-import 'package:mostro_mobile/data/repositories/session_storage.dart' as _i20;
-import 'package:mostro_mobile/features/key_manager/key_manager.dart' as _i21;
-import 'package:mostro_mobile/features/relays/relay.dart' as _i23;
+    as _i19;
+import 'package:mostro_mobile/data/repositories/session_storage.dart' as _i22;
+import 'package:mostro_mobile/features/key_manager/key_manager.dart' as _i23;
+import 'package:mostro_mobile/features/order/models/order_state.dart' as _i11;
+import 'package:mostro_mobile/features/order/notfiers/order_notifier.dart'
+    as _i28;
+import 'package:mostro_mobile/features/relays/relay.dart' as _i25;
 import 'package:mostro_mobile/features/relays/relays_notifier.dart' as _i10;
 import 'package:mostro_mobile/features/settings/settings.dart' as _i2;
 import 'package:mostro_mobile/features/settings/settings_notifier.dart' as _i9;
-import 'package:mostro_mobile/services/deep_link_service.dart' as _i15;
-import 'package:mostro_mobile/services/mostro_service.dart' as _i16;
-import 'package:mostro_mobile/services/nostr_service.dart' as _i11;
+import 'package:mostro_mobile/services/deep_link_service.dart' as _i18;
+import 'package:mostro_mobile/services/mostro_service.dart' as _i12;
+import 'package:mostro_mobile/services/nostr_service.dart' as _i14;
 import 'package:riverpod/src/internals.dart' as _i8;
 import 'package:sembast/sembast.dart' as _i6;
-import 'package:sembast/src/api/transaction.dart' as _i19;
-import 'package:shared_preferences/src/shared_preferences_async.dart' as _i18;
-import 'package:state_notifier/state_notifier.dart' as _i24;
+import 'package:sembast/src/api/transaction.dart' as _i21;
+import 'package:shared_preferences/src/shared_preferences_async.dart' as _i20;
+import 'package:state_notifier/state_notifier.dart' as _i26;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -211,10 +216,41 @@ class _FakeRelayValidationResult_15 extends _i1.SmartFake
         );
 }
 
+class _FakeOrderState_16 extends _i1.SmartFake implements _i11.OrderState {
+  _FakeOrderState_16(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeMostroService_17 extends _i1.SmartFake
+    implements _i12.MostroService {
+  _FakeMostroService_17(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLogger_18 extends _i1.SmartFake implements _i13.Logger {
+  _FakeLogger_18(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [NostrService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockNostrService extends _i1.Mock implements _i11.NostrService {
+class MockNostrService extends _i1.Mock implements _i14.NostrService {
   MockNostrService() {
     _i1.throwOnMissingStub(this);
   }
@@ -256,14 +292,14 @@ class MockNostrService extends _i1.Mock implements _i11.NostrService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i12.RelayInformations?> getRelayInfo(String? relayUrl) =>
+  _i5.Future<_i15.RelayInformations?> getRelayInfo(String? relayUrl) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayInfo,
           [relayUrl],
         ),
-        returnValue: _i5.Future<_i12.RelayInformations?>.value(),
-      ) as _i5.Future<_i12.RelayInformations?>);
+        returnValue: _i5.Future<_i15.RelayInformations?>.value(),
+      ) as _i5.Future<_i15.RelayInformations?>);
 
   @override
   _i5.Future<void> publishEvent(_i3.NostrEvent? event) => (super.noSuchMethod(
@@ -346,7 +382,7 @@ class MockNostrService extends _i1.Mock implements _i11.NostrService {
           #getMostroPubKey,
           [],
         ),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getMostroPubKey,
@@ -425,7 +461,7 @@ class MockNostrService extends _i1.Mock implements _i11.NostrService {
             content,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRumor,
@@ -456,7 +492,7 @@ class MockNostrService extends _i1.Mock implements _i11.NostrService {
             encryptedContent,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i13.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSeal,
@@ -508,7 +544,7 @@ class MockNostrService extends _i1.Mock implements _i11.NostrService {
       );
 
   @override
-  _i5.Future<_i14.Order?> fetchEventById(
+  _i5.Future<_i17.Order?> fetchEventById(
     String? eventId, [
     List<String>? specificRelays,
   ]) =>
@@ -520,11 +556,11 @@ class MockNostrService extends _i1.Mock implements _i11.NostrService {
             specificRelays,
           ],
         ),
-        returnValue: _i5.Future<_i14.Order?>.value(),
-      ) as _i5.Future<_i14.Order?>);
+        returnValue: _i5.Future<_i17.Order?>.value(),
+      ) as _i5.Future<_i17.Order?>);
 
   @override
-  _i5.Future<_i15.OrderInfo?> fetchOrderInfoByEventId(
+  _i5.Future<_i18.OrderInfo?> fetchOrderInfoByEventId(
     String? eventId, [
     List<String>? specificRelays,
   ]) =>
@@ -536,14 +572,14 @@ class MockNostrService extends _i1.Mock implements _i11.NostrService {
             specificRelays,
           ],
         ),
-        returnValue: _i5.Future<_i15.OrderInfo?>.value(),
-      ) as _i5.Future<_i15.OrderInfo?>);
+        returnValue: _i5.Future<_i18.OrderInfo?>.value(),
+      ) as _i5.Future<_i18.OrderInfo?>);
 }
 
 /// A class which mocks [MostroService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMostroService extends _i1.Mock implements _i16.MostroService {
+class MockMostroService extends _i1.Mock implements _i12.MostroService {
   MockMostroService() {
     _i1.throwOnMissingStub(this);
   }
@@ -723,7 +759,7 @@ class MockMostroService extends _i1.Mock implements _i16.MostroService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockOpenOrdersRepository extends _i1.Mock
-    implements _i17.OpenOrdersRepository {
+    implements _i19.OpenOrdersRepository {
   MockOpenOrdersRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -816,7 +852,7 @@ class MockOpenOrdersRepository extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 // ignore: must_be_immutable
 class MockSharedPreferencesAsync extends _i1.Mock
-    implements _i18.SharedPreferencesAsync {
+    implements _i20.SharedPreferencesAsync {
   MockSharedPreferencesAsync() {
     _i1.throwOnMissingStub(this);
   }
@@ -1022,7 +1058,7 @@ class MockDatabase extends _i1.Mock implements _i6.Database {
   @override
   String get path => (super.noSuchMethod(
         Invocation.getter(#path),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#path),
         ),
@@ -1030,14 +1066,14 @@ class MockDatabase extends _i1.Mock implements _i6.Database {
 
   @override
   _i5.Future<T> transaction<T>(
-          _i5.FutureOr<T> Function(_i19.Transaction)? action) =>
+          _i5.FutureOr<T> Function(_i21.Transaction)? action) =>
       (super.noSuchMethod(
         Invocation.method(
           #transaction,
           [action],
         ),
-        returnValue: _i13.ifNotNull(
-              _i13.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #transaction,
@@ -1068,7 +1104,7 @@ class MockDatabase extends _i1.Mock implements _i6.Database {
 /// A class which mocks [SessionStorage].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSessionStorage extends _i1.Mock implements _i20.SessionStorage {
+class MockSessionStorage extends _i1.Mock implements _i22.SessionStorage {
   MockSessionStorage() {
     _i1.throwOnMissingStub(this);
   }
@@ -1331,7 +1367,7 @@ class MockSessionStorage extends _i1.Mock implements _i20.SessionStorage {
 /// A class which mocks [KeyManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockKeyManager extends _i1.Mock implements _i21.KeyManager {
+class MockKeyManager extends _i1.Mock implements _i23.KeyManager {
   MockKeyManager() {
     _i1.throwOnMissingStub(this);
   }
@@ -1469,6 +1505,15 @@ class MockKeyManager extends _i1.Mock implements _i21.KeyManager {
       ) as _i5.Future<int>);
 
   @override
+  _i5.Future<int> getNextKeyIndex() => (super.noSuchMethod(
+        Invocation.method(
+          #getNextKeyIndex,
+          [],
+        ),
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
+
+  @override
   _i5.Future<void> setCurrentKeyIndex(int? index) => (super.noSuchMethod(
         Invocation.method(
           #setCurrentKeyIndex,
@@ -1482,7 +1527,7 @@ class MockKeyManager extends _i1.Mock implements _i21.KeyManager {
 /// A class which mocks [MostroStorage].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMostroStorage extends _i1.Mock implements _i22.MostroStorage {
+class MockMostroStorage extends _i1.Mock implements _i24.MostroStorage {
   MockMostroStorage() {
     _i1.throwOnMissingStub(this);
   }
@@ -1873,7 +1918,7 @@ class MockSettings extends _i1.Mock implements _i2.Settings {
   @override
   String get mostroPublicKey => (super.noSuchMethod(
         Invocation.getter(#mostroPublicKey),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mostroPublicKey),
         ),
@@ -1970,7 +2015,7 @@ class MockRef<State extends Object?> extends _i1.Mock
           #refresh,
           [provider],
         ),
-        returnValue: _i13.dummyValue<T>(
+        returnValue: _i16.dummyValue<T>(
           this,
           Invocation.method(
             #refresh,
@@ -2077,7 +2122,7 @@ class MockRef<State extends Object?> extends _i1.Mock
           #read,
           [provider],
         ),
-        returnValue: _i13.dummyValue<T>(
+        returnValue: _i16.dummyValue<T>(
           this,
           Invocation.method(
             #read,
@@ -2101,7 +2146,7 @@ class MockRef<State extends Object?> extends _i1.Mock
           #watch,
           [provider],
         ),
-        returnValue: _i13.dummyValue<T>(
+        returnValue: _i16.dummyValue<T>(
           this,
           Invocation.method(
             #watch,
@@ -2197,7 +2242,7 @@ class MockProviderSubscription<State> extends _i1.Mock
           #read,
           [],
         ),
-        returnValue: _i13.dummyValue<State>(
+        returnValue: _i16.dummyValue<State>(
           this,
           Invocation.method(
             #read,
@@ -2249,10 +2294,10 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
       ) as List<String>);
 
   @override
-  List<_i23.MostroRelayInfo> get mostroRelaysWithStatus => (super.noSuchMethod(
+  List<_i25.MostroRelayInfo> get mostroRelaysWithStatus => (super.noSuchMethod(
         Invocation.getter(#mostroRelaysWithStatus),
-        returnValue: <_i23.MostroRelayInfo>[],
-      ) as List<_i23.MostroRelayInfo>);
+        returnValue: <_i25.MostroRelayInfo>[],
+      ) as List<_i25.MostroRelayInfo>);
 
   @override
   bool get mounted => (super.noSuchMethod(
@@ -2261,22 +2306,22 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
       ) as bool);
 
   @override
-  _i5.Stream<List<_i23.Relay>> get stream => (super.noSuchMethod(
+  _i5.Stream<List<_i25.Relay>> get stream => (super.noSuchMethod(
         Invocation.getter(#stream),
-        returnValue: _i5.Stream<List<_i23.Relay>>.empty(),
-      ) as _i5.Stream<List<_i23.Relay>>);
+        returnValue: _i5.Stream<List<_i25.Relay>>.empty(),
+      ) as _i5.Stream<List<_i25.Relay>>);
 
   @override
-  List<_i23.Relay> get state => (super.noSuchMethod(
+  List<_i25.Relay> get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: <_i23.Relay>[],
-      ) as List<_i23.Relay>);
+        returnValue: <_i25.Relay>[],
+      ) as List<_i25.Relay>);
 
   @override
-  List<_i23.Relay> get debugState => (super.noSuchMethod(
+  List<_i25.Relay> get debugState => (super.noSuchMethod(
         Invocation.getter(#debugState),
-        returnValue: <_i23.Relay>[],
-      ) as List<_i23.Relay>);
+        returnValue: <_i25.Relay>[],
+      ) as List<_i25.Relay>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -2294,7 +2339,7 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
       );
 
   @override
-  set state(List<_i23.Relay>? value) => super.noSuchMethod(
+  set state(List<_i25.Relay>? value) => super.noSuchMethod(
         Invocation.setter(
           #state,
           value,
@@ -2303,7 +2348,7 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
       );
 
   @override
-  _i5.Future<void> addRelay(_i23.Relay? relay) => (super.noSuchMethod(
+  _i5.Future<void> addRelay(_i25.Relay? relay) => (super.noSuchMethod(
         Invocation.method(
           #addRelay,
           [relay],
@@ -2314,8 +2359,8 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
 
   @override
   _i5.Future<void> updateRelay(
-    _i23.Relay? oldRelay,
-    _i23.Relay? updatedRelay,
+    _i25.Relay? oldRelay,
+    _i25.Relay? updatedRelay,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2482,8 +2527,8 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
 
   @override
   bool updateShouldNotify(
-    List<_i23.Relay>? old,
-    List<_i23.Relay>? current,
+    List<_i25.Relay>? old,
+    List<_i25.Relay>? current,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2498,7 +2543,7 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
 
   @override
   _i4.RemoveListener addListener(
-    _i24.Listener<List<_i23.Relay>>? listener, {
+    _i26.Listener<List<_i25.Relay>>? listener, {
     bool? fireImmediately = true,
   }) =>
       (super.noSuchMethod(
@@ -2509,4 +2554,479 @@ class MockRelaysNotifier extends _i1.Mock implements _i10.RelaysNotifier {
         ),
         returnValue: () {},
       ) as _i4.RemoveListener);
+}
+
+/// A class which mocks [OrderState].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockOrderState extends _i1.Mock implements _i11.OrderState {
+  MockOrderState() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i27.Status get status => (super.noSuchMethod(
+        Invocation.getter(#status),
+        returnValue: _i27.Status.active,
+      ) as _i27.Status);
+
+  @override
+  _i27.Action get action => (super.noSuchMethod(
+        Invocation.getter(#action),
+        returnValue: _i27.Action.newOrder,
+      ) as _i27.Action);
+
+  @override
+  _i11.OrderState copyWith({
+    _i27.Status? status,
+    _i27.Action? action,
+    _i17.Order? order,
+    _i7.PaymentRequest? paymentRequest,
+    _i7.CantDo? cantDo,
+    _i7.Dispute? dispute,
+    _i7.Peer? peer,
+    _i7.PaymentFailed? paymentFailed,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #copyWith,
+          [],
+          {
+            #status: status,
+            #action: action,
+            #order: order,
+            #paymentRequest: paymentRequest,
+            #cantDo: cantDo,
+            #dispute: dispute,
+            #peer: peer,
+            #paymentFailed: paymentFailed,
+          },
+        ),
+        returnValue: _FakeOrderState_16(
+          this,
+          Invocation.method(
+            #copyWith,
+            [],
+            {
+              #status: status,
+              #action: action,
+              #order: order,
+              #paymentRequest: paymentRequest,
+              #cantDo: cantDo,
+              #dispute: dispute,
+              #peer: peer,
+              #paymentFailed: paymentFailed,
+            },
+          ),
+        ),
+      ) as _i11.OrderState);
+
+  @override
+  _i11.OrderState updateWith(_i7.MostroMessage<_i7.Payload>? message) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateWith,
+          [message],
+        ),
+        returnValue: _FakeOrderState_16(
+          this,
+          Invocation.method(
+            #updateWith,
+            [message],
+          ),
+        ),
+      ) as _i11.OrderState);
+
+  @override
+  List<_i27.Action> getActions(_i27.Role? role) => (super.noSuchMethod(
+        Invocation.method(
+          #getActions,
+          [role],
+        ),
+        returnValue: <_i27.Action>[],
+      ) as List<_i27.Action>);
+}
+
+/// A class which mocks [OrderNotifier].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockOrderNotifier extends _i1.Mock implements _i28.OrderNotifier {
+  MockOrderNotifier() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i12.MostroService get mostroService => (super.noSuchMethod(
+        Invocation.getter(#mostroService),
+        returnValue: _FakeMostroService_17(
+          this,
+          Invocation.getter(#mostroService),
+        ),
+      ) as _i12.MostroService);
+
+  @override
+  set mostroService(_i12.MostroService? _mostroService) => super.noSuchMethod(
+        Invocation.setter(
+          #mostroService,
+          _mostroService,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  String get orderId => (super.noSuchMethod(
+        Invocation.getter(#orderId),
+        returnValue: _i16.dummyValue<String>(
+          this,
+          Invocation.getter(#orderId),
+        ),
+      ) as String);
+
+  @override
+  _i4.Ref<Object?> get ref => (super.noSuchMethod(
+        Invocation.getter(#ref),
+        returnValue: _FakeRef_3<Object?>(
+          this,
+          Invocation.getter(#ref),
+        ),
+      ) as _i4.Ref<Object?>);
+
+  @override
+  _i13.Logger get logger => (super.noSuchMethod(
+        Invocation.getter(#logger),
+        returnValue: _FakeLogger_18(
+          this,
+          Invocation.getter(#logger),
+        ),
+      ) as _i13.Logger);
+
+  @override
+  _i7.Session get session => (super.noSuchMethod(
+        Invocation.getter(#session),
+        returnValue: _FakeSession_7(
+          this,
+          Invocation.getter(#session),
+        ),
+      ) as _i7.Session);
+
+  @override
+  set session(_i7.Session? _session) => super.noSuchMethod(
+        Invocation.setter(
+          #session,
+          _session,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set subscription(
+          _i4.ProviderSubscription<
+                  _i4.AsyncValue<_i7.MostroMessage<_i7.Payload>?>>?
+              _subscription) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #subscription,
+          _subscription,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get mounted => (super.noSuchMethod(
+        Invocation.getter(#mounted),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i5.Stream<_i11.OrderState> get stream => (super.noSuchMethod(
+        Invocation.getter(#stream),
+        returnValue: _i5.Stream<_i11.OrderState>.empty(),
+      ) as _i5.Stream<_i11.OrderState>);
+
+  @override
+  _i11.OrderState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _FakeOrderState_16(
+          this,
+          Invocation.getter(#state),
+        ),
+      ) as _i11.OrderState);
+
+  @override
+  _i11.OrderState get debugState => (super.noSuchMethod(
+        Invocation.getter(#debugState),
+        returnValue: _FakeOrderState_16(
+          this,
+          Invocation.getter(#debugState),
+        ),
+      ) as _i11.OrderState);
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  set onError(_i4.ErrorListener? _onError) => super.noSuchMethod(
+        Invocation.setter(
+          #onError,
+          _onError,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set state(_i11.OrderState? value) => super.noSuchMethod(
+        Invocation.setter(
+          #state,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleEvent(_i7.MostroMessage<_i7.Payload>? event) => super.noSuchMethod(
+        Invocation.method(
+          #handleEvent,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<void> sync() => (super.noSuchMethod(
+        Invocation.method(
+          #sync,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> takeSellOrder(
+    String? orderId,
+    int? amount,
+    String? lnAddress,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #takeSellOrder,
+          [
+            orderId,
+            amount,
+            lnAddress,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> takeBuyOrder(
+    String? orderId,
+    int? amount,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #takeBuyOrder,
+          [
+            orderId,
+            amount,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> sendInvoice(
+    String? orderId,
+    String? invoice,
+    int? amount,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sendInvoice,
+          [
+            orderId,
+            invoice,
+            amount,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> cancelOrder() => (super.noSuchMethod(
+        Invocation.method(
+          #cancelOrder,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> sendFiatSent() => (super.noSuchMethod(
+        Invocation.method(
+          #sendFiatSent,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> releaseOrder() => (super.noSuchMethod(
+        Invocation.method(
+          #releaseOrder,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> disputeOrder() => (super.noSuchMethod(
+        Invocation.method(
+          #disputeOrder,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> submitRating(int? rating) => (super.noSuchMethod(
+        Invocation.method(
+          #submitRating,
+          [rating],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void subscribe() => super.noSuchMethod(
+        Invocation.method(
+          #subscribe,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleError(
+    Object? err,
+    StackTrace? stack,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleError,
+          [
+            err,
+            stack,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool updateShouldNotify(
+    _i11.OrderState? old,
+    _i11.OrderState? current,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateShouldNotify,
+          [
+            old,
+            current,
+          ],
+        ),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i4.RemoveListener addListener(
+    _i26.Listener<_i11.OrderState>? listener, {
+    bool? fireImmediately = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+          {#fireImmediately: fireImmediately},
+        ),
+        returnValue: () {},
+      ) as _i4.RemoveListener);
+}
+
+/// A class which mocks [NostrKeyPairs].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockNostrKeyPairs extends _i1.Mock implements _i3.NostrKeyPairs {
+  MockNostrKeyPairs() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  String get private => (super.noSuchMethod(
+        Invocation.getter(#private),
+        returnValue: _i16.dummyValue<String>(
+          this,
+          Invocation.getter(#private),
+        ),
+      ) as String);
+
+  @override
+  String get public => (super.noSuchMethod(
+        Invocation.getter(#public),
+        returnValue: _i16.dummyValue<String>(
+          this,
+          Invocation.getter(#public),
+        ),
+      ) as String);
+
+  @override
+  List<Object?> get props => (super.noSuchMethod(
+        Invocation.getter(#props),
+        returnValue: <Object?>[],
+      ) as List<Object?>);
+
+  @override
+  set public(String? _public) => super.noSuchMethod(
+        Invocation.setter(
+          #public,
+          _public,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  String sign(String? message) => (super.noSuchMethod(
+        Invocation.method(
+          #sign,
+          [message],
+        ),
+        returnValue: _i16.dummyValue<String>(
+          this,
+          Invocation.method(
+            #sign,
+            [message],
+          ),
+        ),
+      ) as String);
 }

--- a/test/services/mostro_service_helper_functions.dart
+++ b/test/services/mostro_service_helper_functions.dart
@@ -1,3 +1,7 @@
+import 'package:mostro_mobile/data/models/order.dart';
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/data/models/enums/status.dart';
+
 /// Mock server's trade index storage
 class MockServerTradeIndex {
   final Map<String, int> userTradeIndices = {};
@@ -27,4 +31,19 @@ bool validateMessageStructure(Map<String, dynamic> message) {
   }
 
   return true;
+}
+
+Order createTestOrder({int? minAmount, int? maxAmount}) {
+  return Order(
+    id: 'test-order-id',
+    kind: OrderType.buy,
+    status: Status.active,
+    amount: 1000,
+    fiatCode: 'USD',
+    minAmount: minAmount,
+    maxAmount: maxAmount,
+    fiatAmount: 100,
+    paymentMethod: 'Bank transfer',
+    premium: 5,
+  );
 }

--- a/test/services/mostro_service_test.dart
+++ b/test/services/mostro_service_test.dart
@@ -2,11 +2,9 @@ import 'dart:convert';
 import 'package:convert/convert.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:matcher/matcher.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/features/key_manager/key_derivator.dart';
-import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
@@ -20,11 +18,7 @@ import 'package:mostro_mobile/data/repositories/mostro_storage.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
-import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
-import 'package:mostro_mobile/data/models/enums/action.dart';
-import 'package:mostro_mobile/data/models/next_trade.dart';
-import 'package:mostro_mobile/data/models/payload.dart';
 
 import '../mocks.dart';
 import '../mocks.mocks.dart';
@@ -45,7 +39,7 @@ void main() {
 
   // Add dummy for NostrService
   provideDummy<NostrService>(MockNostrService());
-  
+
   // Add dummy for KeyManager
   provideDummy<KeyManager>(MockKeyManager());
 
@@ -392,8 +386,6 @@ void main() {
       expect(isValid, isTrue,
           reason: 'Server should accept valid messages in full privacy mode');
     });
-
-
   });
 }
 
@@ -409,4 +401,3 @@ class TestableReleaseOrderService extends MostroService {
     capturedMessages.add(order);
   }
 }
-

--- a/test/services/mostro_service_test.dart
+++ b/test/services/mostro_service_test.dart
@@ -410,6 +410,7 @@ void main() {
     late TestableReleaseOrderService svc;
     late NostrKeyPairs masterKey;
     late NostrKeyPairs tradeKey;
+    late NostrKeyPairs nextTradeKey;
 
     setUp(() {
       capturedMessages = [];
@@ -420,8 +421,11 @@ void main() {
       final extendedPrivKey = keyDerivator.extendedKeyFromMnemonic(mnemonic);
       final masterPrivKey = keyDerivator.derivePrivateKey(extendedPrivKey, 0);
       final tradePrivKey = keyDerivator.derivePrivateKey(extendedPrivKey, 1);
+      final nextPrivKey = keyDerivator.derivePrivateKey(extendedPrivKey, 5);
+
       masterKey = NostrKeyPairs(private: masterPrivKey);
       tradeKey = NostrKeyPairs(private: tradePrivKey);
+      nextTradeKey = NostrKeyPairs(private: nextPrivKey);
 
       // Ensure a mock session with masterKey and tradeKey is set on mockSessionNotifier
       final session = Session(
@@ -445,7 +449,7 @@ void main() {
 
       // Stub mockKeyManager.deriveTradeKeyFromIndex to return a mock key pair
       when(mockKeyManager.deriveTradeKeyFromIndex(5))
-          .thenAnswer((_) async => masterKey);
+          .thenAnswer((_) async => nextTradeKey);
 
       // Stub mockNostrService.publishEvent
       when(mockNostrService.publishEvent(any))
@@ -490,7 +494,7 @@ void main() {
 
       final payload = message.toJson()['payload'];
       expect(payload, contains('next_trade'));
-      expect(payload['next_trade'], equals([masterKey.public, 5]));
+      expect(payload['next_trade'], equals([nextTradeKey.public, 5]));
     });
 
     test(

--- a/test/services/mostro_service_test.dart
+++ b/test/services/mostro_service_test.dart
@@ -17,9 +17,6 @@ import 'package:mostro_mobile/data/repositories/mostro_storage.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
-import 'package:mostro_mobile/data/models/next_trade.dart';
-import 'package:mostro_mobile/data/models/mostro_message.dart';
-import 'package:mostro_mobile/data/models/enums/action.dart';
 
 import '../mocks.dart';
 import '../mocks.mocks.dart';

--- a/test/services/mostro_service_test.dart
+++ b/test/services/mostro_service_test.dart
@@ -99,6 +99,9 @@ void main() {
     mockServerTradeIndex = MockServerTradeIndex();
     keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
 
+    // Stub mockKeyManager.getNextKeyIndex() to return deterministic value
+    when(mockKeyManager.getNextKeyIndex()).thenAnswer((_) async => 5);
+
     // Setup all stubs before creating any objects that use them
     final testSettings = MockSettings();
     when(testSettings.mostroPublicKey).thenReturn(
@@ -440,9 +443,6 @@ void main() {
       // Stub keyManagerProvider to return our mock
       when(mockRef.read(keyManagerProvider)).thenReturn(mockKeyManager);
 
-      // Stub mockKeyManager.getNextKeyIndex() to return 5
-      when(mockKeyManager.getNextKeyIndex()).thenAnswer((_) async => 5);
-
       // Stub mockKeyManager.deriveTradeKeyFromIndex to return a mock key pair
       when(mockKeyManager.deriveTradeKeyFromIndex(5))
           .thenAnswer((_) async => masterKey);
@@ -501,9 +501,6 @@ void main() {
 
       // Stub keyManagerProvider to return our mock
       when(mockRef.read(keyManagerProvider)).thenReturn(mockKeyManager);
-
-      // Stub mockKeyManager.getNextKeyIndex() to return 5
-      when(mockKeyManager.getNextKeyIndex()).thenAnswer((_) async => 5);
 
       // Stub mockKeyManager.deriveTradeKeyFromIndex to return a mock key pair
       when(mockKeyManager.deriveTradeKeyFromIndex(5))

--- a/test/services/mostro_service_test.dart
+++ b/test/services/mostro_service_test.dart
@@ -140,9 +140,9 @@ void main() {
 
     // Compute SHA-256 hash of the message JSON
     final jsonString = jsonEncode(messageContent);
-    final messageBase64 = hex.encode(jsonString.codeUnits);
+    final messageHex = hex.encode(jsonString.codeUnits);
 
-    return NostrKeyPairs.verify(userPubKey, messageBase64, signatureHex);
+    return NostrKeyPairs.verify(userPubKey, messageHex, signatureHex);
   }
 
   group('MostroService Integration Tests', () {
@@ -234,9 +234,6 @@ void main() {
       when(mockNostrService.publishEvent(any))
           .thenAnswer((_) async => Future<void>.value());
 
-      when(mockNostrService.publishEvent(any))
-          .thenAnswer((_) async => Future.value());
-
       // Act
       await mostroService.takeSellOrder(orderId, 200, 'lnbc5678invoice');
 
@@ -296,9 +293,6 @@ void main() {
       // Mock NostrService's publishEvent only - other methods are now static in NostrUtils
       when(mockNostrService.publishEvent(any))
           .thenAnswer((_) async => Future<void>.value());
-
-      when(mockNostrService.publishEvent(any))
-          .thenAnswer((_) async => Future.value());
 
       // Act
       await mostroService.takeSellOrder(orderId, 300, 'lnbc91011invoice');

--- a/test/services/mostro_service_test.dart
+++ b/test/services/mostro_service_test.dart
@@ -17,6 +17,9 @@ import 'package:mostro_mobile/data/repositories/mostro_storage.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/data/models/next_trade.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
 
 import '../mocks.dart';
 import '../mocks.mocks.dart';
@@ -37,13 +40,13 @@ void main() {
 
   // Add dummy for NostrService
   provideDummy<NostrService>(MockNostrService());
-  
+
   // Create dummy values for Mockito
   final dummyRef = MockRef();
   final dummyKeyManager = MockKeyManager();
   final dummySessionStorage = MockSessionStorage();
   final dummySettings = MockSettings();
-  
+
   // Stub listen on dummyRef to prevent errors when creating MockSubscriptionManager
   when(dummyRef.listen<List<Session>>(
     any,
@@ -51,13 +54,12 @@ void main() {
     onError: anyNamed('onError'),
     fireImmediately: anyNamed('fireImmediately'),
   )).thenReturn(MockProviderSubscription<List<Session>>());
-  
+
   // Create and provide dummy values
   final dummySessionNotifier = MockSessionNotifier(
-    dummyRef, dummyKeyManager, dummySessionStorage, dummySettings
-  );
+      dummyRef, dummyKeyManager, dummySessionStorage, dummySettings);
   provideDummy<SessionNotifier>(dummySessionNotifier);
-  
+
   // Provide dummy for SubscriptionManager
   final dummySubscriptionManagerForMockito = MockSubscriptionManager(dummyRef);
   provideDummy<SubscriptionManager>(dummySubscriptionManagerForMockito);
@@ -80,7 +82,7 @@ void main() {
     mockNostrService = MockNostrService();
     mockServerTradeIndex = MockServerTradeIndex();
     keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
-    
+
     // Setup all stubs before creating any objects that use them
     final testSettings = MockSettings();
     when(testSettings.mostroPublicKey).thenReturn(
@@ -88,7 +90,7 @@ void main() {
     when(mockRef.read(settingsProvider)).thenReturn(testSettings);
     when(mockRef.read(mostroStorageProvider)).thenReturn(MockMostroStorage());
     when(mockRef.read(nostrServiceProvider)).thenReturn(mockNostrService);
-    
+
     // Stub the listen method before creating SubscriptionManager
     when(mockRef.listen<List<Session>>(
       any,
@@ -96,7 +98,7 @@ void main() {
       onError: anyNamed('onError'),
       fireImmediately: anyNamed('fireImmediately'),
     )).thenReturn(MockProviderSubscription<List<Session>>());
-    
+
     // Create mockSessionNotifier
     mockSessionNotifier = MockSessionNotifier(
       mockRef,
@@ -104,12 +106,14 @@ void main() {
       mockSessionStorage,
       testSettings,
     );
-    when(mockRef.read(sessionNotifierProvider.notifier)).thenReturn(mockSessionNotifier);
-    
+    when(mockRef.read(sessionNotifierProvider.notifier))
+        .thenReturn(mockSessionNotifier);
+
     // Create mockSubscriptionManager with the stubbed mockRef
     mockSubscriptionManager = MockSubscriptionManager(mockRef);
-    when(mockRef.read(subscriptionManagerProvider)).thenReturn(mockSubscriptionManager);
-    
+    when(mockRef.read(subscriptionManagerProvider))
+        .thenReturn(mockSubscriptionManager);
+
     // Finally create the service under test
     mostroService = MostroService(mockRef);
   });
@@ -385,6 +389,87 @@ void main() {
 
       expect(isValid, isTrue,
           reason: 'Server should accept valid messages in full privacy mode');
+    });
+
+    test('Range order detection logic works correctly', () {
+      // Test different order configurations
+      final testCases = [
+        {
+          'min': 50,
+          'max': 150,
+          'expectedRange': true,
+          'description': 'Valid range order (min != max)'
+        },
+        {
+          'min': 100,
+          'max': 100,
+          'expectedRange': false,
+          'description': 'Regular order (min == max)'
+        },
+        {
+          'min': 200,
+          'max': 100,
+          'expectedRange': false,
+          'description': 'Invalid range (min > max)'
+        },
+        {
+          'min': null,
+          'max': null,
+          'expectedRange': false,
+          'description': 'No range specified'
+        },
+        {
+          'min': 50,
+          'max': null,
+          'expectedRange': false,
+          'description': 'Only min specified'
+        },
+        {
+          'min': null,
+          'max': 150,
+          'expectedRange': false,
+          'description': 'Only max specified'
+        },
+      ];
+
+      for (final testCase in testCases) {
+        final minAmount = testCase['min'] as int?;
+        final maxAmount = testCase['max'] as int?;
+        final expectedRange = testCase['expectedRange'] as bool;
+        final description = testCase['description'] as String;
+
+        // Simulate the range order detection logic from MostroService
+        final isRangeOrder = minAmount != null &&
+            maxAmount != null &&
+            minAmount != maxAmount &&
+            minAmount < maxAmount; // Ensure min < max for valid range
+
+        expect(isRangeOrder, equals(expectedRange), reason: description);
+      }
+    });
+
+    test('Child order recognition works correctly', () {
+      // This test verifies that the app can recognize child orders from range order releases
+      // The actual implementation would check if a new order uses trade keys from existing sessions
+
+      // Simulate a scenario where a user has a session with a specific trade key
+      const userTradeKey =
+          '2d81b5ebf364dc496fba15888bc32c4343cd9c65643b513063e0dafe6d52f4c3';
+
+      // Simulate a child order that uses the same trade key
+      final childOrderPayload = {
+        'buyer_trade_pubkey': userTradeKey,
+        'seller_trade_pubkey': 'different_key_for_seller',
+      };
+
+      // The app should recognize this as a child order belonging to the current user
+      final isChildOrder =
+          childOrderPayload['buyer_trade_pubkey'] == userTradeKey ||
+              childOrderPayload['seller_trade_pubkey'] == userTradeKey;
+
+      expect(isChildOrder, isTrue,
+          reason:
+              'Child order should be recognized when it uses user\'s trade key');
     });
   });
 }


### PR DESCRIPTION
Reference: https://mostro.network/protocol/release.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Range orders now include next-trade payloads when released; key/index progression is automated via a new key-index helper.

- **Bug Fixes**
  - Improved handling of public events and timeouts to reduce stuck or inconsistent order states; added stricter parsing/validation for incoming trade payloads.

- **Refactor**
  - Enhanced event processing, concurrency guards, and notification flows for more reliable state updates.

- **Tests**
  - Expanded tests and mocks for range-order flows, trade-index validation, signature verification, and privacy scenarios.

- **Chores**
  - Android minSdk now derived from Flutter config to satisfy secure storage requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->