### PR TITLE
fix: cleanup session for pending_order_exists cant-do responses

### DIFF
--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -307,6 +307,11 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
             ref.read(sessionNotifierProvider.notifier).cleanupRequestSession(event.requestId!);
           }
         }
+        
+        // Cleanup for order taking failures - delete session by orderId
+        if (cantDo?.cantDoReason == CantDoReason.pendingOrderExists) {
+          ref.read(sessionNotifierProvider.notifier).deleteSession(orderId);
+        }
         // Temp Notification 
         sendNotification(event.action, values: {
           'action': cantDo?.cantDoReason.toString(),


### PR DESCRIPTION
fix #248 
 - Add specific session cleanup for order taking failures
  - When cant-do reason is pending_order_exists, delete session by orderId
  - Prevents phantom orders from appearing in "My Trades" after failed order attempts
  - Separates cleanup logic: requestId for order creation, orderId for order taking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded automatic cleanup to cover cases where a conflicting pending order exists, reducing stuck sessions and duplicate prompts.
  * Enhances overall reliability during order validation by clearing invalid or conflicting sessions sooner, minimizing confusing errors and improving flow continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->