### PR TITLE
fix message structure before sending it

### DIFF
--- a/lib/data/models/order.dart
+++ b/lib/data/models/order.dart
@@ -64,9 +64,7 @@ class Order implements Payload {
     if (buyerInvoice != null) data[type]['buyer_invoice'] = buyerInvoice;
 
     data[type]['created_at'] = createdAt;
-    if (expiresAt != null) {
-      data[type]['expires_at'] = expiresAt;
-    }
+    data[type]['expires_at'] = expiresAt;
 
     if (buyerTradePubkey != null) {
       data[type]['buyer_trade_pubkey'] = buyerTradePubkey;


### PR DESCRIPTION
mostrod expect a message with expires_at: null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Order payloads now always include the expiration field in JSON responses, even when unset (null). This ensures a consistent schema across responses, reduces client-side edge cases, and prevents errors from missing fields in integrations and analytics.
  * No changes to other fields or public interfaces; no breaking API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->