### PR TITLE
Add Malawi Kwacha fiat currency

### DIFF
--- a/assets/data/fiat.json
+++ b/assets/data/fiat.json
@@ -852,6 +852,17 @@
     "price": true,
     "locale": "es-MX"
   },
+  "MWK": {
+    "symbol": "K",
+    "name": "Malawian Kwacha",
+    "symbol_native": "K",
+    "decimal_digits": 2,
+    "rounding": 0,
+    "code": "MWK",
+    "emoji": "🇲🇼",
+    "name_plural": "Malawian kwachas",
+    "price": true
+  },
   "MYR": {
     "symbol": "RM",
     "name": "Malaysian Ringgit",

--- a/assets/data/fiat.json
+++ b/assets/data/fiat.json
@@ -840,6 +840,17 @@
     "emoji": "",
     "name_plural": "Mauritian rupees"
   },
+  "MWK": {
+    "symbol": "K",
+    "name": "Malawian Kwacha",
+    "symbol_native": "K",
+    "decimal_digits": 2,
+    "rounding": 0,
+    "code": "MWK",
+    "emoji": "🇲🇼",
+    "name_plural": "Malawian kwachas",
+    "price": true
+  },
   "MXN": {
     "symbol": "MX$",
     "name": "Peso mexicano",
@@ -851,17 +862,6 @@
     "name_plural": "Pesos",
     "price": true,
     "locale": "es-MX"
-  },
-  "MWK": {
-    "symbol": "K",
-    "name": "Malawian Kwacha",
-    "symbol_native": "K",
-    "decimal_digits": 2,
-    "rounding": 0,
-    "code": "MWK",
-    "emoji": "🇲🇼",
-    "name_plural": "Malawian kwachas",
-    "price": true
   },
   "MYR": {
     "symbol": "RM",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Malawian Kwacha (MWK) across currency pickers and lists, including symbol (K), native symbol, pluralization, and flag emoji.
  - Enabled selection, pricing, and two-decimal formatting for MWK in conversions and price displays.
  - No other currencies were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->