### PR TITLE
refactor: centralize key derivation path config

### DIFF
--- a/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
+++ b/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
@@ -32,9 +32,13 @@ All keys in the system follow the derivation path: **`m/44'/1237'/38383'/0/N`**
 - `0` - External chain (hardcoded)
 - `N` - Key index (0 for identity, 1+ for trades)
 
-This path is defined in the `KeyDerivator` constructor (`lib/features/key_manager/key_manager_provider.dart:13`):
+This path is defined in the `Config` class (`lib/core/config.dart`) and used in the `KeyDerivator` constructor (`lib/features/key_manager/key_manager_provider.dart:14`):
 ```dart
-final keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
+// In Config class
+static const String keyDerivationPath = "m/44'/1237'/38383'/0";
+
+// In key_manager_provider.dart
+final keyDerivator = KeyDerivator(Config.keyDerivationPath);
 ```
 
 ## Identity Key System

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -17,8 +17,6 @@ class Config {
   static const String dBName = 'mostro.db';
   static const String dBPassword = 'mostro';
 
-
-
   // Timeout for relay connections
 
   static const Duration nostrConnectionTimeout = Duration(seconds: 30);
@@ -31,12 +29,13 @@ class Config {
   // Mostro version
   static int mostroVersion = 1;
 
+  // Key derivation configuration
+  static const String keyDerivationPath = "m/44'/1237'/38383'/0";
+
   static const int expirationSeconds = 900;
   static const int expirationHours = 24;
   static const int cleanupIntervalMinutes = 30;
   static const int sessionExpirationHours = 36;
-  
-
 
   // Notification configuration
 

--- a/lib/features/key_manager/key_manager_provider.dart
+++ b/lib/features/key_manager/key_manager_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/features/key_manager/key_derivator.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager.dart';
 import 'package:mostro_mobile/features/key_manager/key_storage.dart';
@@ -10,6 +11,6 @@ final keyManagerProvider = Provider<KeyManager>((ref) {
 
   final keyStorage =
       KeyStorage(secureStorage: secureStorage, sharedPrefs: sharedPrefs);
-  final keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
+  final keyDerivator = KeyDerivator(Config.keyDerivationPath);
   return KeyManager(keyStorage, keyDerivator);
 });

--- a/test/services/mostro_service_test.dart
+++ b/test/services/mostro_service_test.dart
@@ -97,7 +97,7 @@ void main() {
     mockSessionStorage = MockSessionStorage();
     mockNostrService = MockNostrService();
     mockServerTradeIndex = MockServerTradeIndex();
-    keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
+    keyDerivator = KeyDerivator(Config.keyDerivationPath);
 
     // Stub mockKeyManager.getNextKeyIndex() to return deterministic value
     when(mockKeyManager.getNextKeyIndex()).thenAnswer((_) async => 5);


### PR DESCRIPTION
- Add keyDerivationPath constant to Config class for single source of truth
- Update KeyManagerProvider to use Config.keyDerivationPath instead of hardcoded value
- Update mostro_service_test.dart to use centralized configuration
- Update documentation to reflect new centralized approach
- Remove hardcoded derivation path duplication across codebase

This change improves maintainability by ensuring the derivation path is defined in one place, reducing the risk of inconsistencies and making future updates easier to manage.

Fixes: Hardcoded derivation path "m/44'/1237'/38383'/0" was duplicated in multiple files (key_manager_provider.dart, mostro_service_test.dart)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Refactor
  - Centralized the key derivation path in app configuration for consistent usage across the app.
  - Updated key management to consume the centralized setting, reducing hard-coded values.
- Tests
  - Adjusted tests to use the configuration-based key derivation path for consistency.
- Documentation
  - Updated architecture documentation to reflect the new configuration approach for session and key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->