### PR TITLE
Feat/dispute listing

### DIFF
--- a/lib/data/models/dispute.dart
+++ b/lib/data/models/dispute.dart
@@ -6,6 +6,7 @@ import 'package:mostro_mobile/data/models/order.dart';
 enum DisputeDescriptionKey {
   initiatedByUser,      // You opened this dispute
   initiatedByPeer,      // A dispute was opened against you
+  initiatedPendingAdmin,// Dispute initiated, waiting for admin assignment
   inProgress,           // Dispute is being reviewed by an admin
   resolved,             // Dispute has been resolved
   sellerRefunded,       // Dispute resolved - seller refunded
@@ -375,8 +376,8 @@ class DisputeData {
 
     return DisputeData(
       disputeId: dispute.disputeId,
-      orderId: dispute.orderId, // No fallback to hardcoded string
-      status: dispute.status ?? 'unknown',
+      orderId: dispute.orderId ?? (orderState?.order?.id), // Use order from orderState if dispute.orderId is null
+      status: dispute.status ?? 'initiated',
       descriptionKey: descriptionKey,
       counterparty: counterpartyName,
       isCreator: isUserCreator,
@@ -428,10 +429,10 @@ class DisputeData {
     switch (status.toLowerCase()) {
       case 'initiated':
         if (isUserCreator == null) {
-          return DisputeDescriptionKey.unknown; // Unknown creator state
+          return DisputeDescriptionKey.initiatedPendingAdmin; // Waiting for admin assignment
         }
-        return isUserCreator 
-          ? DisputeDescriptionKey.initiatedByUser 
+        return isUserCreator
+          ? DisputeDescriptionKey.initiatedByUser
           : DisputeDescriptionKey.initiatedByPeer;
       case 'in-progress':
         return DisputeDescriptionKey.inProgress;
@@ -452,6 +453,8 @@ class DisputeData {
         return 'You opened this dispute';
       case DisputeDescriptionKey.initiatedByPeer:
         return 'A dispute was opened against you';
+      case DisputeDescriptionKey.initiatedPendingAdmin:
+        return 'Waiting for admin assignment';
       case DisputeDescriptionKey.inProgress:
         return 'Dispute is being reviewed by an admin';
       case DisputeDescriptionKey.resolved:

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logger/logger.dart';
@@ -6,6 +7,9 @@ import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/services/nostr_service.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 /// Repository for managing dispute creation
 class DisputeRepository {
@@ -33,26 +37,47 @@ class DisputeRepository {
         return false;
       }
 
-      // Validate trade key is present
-      if (session.tradeKey.private.isEmpty) {
-        _logger.e('Trade key is empty for order: $orderId, cannot create dispute');
+      final privateKey = session.tradeKey.private;
+      if (privateKey.isEmpty) {
+        _logger.e('Session trade key private key is empty for order: $orderId');
         return false;
       }
 
-      // Create dispute message using Gift Wrap protocol (NIP-59)
-      final disputeMessage = MostroMessage(
-        action: Action.dispute,
-        id: orderId,
+      // Create dispute message according to Mostro protocol
+      final disputeMessage = [
+        {
+          'order': {
+            'version': 1,
+            'id': orderId,
+            'action': 'dispute',
+            'payload': null,
+          }
+        },
+        null // Signature placeholder
+      ];
+
+      // Convert the dispute message to JSON string
+      final messageJson = jsonEncode(disputeMessage);
+      
+      // Encrypt the message using NIP-44 encryption
+      final encryptedContent = await NostrUtils.encryptNIP44(
+        messageJson,
+        privateKey,
+        _mostroPubkey
       );
 
-      // Wrap message using Gift Wrap protocol (NIP-59)
-      final event = await disputeMessage.wrap(
-        tradeKey: session.tradeKey,
-        recipientPubKey: _mostroPubkey,
+      // Create and sign the Nostr event using NostrUtils with encrypted content
+      final signedEvent = NostrUtils.createEvent(
+        kind: 4, // Direct message kind
+        content: encryptedContent,
+        privateKey: privateKey,
+        tags: [
+          ['p', _mostroPubkey], // Send to Mostro
+        ],
       );
 
-      // Send the wrapped event to Mostro
-      await _nostrService.publishEvent(event);
+      // Send the encrypted event to Mostro
+      await _nostrService.publishEvent(signedEvent);
 
       _logger.d('Successfully sent dispute creation for order: $orderId');
       return true;

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -11,6 +11,7 @@ import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 >>>>>>> 4dfe38ce (refactor: simplify dispute creation using MostroMessage wrapper and NIP-17 protocol)
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 
 /// Repository for managing dispute creation
 class DisputeRepository {
@@ -68,39 +69,57 @@ class DisputeRepository {
   }
 
   Future<List<Dispute>> getUserDisputes() async {
-    // Mock implementation for UI testing
-    await Future.delayed(const Duration(milliseconds: 500));
-    
-    return [
-      Dispute(
-        disputeId: 'dispute_001',
-        orderId: 'order_001',
-        status: 'initiated',
-        createdAt: DateTime.now().subtract(const Duration(hours: 1)),
-        action: 'dispute-initiated-by-you',
-      ),
-      Dispute(
-        disputeId: 'dispute_002',
-        orderId: 'order_002',
-        status: 'in-progress',
-        createdAt: DateTime.now().subtract(const Duration(days: 1)),
-        action: 'dispute-initiated-by-peer',
-        adminPubkey: 'admin_123',
-      ),
-    ];
+    try {
+      _logger.d('Getting user disputes from sessions');
+
+      // Get all user sessions and check their order states for disputes
+      final sessions = _ref.read(sessionNotifierProvider);
+      final disputes = <Dispute>[];
+
+      for (final session in sessions) {
+        if (session.orderId != null) {
+          try {
+            // Get the order state for this session
+            final orderState = _ref.read(orderNotifierProvider(session.orderId!));
+            
+            if (orderState.dispute != null) {
+              disputes.add(orderState.dispute!);
+            }
+          } catch (e) {
+            _logger.w('Failed to get order state for order ${session.orderId}: $e');
+          }
+        }
+      }
+
+      _logger.d('Found ${disputes.length} disputes from sessions');
+      return disputes;
+    } catch (e) {
+      _logger.e('Failed to get user disputes: $e');
+      return [];
+    }
   }
 
   Future<Dispute?> getDispute(String disputeId) async {
-    // Mock implementation
-    await Future.delayed(const Duration(milliseconds: 300));
-    
-    return Dispute(
-      disputeId: disputeId,
-      orderId: 'order_${disputeId.substring(0, 8)}',
-      status: 'initiated',
-      createdAt: DateTime.now().subtract(const Duration(hours: 2)),
-      action: 'dispute-initiated-by-you',
-    );
+    try {
+      _logger.d('Getting dispute by ID: $disputeId');
+      
+      // Get all user disputes and find the one with matching ID
+      final disputes = await getUserDisputes();
+      final dispute = disputes.firstWhereOrNull(
+        (d) => d.disputeId == disputeId,
+      );
+      
+      if (dispute != null) {
+        _logger.d('Found dispute with ID: $disputeId');
+      } else {
+        _logger.w('No dispute found with ID: $disputeId');
+      }
+      
+      return dispute;
+    } catch (e) {
+      _logger.e('Failed to get dispute by ID $disputeId: $e');
+      return null;
+    }
   }
 
   Future<void> sendDisputeMessage(String disputeId, String message) async {

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -4,11 +4,6 @@ import 'package:logger/logger.dart';
 import 'package:mostro_mobile/data/models/dispute.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
-<<<<<<< HEAD
-import 'package:mostro_mobile/services/nostr_service.dart';
-import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
-=======
->>>>>>> 4dfe38ce (refactor: simplify dispute creation using MostroMessage wrapper and NIP-17 protocol)
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -1,15 +1,16 @@
-import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logger/logger.dart';
 import 'package:mostro_mobile/data/models/dispute.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
+<<<<<<< HEAD
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+=======
+>>>>>>> 4dfe38ce (refactor: simplify dispute creation using MostroMessage wrapper and NIP-17 protocol)
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
-import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 /// Repository for managing dispute creation
 class DisputeRepository {
@@ -37,47 +38,20 @@ class DisputeRepository {
         return false;
       }
 
-      final privateKey = session.tradeKey.private;
-      if (privateKey.isEmpty) {
-        _logger.e('Session trade key private key is empty for order: $orderId');
-        return false;
-      }
-
-      // Create dispute message according to Mostro protocol
-      final disputeMessage = [
-        {
-          'order': {
-            'version': 1,
-            'id': orderId,
-            'action': 'dispute',
-            'payload': null,
-          }
-        },
-        null // Signature placeholder
-      ];
-
-      // Convert the dispute message to JSON string
-      final messageJson = jsonEncode(disputeMessage);
-      
-      // Encrypt the message using NIP-44 encryption
-      final encryptedContent = await NostrUtils.encryptNIP44(
-        messageJson,
-        privateKey,
-        _mostroPubkey
+      // Create dispute message using Gift Wrap protocol (NIP-17)
+      final disputeMessage = MostroMessage(
+        action: Action.dispute,
+        id: orderId,
       );
 
-      // Create and sign the Nostr event using NostrUtils with encrypted content
-      final signedEvent = NostrUtils.createEvent(
-        kind: 4, // Direct message kind
-        content: encryptedContent,
-        privateKey: privateKey,
-        tags: [
-          ['p', _mostroPubkey], // Send to Mostro
-        ],
+      // Wrap message using NIP-17 Gift Wrap protocol
+      final event = await disputeMessage.wrap(
+        tradeKey: session.tradeKey,
+        recipientPubKey: _mostroPubkey,
       );
 
-      // Send the encrypted event to Mostro
-      await _nostrService.publishEvent(signedEvent);
+      // Send the wrapped event to Mostro
+      await _nostrService.publishEvent(event);
 
       _logger.d('Successfully sent dispute creation for order: $orderId');
       return true;

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -38,13 +38,13 @@ class DisputeRepository {
         return false;
       }
 
-      // Create dispute message using Gift Wrap protocol (NIP-17)
+      // Create dispute message using Gift Wrap protocol (NIP-59)
       final disputeMessage = MostroMessage(
         action: Action.dispute,
         id: orderId,
       );
 
-      // Wrap message using NIP-17 Gift Wrap protocol
+      // Wrap message using NIP-59 Gift Wrap protocol
       final event = await disputeMessage.wrap(
         tradeKey: session.tradeKey,
         recipientPubKey: _mostroPubkey,

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -38,13 +38,19 @@ class DisputeRepository {
         return false;
       }
 
+      // Validate trade key is present
+      if (session.tradeKey.private.isEmpty) {
+        _logger.e('Trade key is empty for order: $orderId, cannot create dispute');
+        return false;
+      }
+
       // Create dispute message using Gift Wrap protocol (NIP-59)
       final disputeMessage = MostroMessage(
         action: Action.dispute,
         id: orderId,
       );
 
-      // Wrap message using NIP-59 Gift Wrap protocol
+      // Wrap message using Gift Wrap protocol (NIP-59)
       final event = await disputeMessage.wrap(
         tradeKey: session.tradeKey,
         recipientPubKey: _mostroPubkey,

--- a/lib/features/chat/screens/chat_rooms_list.dart
+++ b/lib/features/chat/screens/chat_rooms_list.dart
@@ -1,5 +1,6 @@
 // NostrEvent is now accessed through ChatRoom model
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
@@ -51,8 +52,43 @@ class ChatRoomsScreen extends ConsumerWidget {
                     ),
                   ),
                 ),
-                // Tab bar
-                ChatTabs(currentTab: currentTab),
+                // Tab bar - only show disputes tab in debug mode
+                if (kDebugMode)
+                  ChatTabs(currentTab: currentTab)
+                else
+                  // In release mode, just show Messages tab header
+                  Container(
+                    decoration: BoxDecoration(
+                      color: AppTheme.backgroundDark,
+                      border: Border(
+                        bottom: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.1),
+                          width: 1.0,
+                        ),
+                      ),
+                    ),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      decoration: BoxDecoration(
+                        border: Border(
+                          bottom: BorderSide(
+                            color: AppTheme.mostroGreen,
+                            width: 3.0,
+                          ),
+                        ),
+                      ),
+                      child: Text(
+                        S.of(context)!.messages,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: AppTheme.mostroGreen,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 15,
+                          letterSpacing: 0.5,
+                        ),
+                      ),
+                    ),
+                  ),
                 // Description text
                 Container(
                   width: double.infinity,
@@ -66,7 +102,9 @@ class ChatRoomsScreen extends ConsumerWidget {
                     ),
                   ),
                   child: Text(
-                    _getTabDescription(context, currentTab),
+                    kDebugMode ? _getTabDescription(context, currentTab) :
+                      S.of(context)?.conversationsDescription ??
+                      'Here you\'ll find your conversations with other users during trades.',
                     style: TextStyle(
                       color: AppTheme.textSecondary,
                       fontSize: 14,
@@ -75,25 +113,30 @@ class ChatRoomsScreen extends ConsumerWidget {
                 ),
                 // Content area with gesture detection
                 Expanded(
-                  child: GestureDetector(
-                    onHorizontalDragEnd: (details) {
-                      if (details.primaryVelocity != null &&
-                          details.primaryVelocity! < 0) {
-                        // Swipe left - go to disputes
-                        ref.read(chatTabProvider.notifier).state = ChatTabType.disputes;
-                      } else if (details.primaryVelocity != null &&
-                          details.primaryVelocity! > 0) {
-                        // Swipe right - go to messages
-                        ref.read(chatTabProvider.notifier).state = ChatTabType.messages;
-                      }
-                    },
-                    child: Container(
-                      color: AppTheme.backgroundDark,
-                      child: currentTab == ChatTabType.messages
-                          ? _buildBody(context, ref)
-                          : const DisputesList(),
-                    ),
-                  ),
+                  child: kDebugMode
+                      ? GestureDetector(
+                          onHorizontalDragEnd: (details) {
+                            if (details.primaryVelocity != null &&
+                                details.primaryVelocity! < 0) {
+                              // Swipe left - go to disputes
+                              ref.read(chatTabProvider.notifier).state = ChatTabType.disputes;
+                            } else if (details.primaryVelocity != null &&
+                                details.primaryVelocity! > 0) {
+                              // Swipe right - go to messages
+                              ref.read(chatTabProvider.notifier).state = ChatTabType.messages;
+                            }
+                          },
+                          child: Container(
+                            color: AppTheme.backgroundDark,
+                            child: currentTab == ChatTabType.messages
+                                ? _buildBody(context, ref)
+                                : const DisputesList(),
+                          ),
+                        )
+                      : Container(
+                          color: AppTheme.backgroundDark,
+                          child: _buildBody(context, ref),
+                        ),
                 ),
                 // Add bottom padding to prevent content from being covered by BottomNavBar
                 SizedBox(

--- a/lib/features/disputes/widgets/dispute_status_content.dart
+++ b/lib/features/disputes/widgets/dispute_status_content.dart
@@ -124,6 +124,8 @@ class DisputeStatusContent extends StatelessWidget {
         return S.of(context)!.disputeOpenedByYou(dispute.counterpartyDisplay);
       case DisputeDescriptionKey.initiatedByPeer:
         return S.of(context)!.disputeOpenedAgainstYou(dispute.counterpartyDisplay);
+      case DisputeDescriptionKey.initiatedPendingAdmin:
+        return S.of(context)!.disputeWaitingForAdmin;
       case DisputeDescriptionKey.inProgress:
         // Use status text with a descriptive message
         return "${S.of(context)!.disputeStatusInProgress}: ${dispute.description}";

--- a/lib/features/disputes/widgets/disputes_list.dart
+++ b/lib/features/disputes/widgets/disputes_list.dart
@@ -1,94 +1,90 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/features/disputes/widgets/dispute_list_item.dart';
-import 'package:mostro_mobile/data/models/dispute.dart';
+import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
-class DisputesList extends StatelessWidget {
+class DisputesList extends ConsumerWidget {
   const DisputesList({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    // Only show hardcoded mock disputes in debug mode
-    final mockDisputes = kDebugMode ? [
-      DisputeData(
-        disputeId: 'dispute_001',
-        orderId: 'order_abc123',
-        status: 'initiated',
-        descriptionKey: DisputeDescriptionKey.initiatedByUser,
-        counterparty: 'user_456',
-        isCreator: true,
-        createdAt: DateTime.now().subtract(const Duration(hours: 2)),
-        userRole: UserRole.buyer,
-      ),
-      DisputeData(
-        disputeId: 'dispute_002', 
-        orderId: 'order_def456',
-        status: 'in-progress',
-        descriptionKey: DisputeDescriptionKey.inProgress,
-        counterparty: 'admin_789',
-        isCreator: false,
-        createdAt: DateTime.now().subtract(const Duration(days: 1)),
-        userRole: UserRole.seller,
-      ),
-      DisputeData(
-        disputeId: 'dispute_003',
-        orderId: 'order_ghi789',
-        status: 'resolved',
-        descriptionKey: DisputeDescriptionKey.resolved,
-        counterparty: 'user_123',
-        isCreator: null, // Unknown creator state for resolved dispute
-        createdAt: DateTime.now().subtract(const Duration(days: 3)),
-        userRole: UserRole.buyer,
-      ),
-    ] : <DisputeData>[];
+  Widget build(BuildContext context, WidgetRef ref) {
+    final disputesAsync = ref.watch(userDisputeDataProvider);
 
-    if (mockDisputes.isEmpty) {
-      return Center(
+    return disputesAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stackTrace) => Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(
-              Icons.gavel,
+              Icons.error_outline,
               size: 64,
               color: AppTheme.textSecondary,
             ),
             const SizedBox(height: 16),
             Text(
-              kDebugMode ? S.of(context)!.noDisputesAvailable : S.of(context)!.disputesNotAvailable,
+              S.of(context)!.failedLoadDisputes,
               style: TextStyle(
                 color: AppTheme.textSecondary,
                 fontSize: 16,
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              kDebugMode 
-                ? S.of(context)!.disputesWillAppear
-                : S.of(context)!.disputesComingSoon,
-              style: TextStyle(
-                color: AppTheme.textSecondary,
-                fontSize: 14,
-              ),
-              textAlign: TextAlign.center,
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => ref.refresh(userDisputeDataProvider),
+              child: Text(S.of(context)!.retry),
             ),
           ],
         ),
-      );
-    }
+      ),
+      data: (disputes) {
+        if (disputes.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.gavel,
+                  size: 64,
+                  color: AppTheme.textSecondary,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  S.of(context)!.noDisputesAvailable,
+                  style: TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  S.of(context)!.disputesWillAppear,
+                  style: TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 14,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          );
+        }
 
-    return ListView.builder(
-      padding: const EdgeInsets.all(16),
-      itemCount: mockDisputes.length,
-      itemBuilder: (context, index) {
-        final disputeData = mockDisputes[index];
-        
-        return DisputeListItem(
-          dispute: disputeData,
-          onTap: () {
-            context.push('/dispute_details/${disputeData.disputeId}');
+        return ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: disputes.length,
+          itemBuilder: (context, index) {
+            final disputeData = disputes[index];
+            
+            return DisputeListItem(
+              dispute: disputeData,
+              onTap: () {
+                context.push('/dispute_details/${disputeData.disputeId}');
+              },
+            );
           },
         );
       },

--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -278,6 +278,13 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
           logger.e('disputeInitiatedByYou: Missing Dispute payload for event ${event.id} with action ${event.action}');
           return;
         }
+
+        // Ensure dispute has the orderId for proper association
+        final disputeWithOrderId = dispute.copyWith(orderId: orderId);
+
+        // Save dispute in state for listing
+        state = state.copyWith(dispute: disputeWithOrderId);
+
         sendNotification(event.action, values: {
           'dispute_id': dispute.disputeId,
         }, eventId: event.id);
@@ -289,6 +296,13 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
           logger.e('disputeInitiatedByPeer: Missing Dispute payload for event ${event.id} with action ${event.action}');
           return;
         }
+
+        // Ensure dispute has the orderId for proper association
+        final disputeWithOrderId = dispute.copyWith(orderId: orderId);
+
+        // Save dispute in state for listing
+        state = state.copyWith(dispute: disputeWithOrderId);
+
         sendNotification(event.action, values: {
           'dispute_id': dispute.disputeId,
         }, eventId: event.id);

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -24,7 +24,6 @@ import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/shared/providers/time_provider.dart';
 import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
-import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class TradeDetailScreen extends ConsumerWidget {

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -719,9 +719,6 @@ class TradeDetailScreen extends ConsumerWidget {
             final success = await repository.createDispute(orderId);
             
             if (success && context.mounted) {
-              // Also notify the order notifier
-              ref.read(orderNotifierProvider(orderId).notifier).disputeOrder();
-              
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text(S.of(context)!.disputeCreatedSuccessfully),

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -24,6 +24,7 @@ import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/shared/providers/time_provider.dart';
 import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
+import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class TradeDetailScreen extends ConsumerWidget {
@@ -718,6 +719,9 @@ class TradeDetailScreen extends ConsumerWidget {
             final success = await repository.createDispute(orderId);
             
             if (success && context.mounted) {
+              // Also notify the order notifier
+              ref.read(orderNotifierProvider(orderId).notifier).disputeOrder();
+              
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text(S.of(context)!.disputeCreatedSuccessfully),
@@ -736,7 +740,7 @@ class TradeDetailScreen extends ConsumerWidget {
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: Text(S.of(context)!.disputeCreationErrorWithMessage(e.toString())),
+                  content: Text(S.of(context)!.disputeCreationError(e.toString())),
                   backgroundColor: AppTheme.red1,
                 ),
               );

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -740,7 +740,7 @@ class TradeDetailScreen extends ConsumerWidget {
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: Text(S.of(context)!.disputeCreationError(e.toString())),
+                  content: Text(S.of(context)!.disputeCreationErrorWithMessage(e.toString())),
                   backgroundColor: AppTheme.red1,
                 ),
               );

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -293,21 +293,9 @@
   "disputeTradeDialogContent": "You are about to start a dispute with your counterparty. Do you want to continue?",
   "disputeCreatedSuccessfully": "Dispute created successfully",
   "disputeCreationFailed": "Failed to create dispute",
+  "disputeCreationError": "Error creating dispute",
   "disputeCreationErrorWithMessage": "Error creating dispute: {error}",
   "@disputeCreationErrorWithMessage": {
-<<<<<<< HEAD
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "disputeCreatedSuccessfully": "Dispute created successfully",
-  "disputeCreationFailed": "Failed to create dispute",
-  "disputeCreationError": "Error creating dispute: {error}",
-  "@disputeCreationError": {
-=======
->>>>>>> 4dfe38ce (refactor: simplify dispute creation using MostroMessage wrapper and NIP-17 protocol)
     "placeholders": {
       "error": {
         "type": "String"
@@ -719,6 +707,12 @@
       "counterparty": { "type": "String" }
     }
   },
+  "disputeWaitingForAdmin": "Waiting for admin assignment",
+  "disputeYouOpened": "You opened this dispute",
+  "disputeOpenedAgainstUser": "A dispute was opened against you",
+  "disputeInProgress": "Dispute is being reviewed by an admin",
+  "disputeResolved": "Dispute has been resolved",
+  "disputeSellerRefunded": "Dispute resolved - seller refunded",
   "disputeInstruction1": "Wait for a solver to take your dispute. Once they arrive, share any relevant evidence to help clarify the situation.",
   "disputeInstruction2": "The final decision will be made based on the evidence presented.",
   "disputeInstruction3": "If you don't respond, the system will assume you don't want to cooperate and you might lose the dispute.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -295,6 +295,7 @@
   "disputeCreationFailed": "Failed to create dispute",
   "disputeCreationErrorWithMessage": "Error creating dispute: {error}",
   "@disputeCreationErrorWithMessage": {
+<<<<<<< HEAD
     "placeholders": {
       "error": {
         "type": "String"
@@ -305,6 +306,8 @@
   "disputeCreationFailed": "Failed to create dispute",
   "disputeCreationError": "Error creating dispute: {error}",
   "@disputeCreationError": {
+=======
+>>>>>>> 4dfe38ce (refactor: simplify dispute creation using MostroMessage wrapper and NIP-17 protocol)
     "placeholders": {
       "error": {
         "type": "String"

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -301,6 +301,16 @@
       }
     }
   },
+  "disputeCreatedSuccessfully": "Dispute created successfully",
+  "disputeCreationFailed": "Failed to create dispute",
+  "disputeCreationError": "Error creating dispute: {error}",
+  "@disputeCreationError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "typeToAdd": "Type to add...",
   "noneSelected": "None selected",
   "fiatCurrencies": "Fiat currencies",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -610,8 +610,8 @@
   "disputeTradeDialogContent": "Estás a punto de iniciar una disputa con tu contraparte. ¿Deseas continuar?",
   "disputeCreatedSuccessfully": "Disputa creada exitosamente",
   "disputeCreationFailed": "Falló la creación de la disputa",
-  "disputeCreationErrorWithMessage": "Error al crear la disputa: {error}",
-  "@disputeCreationErrorWithMessage": {
+  "disputeCreationError": "Error al crear la disputa: {error}",
+  "@disputeCreationError": {
     "placeholders": {
       "error": {
         "type": "String"

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -610,8 +610,8 @@
   "disputeTradeDialogContent": "Estás a punto de iniciar una disputa con tu contraparte. ¿Deseas continuar?",
   "disputeCreatedSuccessfully": "Disputa creada exitosamente",
   "disputeCreationFailed": "Falló la creación de la disputa",
-  "disputeCreationError": "Error al crear la disputa: {error}",
-  "@disputeCreationError": {
+  "disputeCreationErrorWithMessage": "Error al crear la disputa: {error}",
+  "@disputeCreationErrorWithMessage": {
     "placeholders": {
       "error": {
         "type": "String"

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -610,6 +610,7 @@
   "disputeTradeDialogContent": "Estás a punto de iniciar una disputa con tu contraparte. ¿Deseas continuar?",
   "disputeCreatedSuccessfully": "Disputa creada exitosamente",
   "disputeCreationFailed": "Falló la creación de la disputa",
+  "disputeCreationError": "Error al crear la disputa",
   "disputeCreationErrorWithMessage": "Error al crear la disputa: {error}",
   "@disputeCreationErrorWithMessage": {
     "placeholders": {
@@ -712,6 +713,12 @@
       "counterparty": { "type": "String" }
     }
   },
+  "disputeWaitingForAdmin": "Esperando asignación de administrador",
+  "disputeYouOpened": "Tú abriste esta disputa",
+  "disputeOpenedAgainstUser": "Se abrió una disputa contra ti",
+  "disputeInProgress": "La disputa está siendo revisada por un administrador",
+  "disputeResolved": "La disputa ha sido resuelta",
+  "disputeSellerRefunded": "Disputa resuelta - vendedor reembolsado",
   "disputeInstruction1": "Espera a que un mediador tome tu disputa. Una vez que llegue, comparte cualquier evidencia relevante para ayudar a aclarar la situación.",
   "disputeInstruction2": "La decisión final se tomará en base a la evidencia presentada.",
   "disputeInstruction3": "Si no respondes, el sistema asumirá que no deseas cooperar y podrías perder la disputa.",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -675,8 +675,8 @@
   "disputeTradeDialogContent": "Stai per iniziare una disputa con la tua controparte. Vuoi continuare?",
   "disputeCreatedSuccessfully": "Disputa creata con successo",
   "disputeCreationFailed": "Creazione della disputa fallita",
-  "disputeCreationErrorWithMessage": "Errore nella creazione della disputa: {error}",
-  "@disputeCreationErrorWithMessage": {
+  "disputeCreationError": "Errore nella creazione della disputa: {error}",
+  "@disputeCreationError": {
     "placeholders": {
       "error": {
         "type": "String"

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -675,6 +675,7 @@
   "disputeTradeDialogContent": "Stai per iniziare una disputa con la tua controparte. Vuoi continuare?",
   "disputeCreatedSuccessfully": "Disputa creata con successo",
   "disputeCreationFailed": "Creazione della disputa fallita",
+  "disputeCreationError": "Errore nella creazione della disputa",
   "disputeCreationErrorWithMessage": "Errore nella creazione della disputa: {error}",
   "@disputeCreationErrorWithMessage": {
     "placeholders": {
@@ -766,6 +767,12 @@
       "counterparty": { "type": "String" }
     }
   },
+  "disputeWaitingForAdmin": "In attesa di assegnazione amministratore",
+  "disputeYouOpened": "Hai aperto questa disputa",
+  "disputeOpenedAgainstUser": "È stata aperta una disputa contro di te",
+  "disputeInProgress": "La disputa è in corso di revisione da un amministratore",
+  "disputeResolved": "La disputa è stata risolta",
+  "disputeSellerRefunded": "Disputa risolta - venditore rimborsato",
   "disputeInstruction1": "Attendi che un risolutore prenda in carico la tua disputa. Una volta arrivato, condividi qualsiasi prova rilevante per aiutare a chiarire la situazione.",
   "disputeInstruction2": "La decisione finale sarà presa sulla base delle prove presentate.",
   "disputeInstruction3": "Se non rispondi, il sistema presumerà che tu non voglia collaborare e potresti perdere la disputa.",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -675,8 +675,8 @@
   "disputeTradeDialogContent": "Stai per iniziare una disputa con la tua controparte. Vuoi continuare?",
   "disputeCreatedSuccessfully": "Disputa creata con successo",
   "disputeCreationFailed": "Creazione della disputa fallita",
-  "disputeCreationError": "Errore nella creazione della disputa: {error}",
-  "@disputeCreationError": {
+  "disputeCreationErrorWithMessage": "Errore nella creazione della disputa: {error}",
+  "@disputeCreationErrorWithMessage": {
     "placeholders": {
       "error": {
         "type": "String"

--- a/lib/services/dispute_service.dart
+++ b/lib/services/dispute_service.dart
@@ -28,19 +28,35 @@ class DisputeService {
         adminPubkey: 'admin_123',
       ),
     ];
+    // Mock implementation for UI testing
+    await Future.delayed(const Duration(milliseconds: 500));
+    
+    return [
+      Dispute(
+        disputeId: 'dispute_001',
+        orderId: 'order_001',
+        status: 'initiated',
+        createdAt: DateTime.now().subtract(const Duration(hours: 1)),
+        action: 'dispute-initiated-by-you',
+      ),
+      Dispute(
+        disputeId: 'dispute_002',
+        orderId: 'order_002',
+        status: 'in-progress',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        action: 'dispute-initiated-by-peer',
+        adminPubkey: 'admin_123',
+      ),
+    ];
   }
 
   Future<Dispute?> getDispute(String disputeId) async {
     // Mock implementation
     await Future.delayed(const Duration(milliseconds: 300));
     
-    // Safe prefix extraction to avoid RangeError
-    final prefixLen = min(8, disputeId.length);
-    final orderIdSuffix = disputeId.isEmpty ? 'unknown' : disputeId.substring(0, prefixLen);
-    
     return Dispute(
       disputeId: disputeId,
-      orderId: 'order_$orderIdSuffix',
+      orderId: 'order_${disputeId.substring(0, 8)}',
       status: 'initiated',
       createdAt: DateTime.now().subtract(const Duration(hours: 2)),
       action: 'dispute-initiated-by-you',
@@ -48,6 +64,8 @@ class DisputeService {
   }
 
   Future<void> sendDisputeMessage(String disputeId, String message) async {
+    // Mock implementation
+    await Future.delayed(const Duration(milliseconds: 200));
     // Mock implementation
     await Future.delayed(const Duration(milliseconds: 200));
   }

--- a/lib/services/dispute_service.dart
+++ b/lib/services/dispute_service.dart
@@ -28,26 +28,6 @@ class DisputeService {
         adminPubkey: 'admin_123',
       ),
     ];
-    // Mock implementation for UI testing
-    await Future.delayed(const Duration(milliseconds: 500));
-    
-    return [
-      Dispute(
-        disputeId: 'dispute_001',
-        orderId: 'order_001',
-        status: 'initiated',
-        createdAt: DateTime.now().subtract(const Duration(hours: 1)),
-        action: 'dispute-initiated-by-you',
-      ),
-      Dispute(
-        disputeId: 'dispute_002',
-        orderId: 'order_002',
-        status: 'in-progress',
-        createdAt: DateTime.now().subtract(const Duration(days: 1)),
-        action: 'dispute-initiated-by-peer',
-        adminPubkey: 'admin_123',
-      ),
-    ];
   }
 
   Future<Dispute?> getDispute(String disputeId) async {

--- a/lib/services/dispute_service.dart
+++ b/lib/services/dispute_service.dart
@@ -54,9 +54,13 @@ class DisputeService {
     // Mock implementation
     await Future.delayed(const Duration(milliseconds: 300));
     
+    // Safe prefix extraction to avoid RangeError
+    final prefixLen = min(8, disputeId.length);
+    final orderIdSuffix = disputeId.isEmpty ? 'unknown' : disputeId.substring(0, prefixLen);
+    
     return Dispute(
       disputeId: disputeId,
-      orderId: 'order_${disputeId.substring(0, 8)}',
+      orderId: 'order_$orderIdSuffix',
       status: 'initiated',
       createdAt: DateTime.now().subtract(const Duration(hours: 2)),
       action: 'dispute-initiated-by-you',


### PR DESCRIPTION
 This PR implements dispute listing functionality by connecting real data from Mostro dispute DMs to the existing UI components. When users create disputes, they now appear automatically in the debug-only "Disputes" tab with actual order information instead of mock data. Key improvements include: proper dispute-to-order association via orderId, enhanced DisputeData creation with OrderState context for displaying real order IDs and statuses, and improved provider logic to match disputes with their corresponding sessions.  The dispute list is currently visible only in debug mode to prevent exposure to end users until the complete dispute resolution system is ready.