### PR TITLE
Fix orphan sessions with timeout detection and cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,18 +113,18 @@ The app follows a specific initialization order in `appInitializerProvider`:
 
 ### Overview
 
-Comprehensive system that prevents orphan sessions and detects order timeouts through dual protection mechanisms: 30-second cleanup timers and real-time timeout detection via public events.
+Comprehensive system that prevents orphan sessions and detects order timeouts through dual protection mechanisms: 10-second cleanup timers and real-time timeout detection via public events.
 
 ### Orphan Session Prevention
 
-#### **30-Second Cleanup Timer**
+#### **10-Second Cleanup Timer**
 Automatic cleanup system that prevents sessions from becoming orphaned when Mostro instances are unresponsive:
 
 - **Activation**: Started automatically when users take orders (`takeSellOrder`, `takeBuyOrder`)
-- **Purpose**: Prevents orphan sessions when Mostro doesn't respond within 30 seconds
+- **Purpose**: Prevents orphan sessions when Mostro doesn't respond within 10 seconds
 - **Cleanup**: Deletes session, shows localized notification, navigates to order book
 - **Cancellation**: Timer automatically cancelled when any response received from Mostro
-- **Implementation**: `AbstractMostroNotifier.startSessionTimeoutCleanup()` in `abstract_mostro_notifier.dart:359-378`
+- **Implementation**: `AbstractMostroNotifier.startSessionTimeoutCleanup()` in `abstract_mostro_notifier.dart:286-305`
 
 #### **Localized User Feedback**
 ```
@@ -164,7 +164,7 @@ When orders are canceled (status changes to `canceled` in public events):
 - **Implementation**: `_checkTimeoutAndCleanup()` method in `order_notifier.dart:172-211`
 
 ### Key Implementation
-- **Dual Protection**: 30-second cleanup + real-time detection provide comprehensive coverage
+- **Dual Protection**: 10-second cleanup + real-time detection provide comprehensive coverage
 - **Race protection**: `_isProcessingTimeout` flag prevents concurrent execution (with proper early return handling)
 - **Role detection**: `_isCreatedByUser()` compares session role with order type
 - **Timer management**: Static timer storage with proper cleanup on disposal

--- a/docs/architecture/APP_INITIALIZATION_ANALYSIS.md
+++ b/docs/architecture/APP_INITIALIZATION_ANALYSIS.md
@@ -341,6 +341,12 @@ void _initializeExistingSessions() {
 - The implementation creates subscriptions for existing sessions manually during constructor execution
 - **Protected by regression test**: `test/features/subscriptions/subscription_manager_initialization_test.dart`
 
+**Why fireImmediately: false is Used**:
+- Prevents the listener from executing before SessionNotifier.init() completes
+- Ensures subscriptions are created with valid session data
+- Avoids creating subscriptions with empty session lists
+- Maintains proper initialization order dependencies
+
 **Historical Context**:
 - **Commit 63dc124e** set `fireImmediately: false` to fix relay switching issues where changing between Mostro instances would lose orders
 - This created a new bug where existing sessions wouldn't get subscriptions on app restart, causing orders to appear stuck in old states

--- a/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
+++ b/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
@@ -184,7 +184,46 @@ Sessions are persisted using `SessionStorage` (`lib/data/repositories/session_st
 
 - **Active Sessions**: Stored in memory (`SessionNotifier._sessions` map)
 - **Persistent Storage**: Serialized to Sembast for app restart recovery
-- **Cleanup**: Automatic cleanup of expired sessions (24 hours default)
+- **Cleanup**: Automatic cleanup of expired sessions (72 hours default)
+
+### Session Lifecycle and Cleanup
+
+#### **Orphan Session Prevention**
+When users take orders, a 30-second cleanup timer is automatically started to prevent orphan sessions:
+
+```dart
+// Automatically started when taking orders
+AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
+```
+
+**Purpose**: Prevents sessions from becoming orphaned when Mostro instances are unresponsive or offline.
+
+#### **Session Deletion**
+Sessions can be deleted through several mechanisms:
+
+1. **Automatic Cleanup**: 30-second timer when no response from Mostro
+2. **Timeout Detection**: Real-time detection via public events (taker scenarios)
+3. **Cancellation**: When orders are cancelled (pending/waiting states only)
+4. **Expiration**: Periodic cleanup of sessions older than 72 hours
+5. **Manual**: User-initiated session cleanup through settings
+
+#### **Session Cleanup Implementation**
+```dart
+// lib/shared/notifiers/session_notifier.dart:157-161
+Future<void> deleteSession(String sessionId) async {
+  _sessions.remove(sessionId);
+  await _storage.deleteSession(sessionId);
+  state = sessions; // Update state to trigger UI updates
+}
+```
+
+#### **Timer Management**
+The orphan session prevention system uses static timer storage for proper resource management:
+
+- **Timer Storage**: `Map<String, Timer> _sessionTimeouts`
+- **Automatic Cancellation**: Timers cancelled when Mostro responds
+- **Disposal Cleanup**: Timers cleaned up when notifiers are disposed
+- **Memory Safety**: Prevents timer-related memory leaks
 
 ## Order Creation Flow
 
@@ -837,6 +876,6 @@ This architecture ensures that user funds and privacy are protected while mainta
 
 ---
 
-*Last updated: December 2024*  
+*Last updated: September 15, 2025*  
 *Protocol version: 1.0*  
 *Key derivation path: m/44'/1237'/38383'/0/N*

--- a/docs/architecture/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
+++ b/docs/architecture/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
@@ -927,5 +927,141 @@ final session = ref.read(sessionNotifierProvider.notifier).getSessionByOrderId(o
 
 ---
 
-**Last Updated**: 2025-08-28 
+## Orphan Session Prevention System
+
+### Overview
+
+A 30-second timeout cleanup system that prevents orphan sessions when Mostro instances are unresponsive or offline. This system works alongside the real-time timeout detection to provide comprehensive session management.
+
+### Implementation
+
+#### **30-Second Cleanup Timer**
+
+When users take orders, a cleanup timer is automatically started to prevent sessions from becoming orphaned if Mostro doesn't respond:
+
+```dart
+// lib/features/order/notfiers/abstract_mostro_notifier.dart:359-378
+static void startSessionTimeoutCleanup(String orderId, Ref ref) {
+  // Cancel existing timer if any
+  _sessionTimeouts[orderId]?.cancel();
+  
+  _sessionTimeouts[orderId] = Timer(const Duration(seconds: 30), () {
+    try {
+      ref.read(sessionNotifierProvider.notifier).deleteSession(orderId);
+      Logger().i('Session cleaned up after 30s timeout: $orderId');
+      
+      // Show timeout message to user and navigate to order book
+      _showTimeoutNotificationAndNavigate(ref);
+    } catch (e) {
+      Logger().e('Failed to cleanup session: $orderId', error: e);
+    }
+    _sessionTimeouts.remove(orderId);
+  });
+  
+  Logger().i('Started 30s timeout timer for order: $orderId');
+}
+```
+
+#### **Timer Cancellation on Response**
+
+The cleanup timer is automatically cancelled when any response is received from Mostro:
+
+```dart
+// lib/features/order/notfiers/abstract_mostro_notifier.dart:86-90
+void handleEvent(MostroMessage event) {
+  // Cancel timer on ANY response from Mostro for this orderId
+  if (event.id != null) {
+    _cancelSessionTimeoutCleanup(event.id!);
+  }
+  // ... rest of event handling
+}
+```
+
+#### **Timer Integration in Order Taking**
+
+The cleanup timer is started automatically when users take orders:
+
+```dart
+// lib/features/order/notfiers/order_notifier.dart:107-108
+Future<void> takeSellOrder(String orderId, int? amount, String? lnAddress) async {
+  // ... session creation
+  
+  // Start 30s timeout cleanup timer for phantom session prevention
+  AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
+  
+  await mostroService.takeSellOrder(orderId, amount, lnAddress);
+}
+```
+
+### User Experience
+
+#### **Timeout Notification and Navigation**
+
+When the 30-second timer expires, users receive a localized notification and are automatically navigated back to the order book:
+
+```dart
+// lib/features/order/notfiers/abstract_mostro_notifier.dart:381-393
+static void _showTimeoutNotificationAndNavigate(Ref ref) {
+  try {
+    // Show snackbar with localized timeout message
+    final notificationNotifier = ref.read(notificationActionsProvider.notifier);
+    notificationNotifier.showCustomMessage('sessionTimeoutMessage');
+    
+    // Navigate to main order book screen (home)
+    final navProvider = ref.read(navigationProvider.notifier);
+    navProvider.go('/');
+  } catch (e) {
+    Logger().e('Failed to show timeout notification or navigate', error: e);
+  }
+}
+```
+
+#### **Localized Messages**
+
+The system includes localized timeout messages in all supported languages:
+
+```json
+// English
+"sessionTimeoutMessage": "No response received, check your connection and try again later"
+
+// Spanish  
+"sessionTimeoutMessage": "No hubo respuesta, verifica tu conexión e inténtalo más tarde"
+
+// Italian
+"sessionTimeoutMessage": "Nessuna risposta ricevuta, verifica la tua connessione e riprova più tardi"
+```
+
+### Integration with Real-Time Detection
+
+The orphan session prevention system works in conjunction with the real-time timeout detection:
+
+1. **Real-time detection**: Monitors public events for status changes and handles timeouts immediately when detected
+2. **30-second cleanup**: Acts as a fallback to prevent orphan sessions when Mostro is completely unresponsive
+3. **Dual protection**: Ensures sessions are cleaned up either through real-time detection or automatic timeout
+
+### Timer Management
+
+#### **Static Timer Storage**
+
+```dart
+// Timer storage for phantom session cleanup
+static final Map<String, Timer> _sessionTimeouts = {};
+```
+
+#### **Proper Cleanup on Disposal**
+
+```dart
+@override
+void dispose() {
+  subscription?.close();
+  // Cancel timer for this specific orderId if it exists
+  _sessionTimeouts[orderId]?.cancel();
+  _sessionTimeouts.remove(orderId);
+  super.dispose();
+}
+```
+
+This ensures that timers are properly cleaned up when notifiers are disposed to prevent memory leaks.
+
+**Last Updated**: September 15, 2025 
 

--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -92,10 +92,8 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
     }
     _processedEventIds.add(eventKey);
     
-    // Cancel timer on ANY response from Mostro for this orderId
-    if (event.id != null) {
-      _cancelSessionTimeoutCleanup(event.id!);
-    }
+    // Cancel timer on ANY response from Mostro for this order
+    _cancelSessionTimeoutCleanup(orderId);
     
     final navProvider = ref.read(navigationProvider.notifier);
 

--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -283,15 +283,15 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         : state.order!.kind == OrderType.sell;
   }
 
-  /// Starts a 30-second timer to cleanup orphan sessions if no response from Mostro
+  /// Starts a 10-second timer to cleanup orphan sessions if no response from Mostro
   static void startSessionTimeoutCleanup(String orderId, Ref ref) {
     // Cancel existing timer if any
     _sessionTimeouts[orderId]?.cancel();
     
-    _sessionTimeouts[orderId] = Timer(const Duration(seconds: 30), () {
+    _sessionTimeouts[orderId] = Timer(const Duration(seconds: 10), () {
       try {
         ref.read(sessionNotifierProvider.notifier).deleteSession(orderId);
-        Logger().i('Session cleaned up after 30s timeout: $orderId');
+        Logger().i('Session cleaned up after 10s timeout: $orderId');
         
         // Show timeout message to user and navigate to order book
         _showTimeoutNotificationAndNavigate(ref);
@@ -301,7 +301,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
       _sessionTimeouts.remove(orderId);
     });
     
-    Logger().i('Started 30s timeout timer for order: $orderId');
+    Logger().i('Started 10s timeout timer for order: $orderId');
   }
   
   /// Shows timeout notification and navigates to order book
@@ -325,7 +325,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
     if (timer != null) {
       timer.cancel();
       _sessionTimeouts.remove(orderId);
-      Logger().i('Cancelled timeout timer for order: $orderId - Mostro responded');
+      Logger().i('Cancelled 10s timeout timer for order: $orderId - Mostro responded');
     }
   }
 

--- a/lib/features/order/notfiers/order_notifier.dart
+++ b/lib/features/order/notfiers/order_notifier.dart
@@ -103,6 +103,10 @@ class OrderNotifier extends AbstractMostroNotifier {
       orderId: orderId,
       role: Role.buyer,
     );
+    
+    // Start 30s timeout cleanup timer for orphan session prevention
+    AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
+    
     await mostroService.takeSellOrder(
       orderId,
       amount,
@@ -116,6 +120,10 @@ class OrderNotifier extends AbstractMostroNotifier {
       orderId: orderId,
       role: Role.seller,
     );
+    
+    // Start 30s timeout cleanup timer for orphan session prevention
+    AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
+    
     await mostroService.takeBuyOrder(
       orderId,
       amount,
@@ -192,9 +200,9 @@ class OrderNotifier extends AbstractMostroNotifier {
           // Send cancellation notification using centralized function
           sendNotification(Action.canceled);
 
-          // Navigate to order book
+          // Navigate to main order book screen
           final navProvider = ref.read(navigationProvider.notifier);
-          navProvider.go('/order_book');
+          navProvider.go('/');
 
           return true; // Session was cleaned up
         } else {

--- a/lib/features/order/notfiers/order_notifier.dart
+++ b/lib/features/order/notfiers/order_notifier.dart
@@ -104,7 +104,7 @@ class OrderNotifier extends AbstractMostroNotifier {
       role: Role.buyer,
     );
     
-    // Start 30s timeout cleanup timer for orphan session prevention
+    // Start 10s timeout cleanup timer for orphan session prevention
     AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
     
     await mostroService.takeSellOrder(
@@ -121,7 +121,7 @@ class OrderNotifier extends AbstractMostroNotifier {
       role: Role.seller,
     );
     
-    // Start 30s timeout cleanup timer for orphan session prevention
+    // Start 10s timeout cleanup timer for orphan session prevention
     AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
     
     await mostroService.takeBuyOrder(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1105,5 +1105,8 @@
   "deleteUserRelayTitle": "Sure you want to disconnect from this relay?",
   "deleteUserRelayMessage": "If you want to use it again later, you'll need to add it manually.",
   "deleteUserRelayConfirm": "Yes",
-  "deleteUserRelayCancel": "No"
+  "deleteUserRelayCancel": "No",
+
+  "@_comment_session_timeout": "Session timeout message",
+  "sessionTimeoutMessage": "No response received, check your connection and try again later"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1083,6 +1083,9 @@
   "deleteUserRelayTitle": "¿Seguro que quieres desconectarte de este relay?",
   "deleteUserRelayMessage": "Si más adelante deseas volver a usarlo, deberás añadirlo manualmente.",
   "deleteUserRelayConfirm": "Sí",
-  "deleteUserRelayCancel": "No"
+  "deleteUserRelayCancel": "No",
+
+  "@_comment_session_timeout": "Session timeout message",
+  "sessionTimeoutMessage": "No hubo respuesta, verifica tu conexión e inténtalo más tarde"
 
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1137,5 +1137,8 @@
   "deleteUserRelayTitle": "Sicuro di volerti disconnettere da questo relay?",
   "deleteUserRelayMessage": "Se vorrai usarlo di nuovo in futuro, dovrai aggiungerlo manualmente.",
   "deleteUserRelayConfirm": "Sì",
-  "deleteUserRelayCancel": "No"
+  "deleteUserRelayCancel": "No",
+
+  "@_comment_session_timeout": "Session timeout message",
+  "sessionTimeoutMessage": "Nessuna risposta ricevuta, verifica la tua connessione e riprova più tardi"
 }

--- a/lib/shared/widgets/notification_listener_widget.dart
+++ b/lib/shared/widgets/notification_listener_widget.dart
@@ -66,6 +66,9 @@ class NotificationListenerWidget extends ConsumerWidget {
             case 'orderCanceled':
               message = S.of(context)!.orderCanceled;
               break;
+            case 'sessionTimeoutMessage':
+              message = S.of(context)!.sessionTimeoutMessage;
+              break;
             default:
               message = next.customMessage!;
           }


### PR DESCRIPTION
fix #64 
  - Add 10s timer cleanup for phantom sessions when Mostro doesn't respond
  - Handle maker vs taker scenarios differently (session preservation vs cleanup)
  - Add localized timeout notifications and automatic navigation
  - Update documentation with this new behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dual orphan-session protection: 10‑second auto-cleanup when taking orders plus real-time public-event timeout detection.
* **UX Improvements**
  * Distinct maker/taker outcomes: makers keep pending orders; takers’ sessions removed and orders return to the book. Timeouts/cancellations surface localized notifications and navigate to the main order book.
* **Localization**
  * Session timeout message added in English, Spanish, Italian.
* **Documentation**
  * Expanded session lifecycle, timer management, cancellation rules; cleanup window extended to 72 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->