### PR TITLE
Fix/child range orders add

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Guidelines
+## Project Structure & Module Organization
+The Flutter app lives in `lib/`, organized by domain: `lib/features/<feature>/` for screens, providers, and widgets; shared utilities in `lib/shared/`; app-wide wiring in `lib/core/` and `lib/services/`; persistence and API abstractions in `lib/data/`; background work in `lib/background/`. Generated localization output sits in `lib/generated/` and should never be hand-edited. Tests mirror the feature layout under `test/`, with end-to-end flows in `integration_test/`. Mobile platform shells live in `android/`, `ios/`, and `web/`, while `assets/` stores images referenced in `pubspec.yaml`. Longer-form docs, including the architecture note, are under `docs/`.
+
+## Build, Test, and Development Commands
+Run `flutter pub get` after pulling changes to sync dependencies. Use `dart run build_runner build -d` whenever localization ARB files, mocks, or generated models change. Start the app locally with `flutter run`. Enforce static analysis via `flutter analyze`, and format the codebase with `flutter format .`. Execute fast feedback tests through `flutter test`, and cover flows that touch native bridges with `flutter test integration_test/`.
+
+## Coding Style & Naming Conventions
+Formatting follows the Dart formatter (two-space indentation, trailing commas to improve diffs). Analyzer rules come from `flutter_lints`; keep the tree at zero warnings. Name Riverpod providers `<Feature>Provider` or `<Feature>Notifier`, and place feature-specific files inside their feature directory. Keep strings in the localization ARB files and access them with `S.of(context)`; never hard-code user-facing copy. Generated files (`*.g.dart`, `*.mocks.dart`) stay untouched.
+
+## Testing Guidelines
+Add unit tests beside the code they cover, using `*_test.dart` naming, and prefer constructing fakes through Mockito via `dart run build_runner build -d`. Integration scenarios belong in `integration_test/` and should exercise full user flows (e.g., order placement with mocked relays). Before opening a review, run both `flutter analyze` and `flutter test`; include `flutter test integration_test/` when altering networking, background jobs, or session recovery.
+
+## Commit & Pull Request Guidelines
+Commits should be concise, written in the imperative mood, and optionally prefixed with a scope (`feat:`, `docs:`) as seen in history, followed by the related PR number if applicable. Squash work so each commit represents one logical change. Pull requests must describe the intent, list key changes, call out risk areas, and link tracking issues. Attach screenshots or screen recordings for UI-facing updates, and note any manual testing performed alongside the command output you ran.

--- a/lib/data/models/session.dart
+++ b/lib/data/models/session.dart
@@ -13,6 +13,9 @@ class Session {
   final bool fullPrivacy;
   final DateTime startTime;
   String? orderId;
+  /// Tracks the order that originated this session when it represents
+  /// the preemptive child generated from a range order release.
+  String? parentOrderId;
   Role? role;
   Peer? _peer;
   NostrKeyPairs? _sharedKey;
@@ -24,6 +27,7 @@ class Session {
     required this.fullPrivacy,
     required this.startTime,
     this.orderId,
+    this.parentOrderId,
     this.role,
     Peer? peer,
   }) {
@@ -42,6 +46,7 @@ class Session {
         'full_privacy': fullPrivacy,
         'start_time': startTime.toIso8601String(),
         'order_id': orderId,
+        'parent_order_id': parentOrderId,
         'role': role?.value,
         'peer': peer?.publicKey,
       };
@@ -128,6 +133,19 @@ class Session {
         }
       }
 
+      // Parent order reference (only set for range order child sessions)
+      String? parentOrderId;
+      final parentOrderValue = json['parent_order_id'];
+      if (parentOrderValue != null) {
+        if (parentOrderValue is String && parentOrderValue.isNotEmpty) {
+          parentOrderId = parentOrderValue;
+        } else if (parentOrderValue is! String) {
+          throw FormatException(
+            'Invalid parent_order_id type: ${parentOrderValue.runtimeType}',
+          );
+        }
+      }
+
       return Session(
         masterKey: masterKeyValue,
         tradeKey: tradeKeyValue,
@@ -135,6 +153,7 @@ class Session {
         fullPrivacy: fullPrivacy,
         startTime: startTime,
         orderId: json['order_id']?.toString(),
+        parentOrderId: parentOrderId,
         role: role,
         peer: peer,
       );


### PR DESCRIPTION
  - Added parentOrderId tracking to Session so range-order children can inherit maker context and persist to storage (lib/data/models/session.dart:15-157).
  - Expanded SessionNotifier with a pre-release child session cache and helper APIs to link the child order once mostrod confirms it; state emission now keeps subscriptions in sync and is heavily commented for clarity (lib/shared/notifiers/session_notifier.dart:15-255).
  - Extended MostroService to prepare child sessions during releaseOrder and to link them immediately when the encrypted Action.newOrder arrives, spinning up the downstream OrderNotifier on the spot (lib/services/mostro_service.dart:44-200).

Documentation

  - Rewrote the child-order sections in docs/architecture/SESSION_AND_KEY_MANAGEMENT.md so they describe the simplified service-driven flow instead of the outdated notifier-based approach.

Add agents file for AI agents