### PR TITLE
fix: Rating notification allows multiple submissions

### DIFF
--- a/lib/features/notifications/widgets/notification_item.dart
+++ b/lib/features/notifications/widgets/notification_item.dart
@@ -8,6 +8,7 @@ import 'package:mostro_mobile/features/notifications/providers/notifications_pro
 import 'package:mostro_mobile/features/notifications/widgets/notification_type_icon.dart';
 import 'package:mostro_mobile/features/notifications/widgets/notification_content.dart';
 import 'package:mostro_mobile/features/notifications/widgets/notification_menu.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class NotificationItem extends ConsumerWidget {
@@ -80,7 +81,7 @@ class NotificationItem extends ConsumerWidget {
           context.push('/order_book');
           break;
         case mostro_action.Action.rate:
-          context.push('/rate_user/${notification.orderId}');
+          _handleRateNotificationTap(context, ref);
           break;
         case mostro_action.Action.payInvoice:
         case mostro_action.Action.fiatSentOk:
@@ -123,6 +124,20 @@ class NotificationItem extends ConsumerWidget {
         case mostro_action.Action.tradePubkey:
           break;
       }
+    }
+  }
+
+  void _handleRateNotificationTap(BuildContext context, WidgetRef ref) {
+    final orderId = notification.orderId;
+    if (orderId == null) return;
+    
+    // Check the current order state to see if rating has already been received
+    final orderState = ref.read(orderNotifierProvider(orderId));
+    
+    if (orderState.action == mostro_action.Action.rateReceived) {
+      context.push('/trade_detail/$orderId');
+    } else {
+      context.push('/rate_user/$orderId');
     }
   }
 


### PR DESCRIPTION
Added a validation in the navigation flow to check if notification has already been sent before navigate.

Note: this PR is ready to be reviewed, pls let me know if any change is needed.  

Closes: #298 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tapping a “Rate” notification now routes you to the correct screen based on the order’s current status, preventing misdirected navigation.
  * Handles cases where the related order is unavailable, avoiding crashes or dead-ends.

* **New Features**
  * Smarter handling of “Rate” notifications: if the order has already received a rating, you’re taken to the trade details; otherwise, you’re guided to submit a rating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->