### PR TITLE
fix: map hold-invoice-payment-settled action to success status

### DIFF
--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -186,7 +186,6 @@ class OrderState {
       // Actions that should set status to active
       case Action.buyerTookOrder:
       case Action.holdInvoicePaymentAccepted:
-      case Action.holdInvoicePaymentSettled:
       case Action.buyerInvoiceAccepted:
         return Status.active;
 
@@ -201,6 +200,7 @@ class OrderState {
       case Action.release:
       case Action.rate:
       case Action.rateReceived:
+      case Action.holdInvoicePaymentSettled:
         return Status.success;
 
       // Actions that should set status to canceled
@@ -311,11 +311,6 @@ class OrderState {
           Action.dispute,
           Action.sendDm,
         ],
-        Action.holdInvoicePaymentSettled: [
-          Action.cancel,
-          Action.dispute,
-          Action.sendDm,
-        ],
         Action.cooperativeCancelInitiatedByPeer: [
           Action.cancel,
           Action.dispute,
@@ -353,6 +348,9 @@ class OrderState {
           Action.rate,
         ],
         Action.released: [
+          Action.rate,
+        ],
+        Action.holdInvoicePaymentSettled: [
           Action.rate,
         ],
         Action.rateReceived: [],
@@ -432,12 +430,6 @@ class OrderState {
       },
       Status.active: {
         Action.holdInvoicePaymentAccepted: [
-          Action.fiatSent,
-          Action.cancel,
-          Action.dispute,
-          Action.sendDm,
-        ],
-        Action.holdInvoicePaymentSettled: [
           Action.fiatSent,
           Action.cancel,
           Action.dispute,


### PR DESCRIPTION
When the seller released the sats, and then received `hold-invoice-payment-settled`  action, the app put it the order in `Active` status, which is incorrect, it should have put it in `Success` status, also that action is only received by the seller, never the buyer.
In this PR:
  - Move Action.holdInvoicePaymentSettled from active to success status mapping
  - Remove holdInvoicePaymentSettled from buyer role (seller-only action)
  - Add rate action for holdInvoicePaymentSettled in seller success state