### PR TITLE
Add environment variable support for Mostro public key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ Connect your device and run:
 flutter run
 ```
 
+### Using Custom Mostro Public Key
+
+By default, the app uses the production Mostro public key. For development or testing with a different Mostro daemon, you can specify a custom public key using the `MOSTRO_PUB_KEY` environment variable:
+
+```bash
+# For development/testing
+flutter run --dart-define=MOSTRO_PUB_KEY=your_custom_mostro_public_key
+
+# Example with a test key
+flutter run --dart-define=MOSTRO_PUB_KEY=0a537332f2d569059add3fd2e376e1d6b8c1e1b9f7a999ac2592b4afbba74a00
+```
+
+This is particularly useful when:
+- Testing with a local Mostro daemon
+- Using different Mostro instances for development
+- Running integration tests with specific configurations
+
 ## Setting up Mostro Daemon
 
 1. Clone the Mostro repository:
@@ -309,4 +326,3 @@ This project is licensed under the MIT License. See the `LICENSE` file for detai
 - ✅ **Security**: Production-ready cryptographic implementation
 - ✅ **Localization**: Complete translation coverage for supported languages
 - ✅ **Documentation**: Comprehensive technical and user documentation
-

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -10,8 +10,10 @@ class Config {
   ];
 
   // Mostro hexkey
-  static const String mostroPubKey =
-      '82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390';
+  static const String mostroPubKey = String.fromEnvironment(
+    'MOSTRO_PUB_KEY',
+    defaultValue: '82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390',
+  );
   //'9d9d0455a96871f2dc4289b8312429db2e925f167b37c77bf7b28014be235980';
 
   static const String dBName = 'mostro.db';


### PR DESCRIPTION
This change allows developers to configure the Mostro daemon public key via the MOSTRO_PUB_KEY environment variable using --dart-define, making it easier to test with different Mostro instances without hardcoding keys. The production key remains as the default value, ensuring backward compatibility. Updated README with usage examples and instructions for development and testing scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for supplying a custom Mostro public key via an environment variable, enabling use with local or alternative setups across development, testing, and integration scenarios.
- Documentation
  - Added a “Using Custom Mostro Public Key” section with instructions and examples for configuring the environment variable in development workflows.
  - Cleaned up the Platform Status section by removing an empty bullet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->