### PR TITLE
feat: add orphan session cleanup for create orders with 10s timeout

### DIFF
--- a/lib/features/order/notfiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notfiers/abstract_mostro_notifier.dart
@@ -53,6 +53,9 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
               logger.i('Received message with action: ${msg?.action}');
             }
             if (msg != null) {
+              // Cancel timer on ANY response from Mostro for this order
+              cancelSessionTimeoutCleanup(orderId);
+              
               if (mounted) {
                 state = state.updateWith(msg);
               }
@@ -106,9 +109,6 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
       return;
     }
     _processedEventIds.add(eventKey);
-    
-    // Cancel timer on ANY response from Mostro for this order
-    _cancelSessionTimeoutCleanup(orderId);
     
     final navProvider = ref.read(navigationProvider.notifier);
 
@@ -413,13 +413,46 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
     }
   }
   
+  /// Starts a 10-second timer to cleanup orphan sessions for create orders (by requestId)
+  static void startSessionTimeoutCleanupForRequestId(int requestId, Ref ref) {
+    final key = requestId.toString();
+    // Cancel existing timer if any
+    _sessionTimeouts[key]?.cancel();
+    
+    _sessionTimeouts[key] = Timer(const Duration(seconds: 10), () {
+      try {
+        ref.read(sessionNotifierProvider.notifier).deleteSessionByRequestId(requestId);
+        Logger().i('Session cleaned up after 10s timeout for requestId: $requestId');
+        
+        // Show timeout message to user and navigate to order book
+        _showTimeoutNotificationAndNavigate(ref);
+      } catch (e) {
+        Logger().e('Failed to cleanup session for requestId: $requestId', error: e);
+      }
+      _sessionTimeouts.remove(key);
+    });
+    
+    Logger().i('Started 10s timeout timer for requestId: $requestId');
+  }
+  
   /// Cancels the timeout timer for a specific orderId
-  static void _cancelSessionTimeoutCleanup(String orderId) {
+  static void cancelSessionTimeoutCleanup(String orderId) {
     final timer = _sessionTimeouts[orderId];
     if (timer != null) {
       timer.cancel();
       _sessionTimeouts.remove(orderId);
       Logger().i('Cancelled 10s timeout timer for order: $orderId - Mostro responded');
+    }
+  }
+  
+  /// Cancels the timeout timer for a specific requestId
+  static void cancelSessionTimeoutCleanupForRequestId(int requestId) {
+    final key = requestId.toString();
+    final timer = _sessionTimeouts[key];
+    if (timer != null) {
+      timer.cancel();
+      _sessionTimeouts.remove(key);
+      Logger().i('Cancelled 10s timeout timer for requestId: $requestId - Mostro responded');
     }
   }
 

--- a/lib/features/order/widgets/action_buttons.dart
+++ b/lib/features/order/widgets/action_buttons.dart
@@ -49,7 +49,7 @@ class ActionButtons extends StatelessWidget {
               orderId: currentRequestId?.toString() ?? '',
               action: nostr_action.Action.newOrder,
               onPressed: onSubmit,
-              timeout: const Duration(seconds: 5),
+              timeout: const Duration(seconds: 10),
               showSuccessIndicator:
                   onSubmit != null, // Only show success indicator when enabled
               backgroundColor: onSubmit != null

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -187,6 +187,14 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     _emitState();
   }
 
+  /// Delete session by requestId for timeout cleanup
+  /// Used when create order timeout expires after 10s with no Mostro response
+  Future<void> deleteSessionByRequestId(int requestId) async {
+    _requestIdToSession.remove(requestId);
+    // Note: No storage deletion - these are temporary sessions in memory only
+    _emitState();
+  }
+
   /// Clean up temporary session by requestId
   /// Used when order creation fails and needs retry
   void cleanupRequestSession(int requestId) {


### PR DESCRIPTION
fix #277 

- Introduce startSessionTimeoutCleanupForRequestId() to handle orphan sessions when creating a new order without a response from Mostro within 10s
- Add cancelSessionTimeoutCleanupForRequestId() to stop timers on any response to avoid false cleanups
- Integrate cleanup logic in AddOrderNotifier:
  - Start timeout after submitting a new order
  - Cancel timeout when receiving response or disposing notifier
- Extend SessionNotifier with deleteSessionByRequestId() for in-memory session cleanup
- Increase action button timeout from 5s to 10s for consistency with cleanup window
- Move timer cancellation from handleEvent() to subscribe() in AbstractMostroNotifier so cancellation applies reliably to all responses