### PR TITLE
feat: add VIEW DISPUTE button for dispute states in order details

### DIFF
--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -420,6 +420,11 @@ class OrderState {
           Action.cancel,
           Action.release,
         ],
+        Action.adminTookDispute: [
+          Action.sendDm,
+          Action.cancel,
+          Action.release,
+        ],
       },
       Status.settledHoldInvoice: {
         Action.addInvoice: [
@@ -536,6 +541,10 @@ class OrderState {
           Action.cancel,
         ],
         Action.disputeInitiatedByPeer: [
+          Action.sendDm,
+          Action.cancel,
+        ],
+        Action.adminTookDispute: [
           Action.sendDm,
           Action.cancel,
         ],

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -268,6 +268,8 @@ class TradeDetailScreen extends ConsumerWidget {
 
     final widgets = <Widget>[];
 
+    // VIEW DISPUTE button is now handled in _buildButtonRow
+
     for (final action in userActions) {
       // FSM-driven action mapping: ensure all actions are handled
       switch (action) {
@@ -343,11 +345,15 @@ class TradeDetailScreen extends ConsumerWidget {
 
         case actions.Action.disputeInitiatedByYou:
         case actions.Action.disputeInitiatedByPeer:
+        case actions.Action.adminTookDispute:
+          // VIEW DISPUTE button is handled above, independent of action system
+          break;
+
         case actions.Action.dispute:
           // Only allow dispute if not already disputed
           if (tradeState.action != actions.Action.disputeInitiatedByYou &&
               tradeState.action != actions.Action.disputeInitiatedByPeer &&
-              tradeState.action != actions.Action.dispute) {
+              tradeState.action != actions.Action.adminTookDispute) {
             widgets.add(_buildDisputeButton(
               context,
               ref,
@@ -519,7 +525,6 @@ class TradeDetailScreen extends ConsumerWidget {
         case actions.Action.adminSettled:
         case actions.Action.adminAddSolver:
         case actions.Action.adminTakeDispute:
-        case actions.Action.adminTookDispute:
         case actions.Action.invoiceUpdated:
         case actions.Action.tradePubkey:
         case actions.Action.cantDo:
@@ -763,11 +768,33 @@ class TradeDetailScreen extends ConsumerWidget {
     );
   }
 
+  Widget _buildViewDisputeButton(BuildContext context, String disputeId) {
+    return ElevatedButton(
+      onPressed: () {
+        context.push('/dispute_details/$disputeId');
+      },
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppTheme.mostroGreen,
+      ),
+      child: Text(S.of(context)!.viewDisputeButton),
+    );
+  }
+
   /// Build button row with equal widths and heights
   Widget _buildButtonRow(
       BuildContext context, WidgetRef ref, OrderState tradeState) {
     final actionButtons = _buildActionButtons(context, ref, tradeState);
-    final allButtons = [_buildCloseButton(context), ...actionButtons];
+    
+    // Check for VIEW DISPUTE button - independent of action system
+    final List<Widget> extraButtons = [];
+    if ((tradeState.action == actions.Action.disputeInitiatedByYou ||
+         tradeState.action == actions.Action.disputeInitiatedByPeer ||
+         tradeState.action == actions.Action.adminTookDispute) &&
+         tradeState.dispute?.disputeId != null) {
+      extraButtons.add(_buildViewDisputeButton(context, tradeState.dispute!.disputeId));
+    }
+    
+    final allButtons = [_buildCloseButton(context), ...actionButtons, ...extraButtons];
 
     if (allButtons.length == 1) {
       // Single button - center it with natural oval shape

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -616,6 +616,7 @@
   
   "rateButton": "RATE",
   "contactButton": "CONTACT",
+  "viewDisputeButton": "VIEW DISPUTE",
   
   "rateCounterpart": "Rate Counterpart",
   "submitRating": "Submit Rating",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -539,6 +539,7 @@
   "completePurchaseButton": "COMPLETAR COMPRA",
   "rateButton": "CALIFICAR",
   "contactButton": "CONTACTAR",
+  "viewDisputeButton": "VER DISPUTA",
   
   "rateCounterpart": "Calificar Contraparte",
   "submitRating": "Enviar Calificación",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -568,6 +568,7 @@
   "completePurchaseButton": "COMPLETA ACQUISTO",
   "rateButton": "VALUTA",
   "contactButton": "CONTATTA",
+  "viewDisputeButton": "VISUALIZZA DISPUTA",
   
   "rateCounterpart": "Valuta Controparte",
   "submitRating": "Invia Valutazione",


### PR DESCRIPTION
  closes #322 

Add VIEW DISPUTE button that appears when orders are in dispute states (dispute-initiated-by-you,
  dispute-initiated-by-peer, admin-took-dispute), and improve admin-took-dispute screen 

  - Add viewDisputeButton localization for EN/ES/IT
  - Navigate to dispute details screen when pressed
  - Add Action.adminTookDispute to FSM with same actions as other dispute states
  - Ensure correct buttons appear for both seller and buyer roles

  Improves UX by providing direct access to dispute details from order screen.

Now:
<img width="638" height="1280" alt="image" src="https://github.com/user-attachments/assets/00df5067-6db9-449c-890a-6ccd5f45135e" />

Also admin-took-dispute screen
Before:
<img width="638" height="1280" alt="image" src="https://github.com/user-attachments/assets/75ed0f4f-e232-4851-be52-8f301cd61770" />

Now:
<img width="638" height="1280" alt="image" src="https://github.com/user-attachments/assets/351756ef-685f-452a-8eca-2cf4bba04ee0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “VIEW DISPUTE” button on trade details when a dispute is active, enabling quick access to the dispute thread.
- Improvements
  - Refined dispute action handling to better account for cases where an admin has taken over a dispute, ensuring clearer button display and flow.
- Localization
  - Added translations for the new “VIEW DISPUTE” button in English, Spanish (VER DISPUTA), and Italian (VISUALIZZA DISPUTA).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->