### PR TITLE
 Restore Session Implementation

### DIFF
--- a/integration_test/test_helpers.dart
+++ b/integration_test/test_helpers.dart
@@ -308,6 +308,9 @@ class FakeMostroService implements MostroService {
   Future<void> submitRating(String orderId, int rating) async {}
 
   @override
+  Future<void> requestRestoreSession() async {}
+
+  @override
   Future<Session> publishOrder(MostroMessage order) =>
       throw UnimplementedError();
 

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -13,3 +13,4 @@ export 'package:mostro_mobile/data/models/rating.dart';
 export 'package:mostro_mobile/data/models/session.dart';
 export 'package:mostro_mobile/data/models/payment_failed.dart';
 export 'package:mostro_mobile/data/models/next_trade.dart';
+export 'package:mostro_mobile/data/models/restore_data.dart';

--- a/lib/data/models/enums/action.dart
+++ b/lib/data/models/enums/action.dart
@@ -39,7 +39,8 @@ enum Action {
   invoiceUpdated('invoice-updated'),
   sendDm('send-dm'),
   tradePubkey('trade-pubkey'),
-  timeoutReversal('timeout-reversal');
+  timeoutReversal('timeout-reversal'),
+  restoreSession('restore-session');
 
   final String value;
 

--- a/lib/data/models/mostro_message.dart
+++ b/lib/data/models/mostro_message.dart
@@ -97,7 +97,7 @@ class MostroMessage<T extends Payload> {
 
   factory MostroMessage.fromJson(Map<String, dynamic> json) {
     final timestamp = json['timestamp'];
-    json = json['order'] ?? json['cant-do'] ?? json;
+    json = json['order'] ?? json['cant-do'] ?? json['restore'] ?? json;
     final num requestId = json['request_id'] ?? 0;
 
     return MostroMessage(

--- a/lib/data/models/payload.dart
+++ b/lib/data/models/payload.dart
@@ -6,6 +6,7 @@ import 'package:mostro_mobile/data/models/payment_failed.dart';
 import 'package:mostro_mobile/data/models/payment_request.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
 import 'package:mostro_mobile/data/models/rating_user.dart';
+import 'package:mostro_mobile/data/models/restore_data.dart';
 
 abstract class Payload {
   String get type;
@@ -28,6 +29,8 @@ abstract class Payload {
       return PaymentFailed.fromJson(json['payment_failed']);
     } else if (json.containsKey('next_trade')) {
       return NextTrade.fromJson(json['next_trade']);
+    } else if (json.containsKey('restore_data')) {
+      return RestoreData.fromJson(json);
     } else {
       throw UnsupportedError('Unknown payload type');
     }

--- a/lib/data/models/restore_data.dart
+++ b/lib/data/models/restore_data.dart
@@ -1,0 +1,99 @@
+import 'package:mostro_mobile/data/models/payload.dart';
+
+class RestoreOrderInfo {
+  final String orderId;
+  final int tradeIndex;
+  final String status;
+
+  RestoreOrderInfo({
+    required this.orderId,
+    required this.tradeIndex,
+    required this.status,
+  });
+
+  factory RestoreOrderInfo.fromJson(Map<String, dynamic> json) {
+    return RestoreOrderInfo(
+      orderId: json['order_id'] as String,
+      tradeIndex: json['trade_index'] as int,
+      status: json['status'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'order_id': orderId,
+      'trade_index': tradeIndex,
+      'status': status,
+    };
+  }
+}
+
+class RestoreDisputeInfo {
+  final String disputeId;
+  final String orderId;
+  final int tradeIndex;
+  final String status;
+
+  RestoreDisputeInfo({
+    required this.disputeId,
+    required this.orderId,
+    required this.tradeIndex,
+    required this.status,
+  });
+
+  factory RestoreDisputeInfo.fromJson(Map<String, dynamic> json) {
+    return RestoreDisputeInfo(
+      disputeId: json['dispute_id'] as String,
+      orderId: json['order_id'] as String,
+      tradeIndex: json['trade_index'] as int,
+      status: json['status'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'dispute_id': disputeId,
+      'order_id': orderId,
+      'trade_index': tradeIndex,
+      'status': status,
+    };
+  }
+}
+
+class RestoreData implements Payload {
+  final List<RestoreOrderInfo> orders;
+  final List<RestoreDisputeInfo> disputes;
+
+  RestoreData({
+    required this.orders,
+    required this.disputes,
+  });
+
+  factory RestoreData.fromJson(Map<String, dynamic> json) {
+    final restoreData = json['restore_data'] as Map<String, dynamic>;
+    final ordersJson = restoreData['orders'] as List<dynamic>? ?? [];
+    final disputesJson = restoreData['disputes'] as List<dynamic>? ?? [];
+
+    return RestoreData(
+      orders: ordersJson
+          .map((order) => RestoreOrderInfo.fromJson(order as Map<String, dynamic>))
+          .toList(),
+      disputes: disputesJson
+          .map((dispute) => RestoreDisputeInfo.fromJson(dispute as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  @override
+  String get type => 'restore_data';
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'restore_data': {
+        'orders': orders.map((o) => o.toJson()).toList(),
+        'disputes': disputes.map((d) => d.toJson()).toList(),
+      }
+    };
+  }
+}

--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -9,6 +9,7 @@ import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
 import 'package:mostro_mobile/shared/providers.dart';
+import 'package:mostro_mobile/shared/providers/notifications_history_repository_provider.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class KeyManagementScreen extends ConsumerStatefulWidget {
@@ -67,6 +68,9 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
     final eventStorage = ref.read(eventStorageProvider);
     await eventStorage.deleteAll();
 
+    final notificationsRepo = ref.read(notificationsRepositoryProvider);
+    await notificationsRepo.clearAll();
+
     final keyManager = ref.read(keyManagerProvider);
     await keyManager.generateAndStoreMasterKey();
 
@@ -84,6 +88,18 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
 
   Future<void> _importKeyAndRestore() async {
     try {
+      final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
+      await sessionNotifier.reset();
+
+      final mostroStorage = ref.read(mostroStorageProvider);
+      await mostroStorage.deleteAll();
+
+      final eventStorage = ref.read(eventStorageProvider);
+      await eventStorage.deleteAll();
+
+      final notificationsRepo = ref.read(notificationsRepositoryProvider);
+      await notificationsRepo.clearAll();
+
       await _importKey();
 
       ref.read(subscriptionManagerProvider).reinitializeMasterKeySubscription();
@@ -621,6 +637,12 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
     final words = trimmed.split(RegExp(r'\s+'));
     if (words.length != 12 && words.length != 24) {
       return S.of(context)!.mnemonicValidationInvalidWordCount;
+    }
+
+    for (final word in words) {
+      if (word.length < 3) {
+        return S.of(context)!.mnemonicValidationWordTooShort;
+      }
     }
 
     return null;

--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -602,98 +602,36 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
     );
   }
 
+  String? _validateMnemonic(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return S.of(context)!.mnemonicValidationEmpty;
+    }
+
+    final validCharacters = RegExp(r'^[a-zA-Z\s]+$');
+    if (!validCharacters.hasMatch(trimmed)) {
+      return S.of(context)!.mnemonicValidationInvalidFormat;
+    }
+
+    final words = trimmed.split(RegExp(r'\s+'));
+    if (words.length != 12 && words.length != 24) {
+      return S.of(context)!.mnemonicValidationInvalidWordCount;
+    }
+
+    return null;
+  }
+
   void _showImportDialog(BuildContext context) {
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: AppTheme.backgroundCard,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-          side: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
-        ),
-        title: Text(
-          S.of(context)!.importMostroUser,
-          style: const TextStyle(
-            color: AppTheme.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              S.of(context)!.secretWordsInfoText,
-              style: const TextStyle(
-                color: AppTheme.textSecondary,
-                fontSize: 14,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: _importController,
-              decoration: InputDecoration(
-                hintText: S.of(context)!.secretWords,
-                hintStyle: const TextStyle(color: AppTheme.textSecondary),
-                filled: true,
-                fillColor: AppTheme.backgroundInput,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: AppTheme.activeColor),
-                ),
-              ),
-              style: const TextStyle(color: AppTheme.textPrimary),
-              maxLines: 3,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () {
-              _importController.clear();
-              Navigator.of(dialogContext).pop();
-            },
-            child: Text(
-              S.of(context)!.cancel,
-              style: const TextStyle(
-                color: AppTheme.textSecondary,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-          const SizedBox(width: 12),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.of(dialogContext).pop();
-              _importKeyAndRestore();
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: AppTheme.activeColor,
-              foregroundColor: Colors.black,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(8),
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-            ),
-            child: Text(
-              S.of(context)!.importMostroUser,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ],
+      builder: (dialogContext) => _ImportDialog(
+        importController: _importController,
+        onImport: () {
+          Navigator.of(dialogContext).pop();
+          _importKeyAndRestore();
+        },
+        validateMnemonic: _validateMnemonic,
       ),
     );
   }
@@ -808,6 +746,150 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
           ],
         );
       },
+    );
+  }
+}
+
+class _ImportDialog extends StatefulWidget {
+  final TextEditingController importController;
+  final VoidCallback onImport;
+  final String? Function(String) validateMnemonic;
+
+  const _ImportDialog({
+    required this.importController,
+    required this.onImport,
+    required this.validateMnemonic,
+  });
+
+  @override
+  State<_ImportDialog> createState() => _ImportDialogState();
+}
+
+class _ImportDialogState extends State<_ImportDialog> {
+  String? _errorText;
+
+  void _validateAndImport() {
+    final error = widget.validateMnemonic(widget.importController.text);
+    if (error == null) {
+      widget.onImport();
+    } else {
+      setState(() {
+        _errorText = error;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppTheme.backgroundCard,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+      ),
+      title: Text(
+        S.of(context)!.importMostroUser,
+        style: const TextStyle(
+          color: AppTheme.textPrimary,
+          fontSize: 18,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            S.of(context)!.secretWordsInfoText,
+            style: const TextStyle(
+              color: AppTheme.textSecondary,
+              fontSize: 14,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: widget.importController,
+            decoration: InputDecoration(
+              hintText: S.of(context)!.secretWords,
+              hintStyle: const TextStyle(color: AppTheme.textSecondary),
+              filled: true,
+              fillColor: AppTheme.backgroundInput,
+              errorText: _errorText,
+              errorStyle: const TextStyle(
+                color: Colors.redAccent,
+                fontSize: 12,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide(
+                  color: _errorText != null
+                      ? Colors.redAccent
+                      : Colors.white.withValues(alpha: 0.1),
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide(
+                  color: _errorText != null
+                      ? Colors.redAccent
+                      : Colors.white.withValues(alpha: 0.1),
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide(
+                  color:
+                      _errorText != null ? Colors.redAccent : AppTheme.activeColor,
+                ),
+              ),
+            ),
+            style: const TextStyle(color: AppTheme.textPrimary),
+            maxLines: 3,
+            onChanged: (_) {
+              if (_errorText != null) {
+                setState(() {
+                  _errorText = null;
+                });
+              }
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            widget.importController.clear();
+            Navigator.of(context).pop();
+          },
+          child: Text(
+            S.of(context)!.cancel,
+            style: const TextStyle(
+              color: AppTheme.textSecondary,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        ElevatedButton(
+          onPressed: _validateAndImport,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppTheme.activeColor,
+            foregroundColor: Colors.black,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          ),
+          child: Text(
+            S.of(context)!.importMostroUser,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -7,6 +7,7 @@ import 'package:lucide_icons/lucide_icons.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
@@ -84,6 +85,9 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
   Future<void> _importKeyAndRestore() async {
     try {
       await _importKey();
+
+      ref.read(subscriptionManagerProvider).reinitializeMasterKeySubscription();
+
       await ref.read(mostroServiceProvider).requestRestoreSession();
 
       if (mounted) {

--- a/lib/features/key_manager/key_management_screen.dart
+++ b/lib/features/key_manager/key_management_screen.dart
@@ -72,25 +72,38 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
     await _loadKeys();
   }
 
-  // ignore: unused_element
   Future<void> _importKey() async {
     final keyManager = ref.read(keyManagerProvider);
     final importValue = _importController.text.trim();
     if (importValue.isNotEmpty) {
-      try {
-        await keyManager.importMnemonic(importValue);
-        await _loadKeys();
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(S.of(context)!.keyImportedSuccessfully)),
-          );
-        }
-      } catch (e) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(S.of(context)!.importFailed(e.toString()))),
-          );
-        }
+      await keyManager.importMnemonic(importValue);
+      await _loadKeys();
+    }
+  }
+
+  Future<void> _importKeyAndRestore() async {
+    try {
+      await _importKey();
+      await ref.read(mostroServiceProvider).requestRestoreSession();
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(S.of(context)!.keyImportedSuccessfully),
+            backgroundColor: Colors.green,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(S.of(context)!.importFailed(e.toString())),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 5),
+          ),
+        );
       }
     }
   }
@@ -558,10 +571,9 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
     return SizedBox(
       width: double.infinity,
       child: OutlinedButton(
-        onPressed: null, // Keep disabled as requested
+        onPressed: () => _showImportDialog(context),
         style: OutlinedButton.styleFrom(
-          side:
-              BorderSide(color: AppTheme.textSecondary.withValues(alpha: 0.3)),
+          side: const BorderSide(color: AppTheme.activeColor),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
           ),
@@ -570,22 +582,118 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(
+            const Icon(
               LucideIcons.download,
               size: 20,
-              color: AppTheme.textSecondary.withValues(alpha: 0.5),
+              color: AppTheme.activeColor,
             ),
             const SizedBox(width: 8),
             Text(
               S.of(context)!.importMostroUser,
-              style: TextStyle(
+              style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w500,
-                color: AppTheme.textSecondary.withValues(alpha: 0.5),
+                color: AppTheme.activeColor,
               ),
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  void _showImportDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppTheme.backgroundCard,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+        ),
+        title: Text(
+          S.of(context)!.importMostroUser,
+          style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              S.of(context)!.secretWordsInfoText,
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 14,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _importController,
+              decoration: InputDecoration(
+                hintText: S.of(context)!.secretWords,
+                hintStyle: const TextStyle(color: AppTheme.textSecondary),
+                filled: true,
+                fillColor: AppTheme.backgroundInput,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: AppTheme.activeColor),
+                ),
+              ),
+              style: const TextStyle(color: AppTheme.textPrimary),
+              maxLines: 3,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              _importController.clear();
+              Navigator.of(dialogContext).pop();
+            },
+            child: Text(
+              S.of(context)!.cancel,
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              _importKeyAndRestore();
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppTheme.activeColor,
+              foregroundColor: Colors.black,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            ),
+            child: Text(
+              S.of(context)!.importMostroUser,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/notifications/utils/notification_message_mapper.dart
+++ b/lib/features/notifications/utils/notification_message_mapper.dart
@@ -85,6 +85,8 @@ class NotificationMessageMapper {
       case mostro.Action.tradePubkey:
       case mostro.Action.timeoutReversal:
         return 'notification_order_update_title';
+      case mostro.Action.restoreSession:
+        return 'notification_order_update_title';
     }
   }
 
@@ -177,6 +179,8 @@ class NotificationMessageMapper {
         return 'notification_dispute_started_message';
       case mostro.Action.tradePubkey:
       case mostro.Action.timeoutReversal:
+        return 'notification_order_update_message';
+      case mostro.Action.restoreSession:
         return 'notification_order_update_message';
     }
   }

--- a/lib/features/notifications/widgets/notification_item.dart
+++ b/lib/features/notifications/widgets/notification_item.dart
@@ -122,6 +122,7 @@ class NotificationItem extends ConsumerWidget {
         case mostro_action.Action.adminTookDispute:
         case mostro_action.Action.invoiceUpdated:
         case mostro_action.Action.tradePubkey:
+        case mostro_action.Action.restoreSession:
           break;
       }
     }

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -9,6 +9,7 @@ import 'package:mostro_mobile/features/subscriptions/subscription.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 
 /// Manages Nostr subscriptions across different parts of the application.
 ///
@@ -24,16 +25,19 @@ class SubscriptionManager {
   final _ordersController = StreamController<NostrEvent>.broadcast();
   final _chatController = StreamController<NostrEvent>.broadcast();
   final _relayListController = StreamController<RelayListEvent>.broadcast();
+  final _masterKeyController = StreamController<NostrEvent>.broadcast();
 
   Stream<NostrEvent> get orders => _ordersController.stream;
   Stream<NostrEvent> get chat => _chatController.stream;
   Stream<RelayListEvent> get relayList => _relayListController.stream;
+  Stream<NostrEvent> get masterKey => _masterKeyController.stream;
 
   SubscriptionManager(this.ref) {
     _initSessionListener();
     // Ensure resources are released with provider/container lifecycle
     ref.onDispose(dispose);
     _initializeExistingSessions();
+    _initializeMasterKeySubscription();
   }
 
   void _initSessionListener() {
@@ -71,20 +75,48 @@ class SubscriptionManager {
     }
   }
 
+  /// Initialize master key subscription for restore session responses
+  void _initializeMasterKeySubscription() {
+    try {
+      final keyManager = ref.read(keyManagerProvider);
+      final masterKey = keyManager.masterKeyPair;
+      if (masterKey != null) {
+        final filter = NostrFilter(
+          kinds: [1059],
+          p: [masterKey.public],
+        );
+        subscribe(
+          type: SubscriptionType.masterKey,
+          filter: filter,
+        );
+        _logger.i('Master key subscription initialized');
+      }
+    } catch (e, stackTrace) {
+      _logger.e('Error initializing master key subscription',
+          error: e, stackTrace: stackTrace);
+    }
+  }
+
+  /// Session-based subscription types that depend on active sessions
+  static const _sessionBasedTypes = [
+    SubscriptionType.orders,
+    SubscriptionType.chat,
+  ];
+
   void _updateAllSubscriptions(List<Session> sessions) {
     if (sessions.isEmpty) {
-      _logger.i('No sessions available, clearing all subscriptions');
-      _clearAllSubscriptions();
+      _logger.i('No sessions available, clearing session-based subscriptions');
+      _clearSessionBasedSubscriptions();
       return;
     }
 
-    for (final type in SubscriptionType.values) {
+    for (final type in _sessionBasedTypes) {
       _updateSubscription(type, sessions);
     }
   }
 
-  void _clearAllSubscriptions() {
-    for (final type in SubscriptionType.values) {
+  void _clearSessionBasedSubscriptions() {
+    for (final type in _sessionBasedTypes) {
       unsubscribeByType(type);
     }
   }
@@ -144,6 +176,16 @@ class SubscriptionManager {
       case SubscriptionType.relayList:
         // Relay list subscriptions are handled separately via subscribeToMostroRelayList
         return null;
+      case SubscriptionType.masterKey:
+        final keyManager = ref.read(keyManagerProvider);
+        final masterKey = keyManager.masterKeyPair;
+        if (masterKey == null) {
+          return null;
+        }
+        return NostrFilter(
+          kinds: [1059],
+          p: [masterKey.public],
+        );
     }
   }
 
@@ -161,6 +203,9 @@ class SubscriptionManager {
           if (relayListEvent != null) {
             _relayListController.add(relayListEvent);
           }
+          break;
+        case SubscriptionType.masterKey:
+          _masterKeyController.add(event);
           break;
       }
     } catch (e, stackTrace) {
@@ -210,6 +255,8 @@ class SubscriptionManager {
       case SubscriptionType.relayList:
         // RelayList subscriptions should use subscribeToMostroRelayList() instead
         throw UnsupportedError('Use subscribeToMostroRelayList() for relay list subscriptions');
+      case SubscriptionType.masterKey:
+        return masterKey;
     }
   }
 
@@ -329,5 +376,6 @@ class SubscriptionManager {
     _ordersController.close();
     _chatController.close();
     _relayListController.close();
+    _masterKeyController.close();
   }
 }

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -97,6 +97,12 @@ class SubscriptionManager {
     }
   }
 
+  /// Reinitialize master key subscription after importing new key
+  void reinitializeMasterKeySubscription() {
+    unsubscribeByType(SubscriptionType.masterKey);
+    _initializeMasterKeySubscription();
+  }
+
   /// Session-based subscription types that depend on active sessions
   static const _sessionBasedTypes = [
     SubscriptionType.orders,

--- a/lib/features/subscriptions/subscription_type.dart
+++ b/lib/features/subscriptions/subscription_type.dart
@@ -2,4 +2,5 @@ enum SubscriptionType {
   chat,
   orders,
   relayList,
+  masterKey,
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -859,6 +859,9 @@
   
   "@_comment_account_info_dialogs": "Account Screen Info Dialog Text",
   "secretWordsInfoText": "• These are your secret words, the only way to recover your account if you lose access to this app or want to use your identity in another app.\n\n• Write them down carefully and store them in a secure, private location. Never share them with anyone.\n\n• If you lose these words, you'll permanently lose access to your account.",
+  "mnemonicValidationEmpty": "Secret words cannot be empty",
+  "mnemonicValidationInvalidFormat": "Only letters and spaces are allowed",
+  "mnemonicValidationInvalidWordCount": "Must contain exactly 12 or 24 words",
   "privacyInfoText": "• Reputation Mode protects your privacy from third parties while allowing you to build a reputation with each completed trade.\n\n• Full privacy mode provides maximum anonymity but limits reputation building features.",
   "currentTradeIndexInfoText": "With each new trade, a unique Trade Key is generated to ensure your transactions remain private. The trade index indicates how many keys you've used. If you're in 'Reputation Mode,' you allow Mostro to link all your Trade Keys to calculate and maintain your reputation.",
   "generateNewUserDialogTitle": "Generate a new user?",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -862,6 +862,7 @@
   "mnemonicValidationEmpty": "Secret words cannot be empty",
   "mnemonicValidationInvalidFormat": "Only letters and spaces are allowed",
   "mnemonicValidationInvalidWordCount": "Must contain exactly 12 or 24 words",
+  "mnemonicValidationWordTooShort": "Each word must have at least 3 letters",
   "privacyInfoText": "• Reputation Mode protects your privacy from third parties while allowing you to build a reputation with each completed trade.\n\n• Full privacy mode provides maximum anonymity but limits reputation building features.",
   "currentTradeIndexInfoText": "With each new trade, a unique Trade Key is generated to ensure your transactions remain private. The trade index indicates how many keys you've used. If you're in 'Reputation Mode,' you allow Mostro to link all your Trade Keys to calculate and maintain your reputation.",
   "generateNewUserDialogTitle": "Generate a new user?",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -841,6 +841,7 @@
   "mnemonicValidationEmpty": "Las palabras secretas no pueden estar vacías",
   "mnemonicValidationInvalidFormat": "Solo se permiten letras y espacios",
   "mnemonicValidationInvalidWordCount": "Debe contener exactamente 12 o 24 palabras",
+  "mnemonicValidationWordTooShort": "Cada palabra debe tener al menos 3 letras",
   "privacyInfoText": "• El Modo Reputación protege tu privacidad de terceros mientras te permite construir una reputación con cada intercambio completado.\n\n• El modo de privacidad completa proporciona máximo anonimato pero limita las funciones de construcción de reputación.",
   "currentTradeIndexInfoText": "Con cada nuevo intercambio, se genera una Clave de Intercambio única para asegurar que tus transacciones permanezcan privadas. El índice de intercambio indica cuántas claves has usado. Si estás en 'Modo Reputación,' permites a Mostro vincular todas tus Claves de Intercambio para calcular y mantener tu reputación.",
   "generateNewUserDialogTitle": "¿Generar un nuevo usuario?",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -838,6 +838,9 @@
   
   "@_comment_account_info_dialogs": "Texto de Diálogos de Información de Cuenta",
   "secretWordsInfoText": "• Estas son tus palabras secretas, la única forma de recuperar tu cuenta si pierdes acceso a esta aplicación o quieres usar tu identidad en otra aplicación.\n\n• Escríbelas cuidadosamente y guárdalas en un lugar seguro y privado. Nunca las compartas con nadie.\n\n• Si pierdes estas palabras, perderás permanentemente el acceso a tu cuenta.",
+  "mnemonicValidationEmpty": "Las palabras secretas no pueden estar vacías",
+  "mnemonicValidationInvalidFormat": "Solo se permiten letras y espacios",
+  "mnemonicValidationInvalidWordCount": "Debe contener exactamente 12 o 24 palabras",
   "privacyInfoText": "• El Modo Reputación protege tu privacidad de terceros mientras te permite construir una reputación con cada intercambio completado.\n\n• El modo de privacidad completa proporciona máximo anonimato pero limita las funciones de construcción de reputación.",
   "currentTradeIndexInfoText": "Con cada nuevo intercambio, se genera una Clave de Intercambio única para asegurar que tus transacciones permanezcan privadas. El índice de intercambio indica cuántas claves has usado. Si estás en 'Modo Reputación,' permites a Mostro vincular todas tus Claves de Intercambio para calcular y mantener tu reputación.",
   "generateNewUserDialogTitle": "¿Generar un nuevo usuario?",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -894,6 +894,9 @@
   
   "@_comment_account_info_dialogs": "Testo Dialoghi Informazioni Account",
   "secretWordsInfoText": "• Queste sono le tue parole segrete, l'unico modo per recuperare il tuo account se perdi l'accesso a questa app o vuoi usare la tua identità in un'altra app.\n\n• Scrivile attentamente e conservale in un luogo sicuro e privato. Non condividerle mai con nessuno.\n\n• Se perdi queste parole, perderai permanentemente l'accesso al tuo account.",
+  "mnemonicValidationEmpty": "Le parole segrete non possono essere vuote",
+  "mnemonicValidationInvalidFormat": "Sono consentite solo lettere e spazi",
+  "mnemonicValidationInvalidWordCount": "Deve contenere esattamente 12 o 24 parole",
   "privacyInfoText": "• La Modalità Reputazione protegge la tua privacy da terze parti permettendoti di costruire una reputazione con ogni scambio completato.\n\n• La modalità privacy completa fornisce massimo anonimato ma limita le funzionalità di costruzione della reputazione.",
   "currentTradeIndexInfoText": "Con ogni nuovo scambio, viene generata una Chiave di Scambio unica per assicurare che le tue transazioni rimangano private. L'indice di scambio indica quante chiavi hai usato. Se sei in 'Modalità Reputazione,' permetti a Mostro di collegare tutte le tue Chiavi di Scambio per calcolare e mantenere la tua reputazione.",
   "generateNewUserDialogTitle": "Generare un nuovo utente?",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -897,6 +897,7 @@
   "mnemonicValidationEmpty": "Le parole segrete non possono essere vuote",
   "mnemonicValidationInvalidFormat": "Sono consentite solo lettere e spazi",
   "mnemonicValidationInvalidWordCount": "Deve contenere esattamente 12 o 24 parole",
+  "mnemonicValidationWordTooShort": "Ogni parola deve avere almeno 3 lettere",
   "privacyInfoText": "• La Modalità Reputazione protegge la tua privacy da terze parti permettendoti di costruire una reputazione con ogni scambio completato.\n\n• La modalità privacy completa fornisce massimo anonimato ma limita le funzionalità di costruzione della reputazione.",
   "currentTradeIndexInfoText": "Con ogni nuovo scambio, viene generata una Chiave di Scambio unica per assicurare che le tue transazioni rimangano private. L'indice di scambio indica quante chiavi hai usato. Se sei in 'Modalità Reputazione,' permetti a Mostro di collegare tutte le tue Chiavi di Scambio per calcolare e mantenere la tua reputazione.",
   "generateNewUserDialogTitle": "Generare un nuovo utente?",

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -346,6 +346,7 @@ class MostroService {
 
       final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
       int restoredCount = 0;
+      int maxTradeIndex = 0;
 
       for (final orderInfo in restoreData.orders) {
         try {
@@ -363,9 +364,17 @@ class MostroService {
 
           await sessionNotifier.saveSession(session);
           restoredCount++;
+
+          if (orderInfo.tradeIndex > maxTradeIndex) {
+            maxTradeIndex = orderInfo.tradeIndex;
+          }
         } catch (e) {
           _logger.e('Failed to restore order ${orderInfo.orderId}', error: e);
         }
+      }
+
+      if (maxTradeIndex > 0) {
+        await keyManager.setCurrentKeyIndex(maxTradeIndex + 1);
       }
 
       _logger.i(

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -74,7 +74,6 @@ class MostroService {
     if (matchingSession != null) {
       privateKey = matchingSession.tradeKey.private;
     } else {
-      // Check if this is a master key message (for restore session responses)
       final keyManager = ref.read(keyManagerProvider);
       final masterKey = keyManager.masterKeyPair;
       if (masterKey != null && event.recipient != null && event.recipient == masterKey.public) {
@@ -87,20 +86,24 @@ class MostroService {
 
     try {
       final decryptedEvent = await event.unWrap(privateKey);
-      if (decryptedEvent.content == null) return;
+      if (decryptedEvent.content == null) {
+        _logger.w('Decrypted event has no content');
+        return;
+      }
 
       final result = jsonDecode(decryptedEvent.content!);
-      if (result is! List) return;
+      if (result is! List) {
+        _logger.w('Decoded result is not a List: ${result.runtimeType}');
+        return;
+      }
 
       final msg = MostroMessage.fromJson(result[0]);
 
-      // Handle restore session response
       if (msg.action == Action.restoreSession) {
         await _handleRestoreResponse(msg);
         return;
       }
 
-      // Only store and link for non-restore messages
       if (matchingSession != null) {
         final messageStorage = ref.read(mostroStorageProvider);
         await messageStorage.addMessage(decryptedEvent.id!, msg);
@@ -333,11 +336,41 @@ class MostroService {
       }
 
       final restoreData = message.payload as RestoreData;
-      _logger.i(
-        'Restore session received ${restoreData.orders.length} orders, ${restoreData.disputes.length} disputes'
-      );
 
-      // TODO: Implement session restoration logic here
+      final keyManager = ref.read(keyManagerProvider);
+      final masterKey = keyManager.masterKeyPair;
+      if (masterKey == null) {
+        _logger.e('No master key available for restore');
+        return;
+      }
+
+      final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
+      int restoredCount = 0;
+
+      for (final orderInfo in restoreData.orders) {
+        try {
+          final tradeKey = await keyManager.deriveTradeKeyFromIndex(orderInfo.tradeIndex);
+
+          final session = Session(
+            masterKey: masterKey,
+            tradeKey: tradeKey,
+            keyIndex: orderInfo.tradeIndex,
+            fullPrivacy: _settings.fullPrivacyMode,
+            startTime: DateTime.now(),
+            orderId: orderInfo.orderId,
+            role: Role.seller,
+          );
+
+          await sessionNotifier.saveSession(session);
+          restoredCount++;
+        } catch (e) {
+          _logger.e('Failed to restore order ${orderInfo.orderId}', error: e);
+        }
+      }
+
+      _logger.i(
+        'Restored $restoredCount orders, ${restoreData.disputes.length} disputes'
+      );
     } catch (e, stackTrace) {
       _logger.e('Failed to handle restore response', error: e, stackTrace: stackTrace);
     }

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -20,6 +20,7 @@ class MostroService {
 
   Settings _settings;
   StreamSubscription<NostrEvent>? _ordersSubscription;
+  StreamSubscription<NostrEvent>? _masterKeySubscription;
 
   MostroService(this.ref) : _settings = ref.read(settingsProvider);
 
@@ -34,10 +35,21 @@ class MostroService {
       },
       cancelOnError: false,
     );
+
+    // Subscribe to master key messages for restore session responses
+    _masterKeySubscription = ref.read(subscriptionManagerProvider).masterKey.listen(
+      _onData,
+      onError: (error, stackTrace) {
+        _logger.e('Error in master key subscription',
+            error: error, stackTrace: stackTrace);
+      },
+      cancelOnError: false,
+    );
   }
 
   void dispose() {
     _ordersSubscription?.cancel();
+    _masterKeySubscription?.cancel();
     _logger.i('MostroService disposed');
   }
 
@@ -54,14 +66,24 @@ class MostroService {
     );
 
     final sessions = ref.read(sessionNotifierProvider);
-    final matchingSession = sessions.firstWhereOrNull(
+    Session? matchingSession = sessions.firstWhereOrNull(
       (s) => s.tradeKey.public == event.recipient,
     );
-    if (matchingSession == null) {
-      _logger.w('No matching session found for recipient: ${event.recipient}');
-      return;
+
+    String privateKey;
+    if (matchingSession != null) {
+      privateKey = matchingSession.tradeKey.private;
+    } else {
+      // Check if this is a master key message (for restore session responses)
+      final keyManager = ref.read(keyManagerProvider);
+      final masterKey = keyManager.masterKeyPair;
+      if (masterKey != null && event.recipient != null && event.recipient == masterKey.public) {
+        privateKey = masterKey.private;
+      } else {
+        _logger.w('No matching session found for recipient: ${event.recipient}');
+        return;
+      }
     }
-    final privateKey = matchingSession.tradeKey.private;
 
     try {
       final decryptedEvent = await event.unWrap(privateKey);
@@ -71,15 +93,25 @@ class MostroService {
       if (result is! List) return;
 
       final msg = MostroMessage.fromJson(result[0]);
-      final messageStorage = ref.read(mostroStorageProvider);
-      await messageStorage.addMessage(decryptedEvent.id!, msg);
-      _logger.i(
-        'Received DM, Event ID: ${decryptedEvent.id} with payload: ${decryptedEvent.content}',
-      );
 
-      await _maybeLinkChildOrder(msg, matchingSession);
-    } catch (e) {
-      _logger.e('Error processing event', error: e);
+      // Handle restore session response
+      if (msg.action == Action.restoreSession) {
+        await _handleRestoreResponse(msg);
+        return;
+      }
+
+      // Only store and link for non-restore messages
+      if (matchingSession != null) {
+        final messageStorage = ref.read(mostroStorageProvider);
+        await messageStorage.addMessage(decryptedEvent.id!, msg);
+        _logger.i(
+          'Received DM, Event ID: ${decryptedEvent.id} with payload: ${decryptedEvent.content}',
+        );
+
+        await _maybeLinkChildOrder(msg, matchingSession);
+      }
+    } catch (e, stackTrace) {
+      _logger.e('Error processing event', error: e, stackTrace: stackTrace);
     }
   }
 
@@ -266,6 +298,49 @@ class MostroService {
         payload: RatingUser(userRating: rating),
       ),
     );
+  }
+
+  Future<void> requestRestoreSession() async {
+    _logger.i('Requesting restore session from Mostro');
+
+    final keyManager = ref.read(keyManagerProvider);
+    final masterKey = keyManager.masterKeyPair!;
+
+    final message = MostroMessage(
+      action: Action.restoreSession,
+    );
+
+    final event = await message.wrap(
+      tradeKey: masterKey,
+      recipientPubKey: _settings.mostroPublicKey,
+      masterKey: masterKey,
+      keyIndex: null,
+    );
+
+    await ref.read(nostrServiceProvider).publishEvent(event);
+  }
+
+  Future<void> _handleRestoreResponse(MostroMessage message) async {
+    try {
+      if (message.payload == null) {
+        _logger.w('Received empty restore response');
+        return;
+      }
+
+      if (message.payload is! RestoreData) {
+        _logger.w('Invalid restore payload type: ${message.payload.runtimeType}');
+        return;
+      }
+
+      final restoreData = message.payload as RestoreData;
+      _logger.i(
+        'Restore session received ${restoreData.orders.length} orders, ${restoreData.disputes.length} disputes'
+      );
+
+      // TODO: Implement session restoration logic here
+    } catch (e, stackTrace) {
+      _logger.e('Failed to handle restore response', error: e, stackTrace: stackTrace);
+    }
   }
 
   Future<void> publishOrder(MostroMessage order) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -840,26 +840,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -1462,26 +1462,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.8"
   timeago:
     dependency: "direct main"
     description:
@@ -1614,10 +1614,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -735,6 +735,16 @@ class MockMostroService extends _i1.Mock implements _i12.MostroService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> requestRestoreSession() => (super.noSuchMethod(
+        Invocation.method(
+          #requestRestoreSession,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<void> publishOrder(_i7.MostroMessage<_i7.Payload>? order) =>
       (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
This PR incorporate the process to restore orders and disputes  using the user  mnemonic keys 

###   How Orders Are Marked as Owned

  The restore session feature works by reconstructing user sessions from backend data, which automatically marks orders and disputes  as owned through the existing session-based ownership detection system.

Closes #78 

  Current Flow:

  1. Request Phase (mobile/lib/services/mostro_service.dart:303-323)
    - User imports mnemonic via import dialog
    - App sends encrypted restore-session action to Mostro daemon
    - Request is encrypted to master key derived from mnemonic
  2. Backend Response
    - Returns array of {id, trade_index, status} for each order
  3. Session Reconstruction (mobile/lib/services/mostro_service.dart:326-386)
  for (final orderInfo in restoreData.orders) {
    // Derive the same trade key that was originally used
    final tradeKey = await keyManager.deriveTradeKeyFromIndex(orderInfo.tradeIndex);

    // Create session with original trade_index
    final session = Session(
      masterKey: masterKey,
      tradeKey: tradeKey,
      keyIndex: orderInfo.tradeIndex,  // Original index (3, 5, 7, etc.)
      orderId: orderInfo.orderId,
      role: Role.seller
    );

    await sessionNotifier.saveSession(session);
  }
  4. Automatic Ownership Detection (mobile/lib/features/home/widgets/order_list_item.dart:44-50)
  final session = ref.watch(sessionProvider(order.orderId!));
  if (session != null && session.role != null) {
    orderLabel = session.role == Role.seller
      ? S.of(context)!.youAreSelling.toUpperCase()
      : S.of(context)!.youAreBuying.toUpperCase();
  }

  Key Points:
  - Orders already exist in Order Book (they're public events)
  - Creating a session with matching orderId triggers ownership detection
  - Trade keys are deterministically derived using original indices

  Additional Features Implemented

-   Notification Cleanup on Key Import/Generation
-  Trade Index Management
-  Mnemonic Validation

  Validation rules enforced:

- [ ]   - Exactly 12 or 24 words (BIP-39 standard)
- [ ]   - Only letters and spaces allowed
- [ ]   - Each word must be at least 3 characters 
- [ ]   - Localized error messages (EN/ES/IT)
