### PR TITLE
Set automatic session deletion from 36 to 72 hours

### DIFF
--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -37,7 +37,7 @@ class Config {
   static const int expirationSeconds = 900;
   static const int expirationHours = 24;
   static const int cleanupIntervalMinutes = 30;
-  static const int sessionExpirationHours = 36;
+  static const int sessionExpirationHours = 72;
 
   // Notification configuration
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended session timeout from 36 hours to 72 hours, allowing users to remain logged in longer before requiring re-authentication. This provides improved convenience for continuous work sessions while maintaining security protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->