### PR TITLE
feat: add invalid_fiat_currency error handling with session cleanup

### DIFF
--- a/lib/data/models/enums/cant_do_reason.dart
+++ b/lib/data/models/enums/cant_do_reason.dart
@@ -22,6 +22,7 @@ enum CantDoReason {
   notFound('not_found'),
   invalidDisputeStatus('invalid_dispute_status'),
   invalidAction('invalid_action'),
+  invalidFiatCurrency('invalid_fiat_currency'),
   pendingOrderExists('pending_order_exists');
 
   final String value;

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -167,6 +167,7 @@
   "notFound": "The requested dispute could not be found.",
   "invalidDisputeStatus": "The dispute status is invalid.",
   "invalidAction": "The requested action is invalid.",
+  "invalidFiatCurrency": "This Mostro instance doesn't accept the selected currency, try another instance",
   "pendingOrderExists": "You already have an order waiting for you, you must complete it or cancel it before taking another one.",
   "login": "Login",
   "register": "Register",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -143,6 +143,7 @@
   "notFound": "La disputa solicitada no pudo ser encontrada.",
   "invalidDisputeStatus": "El estado de la disputa es inválido.",
   "invalidAction": "La acción solicitada es inválida.",
+  "invalidFiatCurrency": "Este mostro no acepta la moneda que seleccionaste, prueba con otra instancia",
   "pendingOrderExists": "Ya tienes una orden esperando por ti, debes completarla o cancelarla antes de tomar otra.",
   "login": "Iniciar Sesión",
   "register": "Registrarse",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -167,6 +167,7 @@
   "notFound": "Disputa non trovata.",
   "invalidDisputeStatus": "Lo stato della disputa è invalido.",
   "invalidAction": "L'azione richiesta è invalida",
+  "invalidFiatCurrency": "Questa istanza Mostro non accetta la valuta selezionata, prova un'altra istanza",
   "pendingOrderExists": "Hai già un ordine in attesa, devi completarlo o cancellarlo prima di prenderne un altro.",
   "login": "Accedi",
   "register": "Registrati",

--- a/lib/shared/widgets/notification_listener_widget.dart
+++ b/lib/shared/widgets/notification_listener_widget.dart
@@ -27,6 +27,7 @@ class CantDoNotificationMapper {
     'invalid_rating': (context) => S.of(context)!.invalidRating,
     'invalid_order_kind': (context) => S.of(context)!.invalidOrderKind,
     'invalid_order_status': (context) => S.of(context)!.invalidOrderStatus,
+    'invalid_fiat_currency': (context) => S.of(context)!.invalidFiatCurrency,
   };
   
   static String getMessage(BuildContext context, String cantDoReason) {
@@ -75,7 +76,7 @@ class NotificationListenerWidget extends ConsumerWidget {
         } else if (next.action != null) {
           // Handle specific cant-do reasons with custom messages
           if (next.action == mostro.Action.cantDo) {
-            final reason = next.values['action'];
+            final reason = next.values['reason'];
             if (reason is String && reason.isNotEmpty) {
               message = CantDoNotificationMapper.getMessage(context, reason);
             } else {


### PR DESCRIPTION
fix #325 

  - Add invalidFiatCurrency to CantDoReason enum
  - Fix bug in NotificationListenerWidget: change values['action'] to values['reason']
  - Add localized error messages for invalid fiat currency in en/es/it
  - Add session cleanup and navigation for invalidFiatCurrency errors
  - Update CantDoNotificationMapper with new error type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proper error handling when the selected fiat currency is not supported by the Mostro instance, displaying a helpful message suggesting to try another instance.
  * Improved session management to automatically clean up and navigate back to the order book when this error occurs.
  * Extended localization support with new message translations in English, Spanish, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->