### PR TITLE
Creation of desktop application for windows and mac

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags: ['v*.*.*']          # run only when a tag like v1.2.3 is pushed
   workflow_dispatch:
+    inputs:
+      flutter_version:
+        description: 'Flutter version (or "latest")'
+        required: false
+        default: '3.32.2'
+
+env:
+  FLUTTER_VERSION: '3.32.2'  # Default Flutter version
 
 jobs:
   build-desktop:
@@ -42,7 +50,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: '3.32.2'
+          flutter-version: ${{ inputs.flutter_version || env.FLUTTER_VERSION }}
           cache: true  # Enable caching for faster builds
 
       # 3. Install Linux dependencies (Linux only)
@@ -76,15 +84,26 @@ jobs:
         shell: bash
         continue-on-error: true
 
-      # 6. Install project dependencies
+      # 6. Cache pub dependencies
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            ${{ runner.os == 'Windows' && '%LOCALAPPDATA%\Pub\Cache' || '' }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      # 7. Install project dependencies
       - name: Install dependencies
         run: flutter pub get
 
-      # 7. Generate localization and other required files
+      # 8. Generate localization and other required files
       - name: Generate required files
         run: dart run build_runner build -d
 
-      # 8. Extract version from pubspec.yaml
+      # 9. Extract version from pubspec.yaml
       - name: Extract version
         id: extract_version
         shell: bash
@@ -98,16 +117,26 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "Version: $version"
 
-      # 9. Analyze code (optional)
+      # 10. Analyze code (optional)
       - name: Analyze code
-        run: flutter analyze
+        run: flutter analyze --fatal-infos
         continue-on-error: true
 
-      # 10. Build for platform
+      # 11. Build for platform
       - name: Build ${{ matrix.platform }} release
         run: ${{ matrix.build-command }}
+        
+      # 12. Verify build output exists
+      - name: Verify build output
+        shell: bash
+        run: |
+          if [ ! -d "${{ matrix.artifact-path }}" ]; then
+            echo "ERROR: Build output not found at ${{ matrix.artifact-path }}"
+            exit 1
+          fi
+          echo "✅ Build output verified at ${{ matrix.artifact-path }}"
 
-      # 11. Package Linux build
+      # 13. Package Linux build
       - name: Package Linux build
         if: matrix.platform == 'linux'
         run: |
@@ -115,7 +144,7 @@ jobs:
           tar -czf ./dist/mostro_mobile-${{ steps.extract_version.outputs.version }}-${{ matrix.artifact-name }} \
             -C ${{ matrix.artifact-path }} .
 
-      # 12. Package build (macOS)
+      # 14. Package build (macOS)
       - name: Package macOS build
         if: matrix.platform == 'macos'
         run: |
@@ -123,7 +152,7 @@ jobs:
           find ${{ matrix.artifact-path }} -name "*.app" -type d | head -1 | xargs -I {} \
             zip -r ./dist/mostro_mobile-${{ steps.extract_version.outputs.version }}-${{ matrix.artifact-name }} {}
 
-      # 13. Package build (Windows)
+      # 15. Package build (Windows)
       - name: Package Windows build
         if: matrix.platform == 'windows'
         shell: pwsh
@@ -131,20 +160,30 @@ jobs:
           if (-not (Test-Path "./dist")) { New-Item -ItemType Directory -Path "./dist" | Out-Null }
           Compress-Archive -Path "${{ matrix.artifact-path }}/*" `
             -DestinationPath "./dist/mostro_mobile-${{ steps.extract_version.outputs.version }}-${{ matrix.artifact-name }}"
-      # 14. Upload as artifact
+      
+      # 16. Upload as artifact
       - name: Upload ${{ matrix.platform }} artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-release
-          path: mostro_mobile-${{ steps.extract_version.outputs.version }}-${{ matrix.artifact-name }}
+          path: ./dist/mostro_mobile-${{ steps.extract_version.outputs.version }}-${{ matrix.artifact-name }}
 
-      # 15. Create GitHub Release and upload
+      # 17. Create GitHub Release and upload
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "mostro_mobile-${{ steps.extract_version.outputs.version }}-${{ matrix.artifact-name }}"
+          artifacts: "./dist/mostro_mobile-${{ steps.extract_version.outputs.version }}-${{ matrix.artifact-name }}"
           tag: v${{ steps.extract_version.outputs.version }}
+          name: "Release v${{ steps.extract_version.outputs.version }}"
+          body: |
+            ## Desktop Builds - v${{ steps.extract_version.outputs.version }}
+            
+            **Platform**: ${{ matrix.platform }}
+            **Flutter Version**: ${{ inputs.flutter_version || env.FLUTTER_VERSION }}
+            **Build Date**: ${{ github.event.head_commit.timestamp }}
           allowUpdates: true
-          omitBodyDuringUpdate: true
+          omitBodyDuringUpdate: false
           replacesArtifacts: true
+          draft: false
+          prerelease: false
 


### PR DESCRIPTION
Hi @grunch , @AndreaDiazCorreia , @Catrya ,

this morning i spent sometime to improve gh actions to generate mobile desktop versions for:

- Windows
- MacOs

the result is [here](https://github.com/arkanoider/mobile/releases) in my fork of mobile, if you want to add this as a feature merge this pr, please consider that I am totally noob on MacOs so I am not aware of the best practise to generate for their MacOs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated multi-platform build-and-release pipeline for desktop (Linux, macOS, Windows).
  * Pipeline builds, packages platform-specific archives, uploads artifacts, and creates versioned releases using the extracted project version.
  * Supports tag-triggered and manual runs, configurable runtime version, optional analysis, caching, and tolerant matrix behavior to avoid failing all builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->