### PR TITLE
fix: reset payment methods when fiat currency changes (#352)

### DIFF
--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -192,6 +192,20 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
       ref.watch(exchangeRateProvider(selectedFiatCode));
     }
 
+    // Listen for fiat code changes and reset payment methods when currency changes
+    // This prevents stale payment methods from previous currency selection
+    ref.listen<String?>(selectedFiatCodeProvider, (previous, next) {
+      // Only reset if there was a previous value and it changed
+      // Skip on initial load (previous == null)
+      if (previous != null && previous != next && context.mounted) {
+        setState(() {
+          _selectedPaymentMethods = [];
+          _showCustomPaymentMethod = false;
+          _customPaymentMethodController.clear();
+        });
+      }
+    });
+
     return Scaffold(
       backgroundColor: const Color(0xFF171A23),
       appBar: AppBar(


### PR DESCRIPTION
Fixes #352 by automatically resetting payment methods when fiat currency changes using a Riverpod listener.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed payment method state persisting incorrectly when changing currencies. Payment selections and custom payment fields now properly reset when switching to a different currency, ensuring consistent UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->