### PR TITLE
Update gh action to create v7 and v8 mobile versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,15 +152,17 @@ jobs:
       - name: Rename Split APKs
         if: steps.should_build.outputs.SHOULD_BUILD == 'true'
         run: |
+          set -euo pipefail
+          
           # Rename APKs with version and architecture
           mv build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk \
              build/app/outputs/flutter-apk/mostro-v${{ env.VERSION }}-armeabi-v7a.apk
           mv build/app/outputs/flutter-apk/app-arm64-v8a-release.apk \
              build/app/outputs/flutter-apk/mostro-v${{ env.VERSION }}-arm64-v8a.apk
-
+          
           # Verify renamed files exist
-          ls -lh build/app/outputs/flutter-apk/mostro-v${{ env.VERSION }}-*.apk
-
+          ls -lh build/app/outputs/flutter-apk/mostro-v${{ env.VERSION }}-*.apk || \
+            (echo "❌ Split APKs not found after rename" && exit 1)
       - name: Verify APK Signing
         if: steps.should_build.outputs.SHOULD_BUILD == 'true'
         run: |


### PR DESCRIPTION
Changes Made

1. Updated APK Build Command (line 136)

- Changed from --release to --split-per-abi
- Now generates separate APKs for each architecture instead of a universal APK

2. Added APK Renaming Step (lines 152-162)

- Renames app-armeabi-v7a-release.apk → mostro-mobile-v{VERSION}-armeabi-v7a.apk
- Renames app-arm64-v8a-release.apk → mostro-mobile-v{VERSION}-arm64-v8a.apk
- Includes verification to confirm renamed files exist

3. Updated APK Verification (lines 164-208)

- Created a reusable bash function to verify APKs
- Verifies both v7a and v8a APKs with jarsigner and apksigner
- Maintains certificate SHA-256 fingerprint checking for both APKs

4. Updated Artifact Upload (lines 216-218)

- Now uploads both split APKs to workflow artifacts
- Keeps the .aab file in the upload

5. Updated GitHub Release (line 226)

- Adds both split APKs to the GitHub release
- Result: Each release will have 3 files:
  - mostro-v{VERSION}-armeabi-v7a.apk
  - mostro-v{VERSION}-arm64-v8a.apk
  - app-release.aab

The .aab build remains unchanged and continues to use --release flag. All changes maintain the existing security
  checks and signing verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now produces architecture-specific APKs (armeabi-v7a and arm64-v8a) with versioned filenames.
  * Added a renaming step to produce clearly versioned per-ABI artifacts.
  * Strengthened signing verification to check each per-ABI APK and optionally enforce apksigner SHA-256 fingerprints.
  * Release artifacts updated to publish the renamed per-ABI APKs alongside the AAB.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->