### PR TITLE
fix: add missing build_runner step to flutter.yml workflow

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Generate required files
+        run: dart run build_runner build -d
+
       - name: Generate localizations
         run: flutter gen-l10n
 


### PR DESCRIPTION
fix #374 
Per CLAUDE.md, generated files should never be committed, but CI tests fail due to missing auto-generation.

Add `dart run build_runner build -d` before code analysis to generate required files (`*.g.dart, *.mocks.dart`) and fix CI failures in `flutter analyze` and `flutter test`.
This step is already present in `main.yml` and `desktop.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration workflow to enhance the build process with improved file generation ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->