### PR TITLE
Fix order creation time display bug

### DIFF
--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -35,7 +35,7 @@ extension NostrEventExtensions on NostrEvent {
   String? get name => _getTagValue('name') ?? 'Anon';
   String? get geohash => _getTagValue('g');
   String? get bond => _getTagValue('bond');
-  String? timeAgoWithLocale(String? locale) =>
+  String? timeAgoWithLocale(String locale) =>
       _timeAgoFromCreated(locale);
   DateTime get expirationDate => _getTimeStamp(_getTagValue('expiration')!);
   String? get expiresAt => _getTagValue('expires_at');
@@ -61,10 +61,9 @@ extension NostrEventExtensions on NostrEvent {
   }
 
 
-  String _timeAgoFromCreated([String? locale]) {
+  String _timeAgoFromCreated(String locale) {
     if (createdAt == null) return "invalid date";
-    final effectiveLocale = locale ?? 'es';
-    return timeago.format(createdAt!, allowFromNow: true, locale: effectiveLocale);
+    return timeago.format(createdAt!, allowFromNow: true, locale: locale);
   }
 
   Future<NostrEvent> unWrap(String privateKey) async {


### PR DESCRIPTION
fix #358 

Remove 48-hour subtraction hack from timeAgoWithLocale() that caused orders to show "in X days" instead of "X time ago". Now uses actual created_at timestamp for accurate relative time display.

  - Remove buggy _timeAgo() method and expiration property
  - Update timeAgoWithLocale() to use _timeAgoFromCreated()
  - Fix broken usage in mostro_message_detail_widget.dart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized timestamp calculation for events, now using creation date for time display formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->