### PR TITLE
feat: update info event kind from 38383 to 38385

### DIFF
--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -9,6 +9,7 @@ import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/services/nostr_service.dart';
 
 const orderEventKind = 38383;
+const infoEventKind = 38385;
 const orderFilterDurationHours = 48;
 
 class OpenOrdersRepository implements OrderRepository<NostrEvent> {
@@ -39,7 +40,7 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
         DateTime.now().subtract(Duration(hours: orderFilterDurationHours));
 
     final filter = NostrFilter(
-      kinds: [orderEventKind],
+      kinds: [orderEventKind, infoEventKind],
       since: filterTime,
       authors: [_settings.mostroPublicKey],
     );
@@ -52,7 +53,7 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
       if (event.type == 'order') {
         _events[event.orderId!] = event;
         _eventStreamController.add(_events.values.toList());
-      } else if (event.type == 'info' &&
+      } else if (event.kind == infoEventKind &&
           event.pubkey == _settings.mostroPublicKey) {
         _logger.i('Mostro instance info loaded: $event');
         _mostroInstance = event;


### PR DESCRIPTION
  - Add infoEventKind constant for new Mostro info event kind
  - Update subscription filter to include kind 38385
  - Change info event detection from z-tag to kind-based filtering

Dispute (kind 38386) and rating (kind 38384) events were not actively used in the app, so no changes were needed for them. The app only subscribed to and processed info events (now migrated to kind 38385).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended open orders to recognize and process information events (kind 38385), enabling the system to handle additional event types and provide more comprehensive order information to users.

* **Bug Fixes**
  * Improved event detection mechanism by using standardized event kind identifiers instead of type strings, ensuring more reliable and accurate event identification across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->