### PR TITLE
Add Android permissions for background reliability

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,6 +63,10 @@
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<!-- Background reliability permissions (Fix 03) -->
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
+	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
 	<queries>
 		<intent>

--- a/docs/architecture/BACKGROUND_NOTIFICATIONS_FIX.md
+++ b/docs/architecture/BACKGROUND_NOTIFICATIONS_FIX.md
@@ -188,7 +188,7 @@ Users can customize or hide this channel in Android settings.
 
 ## Implementation Order
 
-1. **Fix 03**: Add Android permissions (low risk, immediate benefit)
+1. **Fix 03**: Add Android permissions (low risk, immediate benefit) ✅ **COMPLETED**
 2. **Fix 02**: FCM starts service (enables reactive wake-up)
 3. **Fix 04**: Subscription persistence (service can recover state)
 4. **Fix 01**: Smart foreground service (ties it all together)


### PR DESCRIPTION
  Add WAKE_LOCK, REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, and RECEIVE_BOOT_COMPLETED
  permissions to AndroidManifest.xml.

  These permissions enable future improvements for reliable background notifications.
  Part of background notifications fix effort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Android background notification system for improved reliability when managing active trades and during idle periods.

* **Chores**
  * Added necessary system permissions to support enhanced background operations and device wake management.
  * Updated documentation outlining the background notification architecture and operational scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->