### PR TITLE
Feat: Add kind 0 metadata fetching for Mostro nodes (P2)

### DIFF
--- a/lib/features/mostro/mostro_node.dart
+++ b/lib/features/mostro/mostro_node.dart
@@ -1,3 +1,6 @@
+/// Sentinel value to explicitly clear an optional field in [MostroNode.withMetadata].
+const String _clearField = '__clear__';
+
 class MostroNode {
   final String pubkey;
   String? name;
@@ -17,12 +20,20 @@ class MostroNode {
     this.addedAt,
   });
 
+  /// Sentinel value to explicitly clear a metadata field.
+  /// Usage: `node.withMetadata(name: MostroNode.clear)`
+  static const String clear = _clearField;
+
   String get displayName => name ?? truncatedPubkey;
 
   String get truncatedPubkey => pubkey.length > 10
       ? '${pubkey.substring(0, 5)}...${pubkey.substring(pubkey.length - 5)}'
       : pubkey;
 
+  /// Returns a copy with updated metadata fields.
+  /// - Pass a value to set it.
+  /// - Pass `null` (or omit) to keep the current value.
+  /// - Pass [MostroNode.clear] to explicitly set the field to `null`.
   MostroNode withMetadata({
     String? name,
     String? picture,
@@ -31,10 +42,10 @@ class MostroNode {
   }) {
     return MostroNode(
       pubkey: pubkey,
-      name: name ?? this.name,
-      picture: picture ?? this.picture,
-      website: website ?? this.website,
-      about: about ?? this.about,
+      name: name == _clearField ? null : (name ?? this.name),
+      picture: picture == _clearField ? null : (picture ?? this.picture),
+      website: website == _clearField ? null : (website ?? this.website),
+      about: about == _clearField ? null : (about ?? this.about),
       isTrusted: isTrusted,
       addedAt: addedAt,
     );

--- a/lib/shared/providers/app_init_provider.dart
+++ b/lib/shared/providers/app_init_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
@@ -20,6 +21,7 @@ final appInitializerProvider = FutureProvider<void>((ref) async {
 
   final mostroNodes = ref.read(mostroNodesProvider.notifier);
   await mostroNodes.init();
+  unawaited(mostroNodes.fetchAllNodeMetadata());
 
   final sessionManager = ref.read(sessionNotifierProvider.notifier);
   await sessionManager.init();

--- a/test/features/mostro/mostro_node_test.dart
+++ b/test/features/mostro/mostro_node_test.dart
@@ -104,6 +104,27 @@ void main() {
       expect(updated.about, 'New about');
     });
 
+    test('withMetadata clears fields when MostroNode.clear is passed', () {
+      final original = MostroNode(
+        pubkey: 'abcde12345fghij67890',
+        name: 'Name',
+        picture: 'https://pic.com',
+        website: 'https://site.com',
+        about: 'About text',
+      );
+
+      final cleared = original.withMetadata(
+        name: MostroNode.clear,
+        picture: MostroNode.clear,
+      );
+
+      expect(cleared.name, isNull);
+      expect(cleared.picture, isNull);
+      // Uncleared fields preserved
+      expect(cleared.website, 'https://site.com');
+      expect(cleared.about, 'About text');
+    });
+
     test('equality is based on pubkey', () {
       final node1 = MostroNode(pubkey: 'abcde12345fghij67890', name: 'Node 1');
       final node2 = MostroNode(pubkey: 'abcde12345fghij67890', name: 'Node 2');


### PR DESCRIPTION
Fetch Nostr kind 0 profile metadata (name, picture, website, about) for each Mostro node, giving users meaningful names and avatars instead of raw pubkeys.

- Add fetchAllNodeMetadata() for batch fetching in a single round trip
- Add fetchNodeMetadata() for per-node refresh
- Deduplicate events across relays, keeping latest by createdAt
- Verify event signatures before applying metadata
- Sanitize picture/website URLs (https-only)
- Guard against disposed notifier after async gaps
- Fire-and-forget on startup via unawaited(), never blocks init
- Add MostroNode.clear sentinel for explicit field clearing
- Add 12 new tests (49 total across P1+P2)
- Update MULTI_MOSTRO_SUPPORT.md with phase status and implementation details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Node metadata is now automatically fetched and cached at app startup, providing complete node information.
  * Enhanced metadata management with improved field handling and explicit clearing capabilities.
  * URL validation ensures only secure HTTPS connections are stored.

* **Improvements**
  * Refined error handling for metadata operations with comprehensive logging and resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->