### PR TITLE
Feat: Add performance stress tests and documentation polish (P5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - URL normalization: Trailing slash removal prevents duplicate entries
 - Instance-isolated testing: Test connections don't affect main app connectivity
 
+### Multi-Mostro Instance Support
+- **Overview**: Users can connect to multiple Mostro instances (nodes) from a single app, switching between them with full relay and subscription reset
+- **Node Types**: Trusted nodes (hardcoded in `Config.trustedMostroNodes`, cannot be removed) vs custom nodes (user-added, persisted in SharedPreferences, removable)
+- **Core Files**: `features/mostro/mostro_node.dart` (model), `mostro_nodes_notifier.dart` (StateNotifier with CRUD, rename, metadata), `mostro_nodes_provider.dart` (Riverpod provider)
+- **UI Components**: `MostroNodeSelector` (bottom sheet for browsing/selecting nodes), `AddCustomNodeDialog` (hex/npub input with validation), `MostroNodeAvatar` (kind 0 picture with `NymAvatar` fallback), `TrustedBadge`
+- **Kind 0 Metadata**: Batch fetch at startup via `fetchAllNodeMetadata()` (fire-and-forget), deduplication keeping latest event per pubkey, signature verification, URL sanitization (https only)
+- **Storage Strategy**: Trusted in `Config`, custom in SharedPreferences (`mostro_custom_nodes`), metadata in-memory only (fetched fresh each launch)
+- **Node Switching**: `selectNode()` → `SettingsNotifier.updateMostroInstance()` → blacklist/userRelays reset → relay reconnection → `RestoreService.initRestoreProcess()`
+- **Backward Compatibility**: Unrecognized `mostroPublicKey` auto-imported as custom node; pubkey validated as 64-char hex; malformed values silently skipped
+- **Error Resilience**: Persist-before-state pattern prevents memory/disk divergence; all persistence errors logged but never crash the app
+- **Implementation**: Located in `features/mostro/` with full documentation in `docs/MULTI_MOSTRO_SUPPORT.md`
+
 ## App Initialization Process
 
 ### Initialization Sequence

--- a/docs/MULTI_MOSTRO_SUPPORT.md
+++ b/docs/MULTI_MOSTRO_SUPPORT.md
@@ -177,15 +177,41 @@ Settings Screen
 - `mostro_nodes_notifier_test.dart`: 34 tests (CRUD, backward compat, metadata fetching)
 - `mostro_integration_test.dart`: 23 tests (cross-component flows, persistence, relay reset, edge cases)
 
-### Phase 5: Polish + Edge Cases — To implement
+### Phase 5: Polish + Edge Cases — Completed
 
-**Goal**: Handle edge cases, improve UX, and finalize documentation.
+**Goal**: Handle edge cases, improve UX, finalize documentation, and add performance stress tests.
 
-**Work Items**:
-- Handle offline metadata fetch gracefully
-- Add loading indicators during node switch
-- Update CLAUDE.md with multi-Mostro architecture notes
-- Performance testing with many custom nodes
+**Work Items Analysis**:
+
+| Work Item | Status | Notes |
+|-----------|--------|-------|
+| Handle offline metadata fetch gracefully | Done in Phase 3 | `MostroNodeAvatar` uses `Image.network` with loading spinner + `NymAvatar` fallback on error. `fetchAllNodeMetadata()` catches all errors and logs. Fire-and-forget at startup. |
+| Add loading indicators during node switch | Done in Phase 3 | `_isSwitching` flag + per-node `CircularProgressIndicator` in `MostroNodeSelector`. Disables all interactions during switch. Error/revert handling with SnackBars. |
+| Update CLAUDE.md with multi-Mostro architecture notes | Done in Phase 5 | Added "Multi-Mostro Instance Support" section under Architecture Overview |
+| Performance testing with many custom nodes | Done in Phase 5 | 5 stress tests with 50 custom nodes |
+
+**Files Created**:
+- `test/features/mostro/mostro_nodes_performance_test.dart` — 5 performance/stress tests
+
+**Files Modified**:
+- `CLAUDE.md` — Added "Multi-Mostro Instance Support" subsection under Architecture Overview (10 bullet points covering node types, core files, UI components, kind 0 metadata, storage, node switching, backward compatibility, error resilience)
+- `docs/MULTI_MOSTRO_SUPPORT.md` — This section (Phase 5 expanded and marked completed)
+
+**Performance Test Details** (5 tests):
+
+| Test | What it verifies |
+|------|-----------------|
+| Add 50 custom nodes and verify all persisted | All 50 added, state length = trusted + 50, persistence round-trip with fresh notifier |
+| selectedNode lookup with last node in large list | Correct node returned when active node is the last in a list of 50+ |
+| Remove node from middle of large list | List integrity after removing node 25/50, surrounding nodes intact, removal persisted |
+| Batch metadata update for all nodes | `updateNodeMetadata()` for all 50+ nodes, all fields updated correctly |
+| Init with 50 pre-existing nodes completes promptly | `init()` loads 50 nodes from storage in under 1 second |
+
+**Test Coverage Summary** (74 total across Phases 1-5):
+- `mostro_node_test.dart`: 12 tests (model serialization, equality, metadata)
+- `mostro_nodes_notifier_test.dart`: 34 tests (CRUD, backward compat, metadata fetching)
+- `mostro_integration_test.dart`: 23 tests (cross-component flows, persistence, relay reset, edge cases)
+- `mostro_nodes_performance_test.dart`: 5 tests (stress testing with 50 custom nodes)
 
 ## Model Reference
 

--- a/test/features/mostro/mostro_nodes_performance_test.dart
+++ b/test/features/mostro/mostro_nodes_performance_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/core/config.dart';
+import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
+import 'package:mostro_mobile/features/mostro/mostro_nodes_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/services/nostr_service.dart';
+
+import '../../mocks.dart';
+import '../../mocks.mocks.dart';
+
+/// Generates a deterministic 64-char hex pubkey from an integer index.
+String makePubkey(int i) => i.toRadixString(16).padLeft(64, '0');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  provideDummy<Settings>(Settings(
+    relays: [],
+    fullPrivacyMode: false,
+    mostroPublicKey: '',
+  ));
+  provideDummy<SettingsNotifier>(MockSettingsNotifier());
+  provideDummy<NostrService>(MockNostrService());
+
+  final trustedPubkey = Config.trustedMostroNodes.first['pubkey']!;
+  const nodeCount = 50;
+
+  group('Performance with many custom nodes', () {
+    late MockSharedPreferencesAsync mockPrefs;
+    late MockRef mockRef;
+    late MockSettingsNotifier mockSettingsNotifier;
+    late Map<String, String> storage;
+
+    setUp(() {
+      mockPrefs = MockSharedPreferencesAsync();
+      mockRef = MockRef();
+      mockSettingsNotifier = MockSettingsNotifier();
+      storage = <String, String>{};
+
+      when(mockPrefs.getString(any)).thenAnswer(
+          (inv) async => storage[inv.positionalArguments[0] as String]);
+      when(mockPrefs.setString(any, any)).thenAnswer((inv) async {
+        storage[inv.positionalArguments[0] as String] =
+            inv.positionalArguments[1] as String;
+      });
+
+      mockSettingsNotifier.state = Settings(
+        relays: ['wss://default.example.com'],
+        fullPrivacyMode: false,
+        mostroPublicKey: trustedPubkey,
+      );
+
+      when(mockRef.read(settingsProvider))
+          .thenAnswer((_) => mockSettingsNotifier.state);
+      when(mockRef.read(settingsProvider.notifier))
+          .thenReturn(mockSettingsNotifier);
+    });
+
+    MostroNodesNotifier createNotifier() {
+      return MostroNodesNotifier(mockPrefs, mockRef);
+    }
+
+    test('add $nodeCount custom nodes and verify all persisted', () async {
+      final notifier = createNotifier();
+      await notifier.init();
+
+      // Add 50 custom nodes
+      for (var i = 0; i < nodeCount; i++) {
+        final result =
+            await notifier.addCustomNode(makePubkey(i), name: 'Node $i');
+        expect(result, true, reason: 'Failed to add node $i');
+      }
+
+      // Verify state has trusted + custom nodes
+      final trustedCount = Config.trustedMostroNodes.length;
+      expect(notifier.state.length, trustedCount + nodeCount);
+      expect(notifier.customNodes.length, nodeCount);
+      expect(notifier.trustedNodes.length, trustedCount);
+
+      // Verify persistence: create a new notifier with same backing store
+      final notifier2 = createNotifier();
+      await notifier2.init();
+      expect(notifier2.customNodes.length, nodeCount);
+
+      // Verify all pubkeys are present and unique
+      final pubkeys = notifier2.customNodes.map((n) => n.pubkey).toSet();
+      expect(pubkeys.length, nodeCount);
+      for (var i = 0; i < nodeCount; i++) {
+        expect(pubkeys, contains(makePubkey(i)));
+      }
+    });
+
+    test('selectedNode lookup with last node in large list', () async {
+      final notifier = createNotifier();
+      await notifier.init();
+
+      // Add 50 custom nodes
+      for (var i = 0; i < nodeCount; i++) {
+        await notifier.addCustomNode(makePubkey(i), name: 'Node $i');
+      }
+
+      // Select the last custom node
+      final lastPubkey = makePubkey(nodeCount - 1);
+      await notifier.selectNode(lastPubkey);
+
+      expect(notifier.selectedNode, isNotNull);
+      expect(notifier.selectedNode!.pubkey, lastPubkey);
+      expect(notifier.selectedNode!.name, 'Node ${nodeCount - 1}');
+      expect(mockSettingsNotifier.state.mostroPublicKey, lastPubkey);
+    });
+
+    test('remove node from middle of large list', () async {
+      final notifier = createNotifier();
+      await notifier.init();
+
+      // Add 50 custom nodes
+      for (var i = 0; i < nodeCount; i++) {
+        await notifier.addCustomNode(makePubkey(i), name: 'Node $i');
+      }
+
+      // Remove node from the middle (node 25)
+      final middleIndex = nodeCount ~/ 2;
+      final middlePubkey = makePubkey(middleIndex);
+      final result = await notifier.removeCustomNode(middlePubkey);
+      expect(result, true);
+
+      // Verify list integrity
+      expect(notifier.customNodes.length, nodeCount - 1);
+      expect(
+        notifier.customNodes.any((n) => n.pubkey == middlePubkey),
+        false,
+        reason: 'Removed node should not be in list',
+      );
+
+      // Verify surrounding nodes still present
+      expect(
+        notifier.customNodes.any((n) => n.pubkey == makePubkey(middleIndex - 1)),
+        true,
+      );
+      expect(
+        notifier.customNodes.any((n) => n.pubkey == makePubkey(middleIndex + 1)),
+        true,
+      );
+
+      // Verify persistence after removal
+      final notifier2 = createNotifier();
+      await notifier2.init();
+      expect(notifier2.customNodes.length, nodeCount - 1);
+      expect(
+        notifier2.customNodes.any((n) => n.pubkey == middlePubkey),
+        false,
+      );
+    });
+
+    test('batch metadata update for all nodes', () async {
+      final notifier = createNotifier();
+      await notifier.init();
+
+      // Add 50 custom nodes
+      for (var i = 0; i < nodeCount; i++) {
+        await notifier.addCustomNode(makePubkey(i), name: 'Node $i');
+      }
+
+      final totalNodes = notifier.state.length;
+
+      // Update metadata for every node (trusted + custom)
+      for (final node in notifier.state) {
+        notifier.updateNodeMetadata(
+          node.pubkey,
+          name: 'Updated ${node.pubkey.substring(0, 8)}',
+          picture: 'https://example.com/avatar/${node.pubkey.substring(0, 8)}.png',
+          about: 'About node ${node.pubkey.substring(0, 8)}',
+        );
+      }
+
+      // Verify all nodes updated
+      expect(notifier.state.length, totalNodes);
+      for (final node in notifier.state) {
+        expect(node.name, startsWith('Updated '));
+        expect(node.picture, startsWith('https://'));
+        expect(node.about, startsWith('About node '));
+      }
+
+      // Verify trusted node metadata updated too
+      final trustedNode =
+          notifier.state.firstWhere((n) => n.pubkey == trustedPubkey);
+      expect(trustedNode.name, startsWith('Updated '));
+      expect(trustedNode.picture, isNotNull);
+    });
+
+    test('init with $nodeCount pre-existing nodes completes promptly',
+        () async {
+      // Pre-populate storage with 50 custom nodes (simulating existing data)
+      final notifier1 = createNotifier();
+      await notifier1.init();
+      for (var i = 0; i < nodeCount; i++) {
+        await notifier1.addCustomNode(makePubkey(i), name: 'Existing $i');
+      }
+
+      // Verify storage was populated
+      expect(
+        storage[SharedPreferencesKeys.mostroCustomNodes.value],
+        isNotNull,
+      );
+
+      // Measure init with many pre-existing nodes
+      final stopwatch = Stopwatch()..start();
+      final notifier2 = createNotifier();
+      await notifier2.init();
+      stopwatch.stop();
+
+      // Verify all loaded correctly
+      expect(notifier2.customNodes.length, nodeCount);
+      expect(notifier2.state.length,
+          Config.trustedMostroNodes.length + nodeCount);
+
+      // Sanity check: init should complete in well under 1 second
+      expect(stopwatch.elapsedMilliseconds, lessThan(1000),
+          reason: 'init() with $nodeCount nodes took too long: '
+              '${stopwatch.elapsedMilliseconds}ms');
+    });
+  });
+}


### PR DESCRIPTION
Add performance/stress tests with 50 custom nodes covering add/persist, selectedNode lookup, mid-list removal, batch metadata update, and init timing. Update CLAUDE.md with multi-Mostro architecture section. Expand Phase 5 documentation in MULTI_MOSTRO_SUPPORT.md with implementation details and updated test coverage (74 total).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completed multi-Mostro instance support, enabling seamless connection to and switching between multiple nodes with persistent configuration.

* **Documentation**
  * Updated documentation marking the multi-node feature as completed with comprehensive implementation details and workflow specifications.

* **Tests**
  * Added performance test suite (5 tests) validating stability and efficiency when managing large-scale node lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->