### PR TITLE
fix: replace Stack layout with Column in chat screen to prevent input bar overlap

### DIFF
--- a/lib/features/chat/screens/chat_room_screen.dart
+++ b/lib/features/chat/screens/chat_room_screen.dart
@@ -24,8 +24,6 @@ class ChatRoomScreen extends ConsumerStatefulWidget {
 }
 
 class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
-  // Constant for BottomNavBar height to ensure consistency
-  static const double bottomNavBarHeight = 80;
   String? _selectedInfoType; // null, 'trade', or 'user'
 
   // Scroll controller for the chat messages list
@@ -112,121 +110,80 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
         ),
       ),
       resizeToAvoidBottomInset: true, // Resize when keyboard appears
-      body: RefreshIndicator(
-        onRefresh: () async {},
-        child: Stack(
-          children: [
-            // Main content area
-            Padding(
-              padding: EdgeInsets.only(
-                  // Dynamic bottom padding based on device settings
-                  bottom: MediaQuery.textScalerOf(context).scale(1.0) > 1.0
-                      ? bottomNavBarHeight +
-                          40 // More padding for zoomed-in text
-                      : bottomNavBarHeight +
-                          10), // Normal padding for regular view
-              child: Column(
-                children: [
-                  // Header with peer information
-                  PeerHeader(peerPubkey: peer, session: session),
+      body: Column(
+        children: [
+          // Header with peer information
+          PeerHeader(peerPubkey: peer, session: session),
 
-                  // Info buttons
-                  InfoButtons(
-                    selectedInfoType: _selectedInfoType,
-                    onInfoTypeChanged: (type) {
-                      // Dismiss keyboard when selecting info tabs to prevent overlap
-                      if (type != null) {
-                        FocusScope.of(context).unfocus();
-                      }
-                      setState(() {
-                        _selectedInfoType = type;
-                      });
-                    },
-                  ),
+          // Info buttons
+          InfoButtons(
+            selectedInfoType: _selectedInfoType,
+            onInfoTypeChanged: (type) {
+              // Dismiss keyboard when selecting info tabs to prevent overlap
+              if (type != null) {
+                FocusScope.of(context).unfocus();
+              }
+              setState(() {
+                _selectedInfoType = type;
+              });
+            },
+          ),
 
-                  // Selected info content
-                  if (_selectedInfoType == 'trade')
-                    TradeInformationTab(
-                      order: order?.copyWith(status: orderState.status),
-                      orderId: widget.orderId,
-                    ),
-                  if (_selectedInfoType == 'user')
-                    UserInformationTab(peerPubkey: peer, session: session),
-
-                  // Chat area
-                  Expanded(
-                    child: Container(
-                      color: AppTheme.backgroundDark,
-                      child: Column(
-                        children: [
-                          Expanded(
-                            child: !chatNotifier.isInitialized
-                                ? const Center(
-                                    child: CircularProgressIndicator())
-                                : ChatMessagesList(
-                                    chatRoom: chatDetailState,
-                                    peerPubkey: peer,
-                                    orderId: widget.orderId,
-                                    scrollController: _scrollController,
-                                  ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+          // Selected info content
+          if (_selectedInfoType == 'trade')
+            TradeInformationTab(
+              order: order?.copyWith(status: orderState.status),
+              orderId: widget.orderId,
             ),
+          if (_selectedInfoType == 'user')
+            UserInformationTab(peerPubkey: peer, session: session),
 
-            // Message input positioned above BottomNavBar with padding
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: MediaQuery.of(context).viewInsets.bottom > 0
-                  ? 0 // When keyboard is open, position at bottom
-                  : bottomNavBarHeight, // Use constant for BottomNavBar height
-              child: Container(
-                decoration: BoxDecoration(
-                  color: AppTheme.backgroundDark, // Match background color
-                  border: Border(
-                    top: BorderSide(
-                      color: Colors.grey.withValues(
-                          alpha: 0.03), // 0.03 opacity - extremely subtle
-                      width: 0.3, // Even thinner line
-                    ),
+          // Chat area
+          Expanded(
+            child: !chatNotifier.isInitialized
+                ? const Center(child: CircularProgressIndicator())
+                : ChatMessagesList(
+                    chatRoom: chatDetailState,
+                    peerPubkey: peer,
+                    orderId: widget.orderId,
+                    scrollController: _scrollController,
                   ),
-                ),
-                child: MessageInput(
-                  orderId: widget.orderId,
-                  selectedInfoType: _selectedInfoType,
-                  onInfoTypeChanged: (type) {
-                    // Dismiss keyboard when selecting info tabs to prevent overlap
-                    if (type != null) {
-                      FocusScope.of(context).unfocus();
-                    }
-                    setState(() {
-                      _selectedInfoType = type;
-                    });
-                  },
+          ),
+
+          // Message input
+          Container(
+            decoration: BoxDecoration(
+              color: AppTheme.backgroundDark,
+              border: Border(
+                top: BorderSide(
+                  color: Colors.grey.withValues(alpha: 0.03),
+                  width: 0.3,
                 ),
               ),
             ),
-
-            // Position BottomNavBar at the bottom of the screen
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              child: MediaQuery.of(context).viewInsets.bottom > 0
-                  ? const SizedBox() // Hide BottomNavBar when keyboard is open
-                  : SafeArea(
-                      top: false,
-                      bottom: true,
-                      child: const BottomNavBar(),
-                    ),
+            child: MessageInput(
+              orderId: widget.orderId,
+              selectedInfoType: _selectedInfoType,
+              onInfoTypeChanged: (type) {
+                // Dismiss keyboard when selecting info tabs to prevent overlap
+                if (type != null) {
+                  FocusScope.of(context).unfocus();
+                }
+                setState(() {
+                  _selectedInfoType = type;
+                });
+              },
             ),
-          ],
-        ),
+          ),
+
+          // Bottom nav bar (hidden when keyboard is open)
+          if (!isKeyboardVisible)
+            SafeArea(
+              top: false,
+              bottom: true,
+              child: const BottomNavBar(),
+            ),
+        ],
       ),
     );
   }

--- a/lib/features/chat/widgets/chat_messages_list.dart
+++ b/lib/features/chat/widgets/chat_messages_list.dart
@@ -117,16 +117,11 @@ class _ChatMessagesListState extends State<ChatMessagesList> {
         // Add caching for better performance with many messages
         cacheExtent: 1000,
         // Add padding to prevent messages from being cut off
-        padding: EdgeInsets.only(
+        padding: const EdgeInsets.only(
           top: 12,
           left: 12,
           right: 12,
-          // Dynamic bottom padding based on device size and accessibility settings
-          bottom: MediaQuery.of(context).viewInsets.bottom > 0 
-              ? 80 // Less padding when keyboard is open
-              : MediaQuery.textScalerOf(context).scale(1.0) > 1.0
-                  ? 120 // More padding for zoomed-in text
-                  : 80, // Normal padding for regular view
+          bottom: 12,
         ),
         itemBuilder: (context, index) {
           final message = sortedMessages[index];

--- a/lib/features/chat/widgets/message_input.dart
+++ b/lib/features/chat/widgets/message_input.dart
@@ -301,11 +301,11 @@ class _MessageInputState extends ConsumerState<MessageInput> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Padding(
-            padding: EdgeInsets.only(
+            padding: const EdgeInsets.only(
               left: 16,
               right: 16,
               top: 12,
-              bottom: 12 + MediaQuery.of(context).padding.bottom,
+              bottom: 12,
             ),
             child: Row(
               children: [


### PR DESCRIPTION
fix #465 

  - Replace Stack+Positioned layout with Column-based layout in ChatRoomScreen
  - Remove hardcoded bottomNavBarHeight constant and compensatory padding calculations
  - Simplify ChatMessagesList bottom padding from 80-120px to uniform 12px
  - Remove redundant safe area padding from MessageInput widget
  - Matches the pattern already used in DisputeChatScreen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized chat room interface layout for improved usability and cleaner structure
  * Bottom navigation bar now hides when the keyboard is open, maximizing visible chat content during message composition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->