### PR TITLE
fix: prevent restore crash and revert loop on node switching

### DIFF
--- a/lib/features/mostro/widgets/mostro_node_selector.dart
+++ b/lib/features/mostro/widgets/mostro_node_selector.dart
@@ -7,7 +7,6 @@ import 'package:mostro_mobile/features/mostro/widgets/add_custom_node_dialog.dar
 import 'package:mostro_mobile/features/mostro/widgets/mostro_node_avatar.dart';
 import 'package:mostro_mobile/features/mostro/widgets/trusted_badge.dart';
 import 'package:mostro_mobile/features/restore/restore_manager.dart';
-import 'package:mostro_mobile/features/restore/restore_progress_notifier.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
@@ -317,15 +316,6 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
         final success = await restoreService.initRestoreProcess();
 
         if (!success) {
-          // Hide error overlay from failed restore
-          ref.read(restoreProgressProvider.notifier).hide();
-
-          // Revert settings to old node
-          await notifier.selectNode(oldPubkey);
-
-          // Re-restore old node's data (since _clearAll already wiped it)
-          await restoreService.initRestoreProcess();
-
           if (mounted) {
             setState(() {
               _isSwitching = false;
@@ -337,7 +327,7 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
             messenger: messenger,
             screenHeight: mediaQuery.size.height,
             statusBarHeight: mediaQuery.padding.top,
-            message: localizations.nodeNotRespondingReverted,
+            message: localizations.errorSwitchingNode,
           );
           return;
         }

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -296,9 +296,25 @@ class RestoreService {
       final contentList = jsonDecode(rumor.content!) as List<dynamic>;
       final messageData = contentList[0] as Map<String, dynamic>;
 
+      // Check if Mostro returned cant-do
+      if (messageData.containsKey('cant-do')) {
+        logger.w('Restore: Mostro returned cant-do for orders details');
+        return OrdersResponse(orders: []);
+      }
+
       // Extract payload from order wrapper
-      final orderWrapper = messageData['order'] as Map<String, dynamic>;
-      final payload = orderWrapper['payload'] as Map<String, dynamic>;
+      final orderWrapper = messageData['order'] as Map<String, dynamic>?;
+      if (orderWrapper == null) {
+        logger.w('Restore: no order wrapper found, returning empty response');
+        return OrdersResponse(orders: []);
+      }
+
+      final payload = orderWrapper['payload'] as Map<String, dynamic>?;
+      if (payload == null) {
+        logger.w(
+            'Restore: no payload in order wrapper, returning empty response');
+        return OrdersResponse(orders: []);
+      }
 
       final ordersResponse = OrdersResponse.fromJson(payload);
 


### PR DESCRIPTION
Add null-safety to _extractOrdersDetails() in RestoreService to handle unexpected null values from Mostro responses, matching the defensive pattern already used in _extractRestoreData().

Remove the revert-on-failure logic in MostroNodeSelector that caused a loop: when restore failed, reverting to the old (potentially offline) node triggered a second restore that also failed, leaving the user stuck with wiped data. Now the user stays on the new node and sees an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging during node switching operations to provide clearer feedback when connection issues occur
  * Improved application stability by adding comprehensive validation and null-safety checks to message parsing logic, preventing potential crashes from incomplete or malformed data structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->