### PR TITLE
docs: add technical plan for dispute chat shared key and multimedia support

### DIFF
--- a/docs/DISPUTE_CHAT_MULTIMEDIA_PLAN.md
+++ b/docs/DISPUTE_CHAT_MULTIMEDIA_PLAN.md
@@ -86,7 +86,7 @@ Currently the app has two completely different chat mechanisms:
 
 **File:** `test/features/disputes/dispute_shared_key_test.dart`
 
-```
+```text
 group('Dispute Shared Key Computation')
   test('computes identical shared key from both sides (user and admin)')
     - Derive two key pairs (simulate user trade key and admin key)
@@ -105,7 +105,7 @@ group('Dispute Shared Key Computation')
 
 **File:** `test/data/models/nostr_event_wrap_test.dart`
 
-```
+```text
 group('p2pWrap / p2pUnwrap round-trip')
   test('wraps and unwraps a text message correctly')
     - Create a kind 1 inner event with known content
@@ -206,7 +206,7 @@ This is identical to `ChatRoomNotifier.getSharedKey()` — consider extracting t
 
 **File:** `test/features/disputes/dispute_chat_notifier_test.dart`
 
-```
+```text
 group('DisputeChatNotifier message model')
   test('stores unwrapped NostrEvent after receiving message')
     - Mock a gift wrap event arriving
@@ -363,7 +363,7 @@ Plus `getCachedImage()`, `cacheDecryptedImage()`, `getCachedFile()`, `cacheDecry
 
 **File:** `test/features/disputes/dispute_multimedia_rendering_test.dart`
 
-```
+```text
 group('Dispute chat message type detection')
   test('detects encrypted image message from NostrEvent content')
     - Create NostrEvent with content = jsonEncode({"type":"image_encrypted",...})
@@ -389,7 +389,7 @@ group('Decoupled EncryptedImageMessage / EncryptedFileMessage')
 
 **File:** `test/features/chat/widgets/encrypted_image_message_test.dart` (regression)
 
-```
+```text
 group('P2P EncryptedImageMessage regression after decoupling')
   test('still works with chatRoomsProvider-based callbacks')
     - Verify existing P2P rendering still functions after refactor
@@ -467,7 +467,7 @@ Both `MessageInput` and `DisputeMessageInput` call this helper, passing their re
 
 **File:** `test/features/disputes/dispute_file_upload_test.dart`
 
-```
+```text
 group('Dispute chat file upload')
   test('encrypts image with admin shared key and uploads to Blossom')
     - Use real crypto keys (KeyDerivator with test mnemonic)
@@ -559,7 +559,7 @@ These methods are also used for regular Mostro protocol messages (user <-> Mostr
 
 **File:** `test/shared/utils/nostr_utils_shared_key_test.dart`
 
-```
+```text
 group('NostrUtils.sharedKeyToBytes')
   test('converts 64-char hex to 32-byte Uint8List')
   test('throws on invalid hex length')
@@ -568,7 +568,7 @@ group('NostrUtils.sharedKeyToBytes')
 
 **File:** `test/shared/mixins/media_cache_mixin_test.dart`
 
-```
+```text
 group('MediaCacheMixin')
   test('caches and retrieves image data by messageId')
   test('caches and retrieves file data by messageId')


### PR DESCRIPTION
  Technical plan for migrating dispute chat (user-admin) from direct gift wrap encryption to shared key (ECDH), unifying it with the P2P chat mechanism, and enabling multimedia (images/files) via Blossom servers.                
   
  ### Phases                                                                                                          
  - **Phase 1:** Switch dispute chat to shared key encryption (protocol change, coordinate with admin dev)
  - **Phase 2:** Unify message model from `DisputeChat` to `NostrEvent` (internal refactor)
  - **Phase 3:** Render multimedia in dispute chat (decouple widgets, reuse P2P rendering)
  - **Phase 4:** Send multimedia from dispute chat (attachment button, upload flow)
  - **Phase 5:** Code cleanup and deduplication (extract shared utilities, remove dead code)

  Each phase = 1 PR, with tests and manual testing checklist.

  Full plan: `docs/DISPUTE_CHAT_MULTIMEDIA_PLAN.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive roadmap for dispute chat improvements: phased rollout for shared-key encryption, unified message model, multimedia rendering and sending, attachment/encryption flows, testing and acceptance criteria, timelines, risk notes, and coordination guidance for staged deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->