### PR TITLE
add HalCash, remove SEPA payment method

### DIFF
--- a/assets/data/payment_methods.json
+++ b/assets/data/payment_methods.json
@@ -9,7 +9,7 @@
   "CRC": ["Bank transfer (IBAN)", "SINPE Móvil", "Cash"],
   "COP": ["Nequi", "Daviplata", "PSE", "Llaves BRE-B", "Transferencia bancaria", "Efectivo"],
   "CUP": ["Transfermovil", "EnZona", "Tarjeta Clásica", "Saldo móvil", "MiTransfer", "Efectivo"],
-  "EUR": ["SEPA", "Revolut", "Bank Transfer", "Wise", "SEPA instant", "Bizum", "SEPA bank transfer", "Payoneer", "Cash"],
+  "EUR": ["Revolut", "HalCash", "Bank Transfer", "Wise", "SEPA instant", "Bizum", "Payoneer", "Cash"],
   "GBP": ["Revolut", "Monzo", "Wise", "Any national bank", "Bank Transfer", "Cash"],
   "JPY": ["PayPay", "Bank Transfer", "Cash"],
   "MLC": ["Transfermovil", "EnZona"],


### PR DESCRIPTION
SEPA is being eliminated because it's a transfer that can take more than 24 hours, SEPA Instant is being retained in its place.
Additionally, the HalCash method is being added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Payment Methods**
  * HalCash is now available for EUR transactions
  * SEPA and SEPA bank transfer are no longer available for EUR payments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->