### PR TITLE
Fix BIP-340 signature bug by overriding bip340 to 0.2.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,13 +130,13 @@ packages:
     source: hosted
     version: "1.0.0"
   bip340:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: bip340
-      sha256: "9a2f454d3f5e2d67a1b21494203132786d95bde8784e7ada74adac00df3ddc11"
+      sha256: "2a92f6ed68959f75d67c9a304c17928b9c9449587d4f75ee68f34152f7f69e87"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   bip39:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,6 +105,9 @@ dependencies:
   firebase_messaging: ^16.1.0
 
 
+dependency_overrides:
+  bip340: ^0.2.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
fix #491 #276

dart_nostr 9.1.1 depends on bip340 0.1.0, which has a bug in bigToBytes() that doesn't pad values to 32 bytes. This causes about 1-2% of Schnorr signatures to be invalid, and 100% failure for keys whose public key starts with 0x00.

The bug was fixed upstream in bip340 0.2.0. We can't go higher than 0.2.0 because version 0.3.0+ changed verify() from String? to String, which breaks dart_nostr's nullable parameter and won't compile.

bip340 0.2.0 has the same API as 0.1.0, just with the padding fix applied. All 218 tests pass.

The override can be removed when dart_nostr updates its bip340 dependency or when we migrate to a different nostr library.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency configuration to ensure compatibility and proper dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->