### PR TITLE
fix: P2P chat messages with images block rendering until download completes

### DIFF
--- a/lib/features/chat/notifiers/chat_room_notifier.dart
+++ b/lib/features/chat/notifiers/chat_room_notifier.dart
@@ -22,6 +22,11 @@ import 'package:mostro_mobile/shared/mixins/media_cache_mixin.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
+  static final EncryptedImageUploadService _imageUploadService =
+      EncryptedImageUploadService();
+  static final EncryptedFileUploadService _fileUploadService =
+      EncryptedFileUploadService();
+
   /// Reload the chat room by re-subscribing to events.
   void reload() {
     // Cancel the current subscription if it exists
@@ -151,10 +156,7 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       }
 
       final chat = await event.p2pUnwrap(session.sharedKey!);
-      
-      // Process special message types (e.g., encrypted images)
-      await _processMessageContent(chat);
-      
+
       // Check if message already exists to prevent duplicates
       final messageExists = state.messages.any((m) => m.id == chat.id);
       if (!messageExists) {
@@ -166,6 +168,9 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       } else {
         logger.d('Message already exists in state, skipping duplicate');
       }
+
+      // Fire-and-forget: pre-download media after message is in state
+      unawaited(_processMessageContent(chat));
 
       // Notify the chat rooms list to update when new messages arrive
       try {
@@ -436,8 +441,7 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       final sharedKey = await getSharedKey();
       
       // Download and decrypt image in background
-      final uploadService = EncryptedImageUploadService();
-      final decryptedImage = await uploadService.downloadAndDecryptImage(
+      final decryptedImage = await _imageUploadService.downloadAndDecryptImage(
         blossomUrl: result.blossomUrl,
         sharedKey: sharedKey,
       );
@@ -476,8 +480,7 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
           final sharedKey = await getSharedKey();
           
           // Download and decrypt image in background
-          final uploadService = EncryptedFileUploadService();
-          final decryptedFile = await uploadService.downloadAndDecryptFile(
+          final decryptedFile = await _fileUploadService.downloadAndDecryptFile(
             blossomUrl: result.blossomUrl,
             sharedKey: sharedKey,
           );

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -75,6 +75,11 @@ class DisputeChatState {
 /// Uses shared key encryption (p2pWrap/p2pUnwrap) with admin via ECDH.
 /// Stores gift wrap events (encrypted) on disk, same pattern as P2P chat.
 class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCacheMixin {
+  static final EncryptedImageUploadService _imageUploadService =
+      EncryptedImageUploadService();
+  static final EncryptedFileUploadService _fileUploadService =
+      EncryptedFileUploadService();
+
   final String disputeId;
   final Ref ref;
 
@@ -446,8 +451,7 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
     try {
       final result = EncryptedImageUploadResult.fromJson(imageData);
       final sharedKey = await getAdminSharedKey();
-      final uploadService = EncryptedImageUploadService();
-      final decryptedImage = await uploadService.downloadAndDecryptImage(
+      final decryptedImage = await _imageUploadService.downloadAndDecryptImage(
         blossomUrl: result.blossomUrl,
         sharedKey: sharedKey,
       );
@@ -463,8 +467,7 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       if (result.fileType == 'image') {
         try {
           final sharedKey = await getAdminSharedKey();
-          final uploadService = EncryptedFileUploadService();
-          final decryptedFile = await uploadService.downloadAndDecryptFile(
+          final decryptedFile = await _fileUploadService.downloadAndDecryptFile(
             blossomUrl: result.blossomUrl,
             sharedKey: sharedKey,
           );


### PR DESCRIPTION
fix #517 
  - Fix blocking `await` in `ChatRoomNotifier._onChatEvent()` that prevented P2P chat messages with encrypted images  
  from appearing until download completed                                                                             
  - Extract `EncryptedImageUploadService` and `EncryptedFileUploadService` to static fields in both `ChatRoomNotifier` and `DisputeChatNotifier` for consistency with `ChatFileUploadHelper` pattern                                      
   
  ### How to test it                                         
**P2P chat image rendering (main fix)**                                                                             
  - Open a P2P chat with a counterpart
  - Have the counterpart send an encrypted image                                                                  
  - **Expected:** Message appears immediately in the chat with a loading spinner ("Decrypting image...")
  - **Expected:** Once download completes, the spinner is replaced by the actual image                            
  - **Previously:** Message was invisible until the image fully downloaded and decrypted                          
                                                                                                                      
 **Slow connection test**                                                                                            
  - Enable network throttling or use a slow connection                                                            
  - Receive an encrypted image in P2P chat                                                                        
  - **Expected:** Message bubble visible within ~1 second, image loads progressively in background                
  - **Previously:** Chat appeared frozen for several seconds with no feedback                                     
                                                                                                                      
**Regression checks**                                                                                               
  - Send and receive text-only P2P messages — should work as before                                               
  - Send and receive encrypted images in **dispute chat** — should work as before (dispute chat already used      
  `unawaited()`)                                                                                                      
  - Verify images are cached after first load (scrolling away and back should show image instantly)               
  - App restart: historical messages with images should load correctly        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized image and file upload service management across chat and dispute messaging features for consistency.
  * Updated message processing flow in the chat module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->