### PR TITLE
Replace the outdated protocol documentation with the most up-to-date version

### DIFF
--- a/docs/protocol/SUMMARY.md
+++ b/docs/protocol/SUMMARY.md
@@ -2,12 +2,15 @@
 
 [Home](./overview.md)
 
+---
+
 - [Keys management](./key_management.md)
 - [Creating a Sell order](./new_sell_order.md)
 - [Creating a Sell range order](./new_sell_range_order.md)
 - [Creating a Buy order](./new_buy_order.md)
 - [Creating a Buy order with a LN address](./new_buy_order_ln_address.md)
 - [List orders](./list_orders.md)
+- [Request order details](./orders.md)
 - [Take sell order](./take_sell.md)
 - [Take sell order with a LN address](./take_sell_ln_address.md)
 - [Take range sell order](./take_sell_range_order.md)
@@ -18,13 +21,15 @@
 - [Release](./release.md)
 - [Rate user](./user_rating.md)
 - [Cancel](./cancel.md)
-- [Dispute](./dispute.md)
 - [Peer-to-peer Chat](./chat.md)
+- [Dispute](./dispute.md)
+- [Dispute Chat](./dispute_chat.md)
 - [List disputes](./list_disputes.md)
 - [Admin Settle order](./admin_settle_order.md)
 - [Admin Cancel order](./admin_cancel_order.md)
 - [Admin Add Solver](./admin_add_solver.md)
 - [Restore session](./restore_session.md)
+- [Last Trade Index](./last_trade_index.md)
 - [Actions](./actions.md)
   - [Message suggestions for actions](./message_suggestions_for_actions.md)
 - [P2P Order event. NIP-69](./order_event.md)

--- a/docs/protocol/admin_add_solver.md
+++ b/docs/protocol/admin_add_solver.md
@@ -9,15 +9,18 @@ The administrator can also solve disputes.
 To add a solver the admin will need to send an `order` message to Mostro with action `admin-add-solver`:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "action": "admin-add-solver",
-    "payload": {
-      "text_message": "npub1qqq884wtp2jn96lqhqlnarl4kk3rmvrc9z2nmrvqujx3m4l2ea5qd5d0fq"
+[
+  {
+    "order": {
+      "version": 1,
+      "action": "admin-add-solver",
+      "payload": {
+        "text_message": "npub1qqq884wtp2jn96lqhqlnarl4kk3rmvrc9z2nmrvqujx3m4l2ea5qd5d0fq"
+      }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 ## Mostro response
@@ -25,11 +28,14 @@ To add a solver the admin will need to send an `order` message to Mostro with ac
 Mostro will send this message to the admin:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "action": "admin-add-solver",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "action": "admin-add-solver",
+      "payload": null
+    }
+  },
+  null
+]
 ```

--- a/docs/protocol/admin_cancel_order.md
+++ b/docs/protocol/admin_cancel_order.md
@@ -3,14 +3,17 @@
 An admin can cancel an order, most of the time this is done when admin is solving a dispute, for this the admin will need to send an `order` message to Mostro with action `admin-cancel` with the `id` of the order like this:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "admin-cancel",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "admin-cancel",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 ## Mostro response
@@ -18,14 +21,17 @@ An admin can cancel an order, most of the time this is done when admin is solvin
 Mostro will send this message to the both parties buyer/seller and to the admin:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "admin-canceled",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "admin-canceled",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 ## Mostro updates addressable events
@@ -68,7 +74,7 @@ The second event updates the addressable dispute event with status `seller-refun
     "id": "098e8622eae022a79bc793984fccbc5ea3f6641bdcdffaa031c00d3bd33ca5a0",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703274022,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "efc75871-2568-40b9-a6ee-c382d4d6de01"],
       ["s", "seller-refunded"],

--- a/docs/protocol/admin_settle_order.md
+++ b/docs/protocol/admin_settle_order.md
@@ -3,14 +3,17 @@
 An admin can settle an order, most of the time this is done when admin is solving a dispute, for this the admin will need to send an `order` message to Mostro with action `admin-settle` with the `id` of the order like this:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "admin-settle",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "admin-settle",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 ## Mostro response
@@ -18,14 +21,17 @@ An admin can settle an order, most of the time this is done when admin is solvin
 Mostro will send this message to the both parties buyer/seller and to the admin:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "admin-settled",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "admin-settled",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 ## Mostro updates addressable dispute event
@@ -40,7 +46,7 @@ Mostro updates the addressable dispute event with status `settled`:
     "id": "098e8622eae022a79bc793984fccbc5ea3f6641bdcdffaa031c00d3bd33ca5a0",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703274022,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "efc75871-2568-40b9-a6ee-c382d4d6de01"],
       ["s", "settled"],

--- a/docs/protocol/cancel.md
+++ b/docs/protocol/cancel.md
@@ -34,7 +34,7 @@ Mostro will send a message with action `cancel` confirming the order was cancele
 ]
 ```
 
-Mostro updates the parameterized replaceable event with `d` tag `<Order Id>` to change the status to `canceled`:
+Mostro updates the addressable event with `d` tag `<Order Id>` to change the status to `canceled`:
 
 ```json
 [
@@ -71,68 +71,83 @@ Mostro updates the parameterized replaceable event with `d` tag `<Order Id>` to 
 A user can cancel an `active` order, but will need the counterparty to agree, let's look at an example where the seller initiates a cooperative cancellation:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "cancel",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "cancel",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 Mostro will send this message to the seller:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "cooperative-cancel-initiated-by-you",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "cooperative-cancel-initiated-by-you",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 And this message to the buyer:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "cooperative-cancel-initiated-by-peer",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "cooperative-cancel-initiated-by-peer",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 The buyer can accept the cooperative cancellation sending this message:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "cancel",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "cancel",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 And Mostro will send this message to both parties:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "cooperative-cancel-accepted",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "cooperative-cancel-accepted",
+      "payload": null
+    }
+  },
+  null
+]
 ```
-Mostro updates the parameterized replaceable event with `d` tag `<Order Id>` to change the status to `canceled`:
+Mostro updates the addressable event with `d` tag `<Order Id>` to change the status to `canceled`:
 
 ```json
 [
@@ -152,6 +167,9 @@ Mostro updates the parameterized replaceable event with `d` tag `<Order Id>` to 
       ["fa", "100"],
       ["pm", "face to face"],
       ["premium", "1"],
+      ["network", "mainnet"],
+      ["layer", "lightning"],
+      ["expiration", "1719391096"],
       ["y", "mostro"],
       ["z", "order"]
     ],

--- a/docs/protocol/dispute.md
+++ b/docs/protocol/dispute.md
@@ -1,6 +1,6 @@
 # Dispute
 
-A use can start a dispute in an order with status `active` or `fiat-sent` sending action `dispute`, here is an example where the seller initiates a dispute:
+A user can start a dispute in an order with status `active` or `fiat-sent` sending action `dispute`, here is an example where the seller initiates a dispute:
 
 ```json
 [
@@ -56,7 +56,7 @@ And here is the message to the buyer:
 
 Mostro will not update the addressable event with `d` tag `<Order Id>` to change the status to `dispute`, this is because the order is still active, the dispute is just a way to let the admins and the other party know that there is a problem with the order.
 
-## Mostro send a addressable event to show the dispute
+## Mostro sends an addressable event to show the dispute
 
 Here is an example of the event sent by Mostro:
 
@@ -68,10 +68,11 @@ Here is an example of the event sent by Mostro:
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703016565,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "<Dispute Id>"],
       ["s", "initiated"],
+      ["initiator", "seller"], // seller or buyer
       ["y", "mostro"],
       ["z", "dispute"]
     ],
@@ -84,45 +85,51 @@ Here is an example of the event sent by Mostro:
 Mostro admin will see the dispute and can take it using the dispute `Id` from `d` tag, here how should look the message sent by the admin:
 
 ```json
-{
-  "dispute": {
-    "version": 1,
-    "id": "<Dispute Id>",
-    "action": "admin-take-dispute",
-    "payload": null
-  }
-}
+[
+  {
+    "dispute": {
+      "version": 1,
+      "id": "<Dispute Id>",
+      "action": "admin-take-dispute",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 Mostro will send a confirmation message to the admin with the order details:
 
 ```json
-{
-  "dispute": {
-    "version": 1,
-    "id": "<Dispute Id>",
-    "action": "admin-took-dispute",
-    "payload": {
-      "order": {
-        "id": "<Order Id>",
-        "kind": "sell",
-        "status": "active",
-        "amount": 7851,
-        "fiat_code": "VES",
-        "fiat_amount": 100,
-        "payment_method": "face to face",
-        "premium": 1,
-        "master_buyer_pubkey": "<Buyer's trade pubkey>",
-        "master_seller_pubkey": "<Seller's trade pubkey>",
-        "buyer_invoice": "lnbcrt11020n1pjcypj3pp58m3d9gcu4cc8l3jgkpfn7zhqv2jfw7p3t6z3tq2nmk9cjqam2c3sdqqcqzzsxqyz5vqsp5mew44wzjs0a58d9sfpkrdpyrytswna6gftlfrv8xghkc6fexu6sq9qyyssqnwfkqdxm66lxjv8z68ysaf0fmm50ztvv773jzuyf8a5tat3lnhks6468ngpv3lk5m7yr7vsg97jh6artva5qhd95vafqhxupyuawmrcqnthl9y",
-        "created_at": 1698870173
+[
+  {
+    "dispute": {
+      "version": 1,
+      "id": "<Dispute Id>",
+      "action": "admin-took-dispute",
+      "payload": {
+        "order": {
+          "id": "<Order Id>",
+          "kind": "sell",
+          "status": "active",
+          "amount": 7851,
+          "fiat_code": "VES",
+          "fiat_amount": 100,
+          "payment_method": "face to face",
+          "premium": 1,
+          "buyer_trade_pubkey": "<Buyer's trade pubkey>",
+          "seller_trade_pubkey": "<Seller's trade pubkey>",
+          "buyer_invoice": "lnbcrt11020n1pjcypj3pp58m3d9gcu4cc8l3jgkpfn7zhqv2jfw7p3t6z3tq2nmk9cjqam2c3sdqqcqzzsxqyz5vqsp5mew44wzjs0a58d9sfpkrdpyrytswna6gftlfrv8xghkc6fexu6sq9qyyssqnwfkqdxm66lxjv8z68ysaf0fmm50ztvv773jzuyf8a5tat3lnhks6468ngpv3lk5m7yr7vsg97jh6artva5qhd95vafqhxupyuawmrcqnthl9y",
+          "created_at": 1698870173
+        }
       }
     }
-  }
-}
+  },
+  null
+]
 ```
 
-Then mostrod send messages to each trade participat, the buyer and seller for them to know the pubkey of the admin who took the dispute, that way the client can start listening events from that specific pubkey, by default clients should discard any messages received from any pubkey different than Mostro node or dispute solver, the message looks like this:
+Then mostrod send messages to each trade participant, the buyer and seller for them to know the pubkey of the admin who took the dispute, that way the client can start listening events from that specific pubkey, by default clients should discard any messages received from any pubkey different than Mostro node or dispute solver, the message looks like this:
 
 ```json
 [
@@ -152,10 +159,11 @@ Also Mostro will broadcast a new addressable dispute event to update the dispute
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703020540,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "<Dispute Id>"],
       ["s", "in-progress"],
+      ["initiator", "seller"], // seller or buyer
       ["y", "mostro"],
       ["z", "dispute"]
     ],

--- a/docs/protocol/dispute_chat.md
+++ b/docs/protocol/dispute_chat.md
@@ -1,0 +1,70 @@
+# Dispute Chat
+
+The dispute chat uses the same shared key encryption scheme as the [Peer-to-peer Chat](./chat.md). Instead of computing a shared key between buyer and seller, each party computes an independent shared key with the admin who took the dispute.
+
+## Establishing the shared key
+
+When an admin takes a dispute, Mostro sends an `admin-took-dispute` message to each party (buyer and seller) containing the admin's pubkey:
+
+```json
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "admin-took-dispute",
+      "payload": {
+        "peer": {
+          "pubkey": "<Admin's pubkey>"
+        }
+      }
+    }
+  },
+  null
+]
+```
+
+Upon receiving this message, the client computes the shared key using ECDH:
+
+```
+Shared Key = ECDH(tradeKey.private, adminPubkey)
+```
+
+The admin computes the same shared key from their side:
+
+```
+Shared Key = ECDH(adminPrivateKey, tradeKey.public)
+```
+
+Each party (buyer and seller) has its own independent shared key with the admin. A session can have both a peer shared key (for the P2P chat) and an admin shared key (for the dispute chat) simultaneously.
+
+## Sending and receiving messages
+
+Messages are wrapped and unwrapped using the same simplified NIP-59 scheme described in [Peer-to-peer Chat](./chat.md#example). The inner event is a kind 1 event signed by the sender's key, encrypted with NIP-44 and placed inside a kind 1059 Gift Wrap event.
+
+The `p` tag in the wrapper event points to the **admin shared key's pubkey**, not the trade key:
+
+```json
+{
+  "content": "<Encrypted content>",
+  "kind": 1059,
+  "created_at": 1703021488,
+  "pubkey": "<Ephemeral pubkey>",
+  "id": "<Event Id>",
+  "sig": "<Ephemeral key signature>",
+  "tags": [["p", "<Admin Shared Pubkey>"]]
+}
+```
+
+## Subscribing to messages
+
+Clients subscribe to kind 1059 events filtered by the admin shared key's pubkey:
+
+```json
+{
+  "kinds": [1059],
+  "#p": ["<Admin Shared Pubkey>"]
+}
+```
+
+Clients should discard any messages received from pubkeys other than the Mostro node or the dispute solver.

--- a/docs/protocol/key_management.md
+++ b/docs/protocol/key_management.md
@@ -147,7 +147,7 @@ Clients must offer a more private version where the client never send the identi
             "payload": null
           }
         },
-        null
+        null // Signature is not needed in full privacy mode
       ],
       "created_at": 1691518405,
       "tags": []

--- a/docs/protocol/last_trade_index.md
+++ b/docs/protocol/last_trade_index.md
@@ -1,0 +1,57 @@
+# Last Trade Index
+
+Defines the `last-trade-index` action used to retrieve the user's last `trade_index`.
+
+## Request
+
+Client sends a Gift wrap Nostr event to Mostro with the following rumor's content. The request sends a `null` payload to indicate that the client is querying for the last trade index.
+
+```json
+[
+  {
+    "restore": {
+      "version": 1,
+      "action": "last-trade-index",
+      "payload": null
+    }
+  },
+  null
+]
+```
+
+## Response
+
+Mostro responds with the user's last trade index as a u32 directly in the `trade_index` field. If the user has never created a trade, the value SHOULD be `1`.
+
+```json
+{
+  "restore": {
+    "version": 1,
+    "action": "last-trade-index",
+    "trade_index": 42,
+    "payload": null
+  }
+}
+```
+
+### Fields
+
+* `restore.version`: Protocol version. Current is `1`.
+* `restore.action`: Must be `last-trade-index`.
+* `restore.trade_index` (response): u32 representing the last `trade_index` for the user. `1` if none.
+* `restore.payload` (response): Must be `null`.
+
+## Example
+
+Client requests the last trade index and receives `7`, meaning the next trade the client creates SHOULD use `trade_index = 8`.
+
+```json
+{
+  "restore": {
+    "version": 1,
+    "action": "last-trade-index",
+    "trade_index": 7,
+    "payload": null
+  }
+}
+```

--- a/docs/protocol/list_disputes.md
+++ b/docs/protocol/list_disputes.md
@@ -1,6 +1,6 @@
 # Listing Disputes
 
-Mostro publishes new disputes with event kind `38383` and status `initiated`:
+Mostro publishes new disputes with event kind `38386` and status `initiated`:
 
 ```json
 [
@@ -10,7 +10,7 @@ Mostro publishes new disputes with event kind `38383` and status `initiated`:
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1703016565,
-    "kind": 38383,
+    "kind": 38386,
     "tags": [
       ["d", "<Dispute Id>"],
       ["s", "initiated"],
@@ -23,4 +23,4 @@ Mostro publishes new disputes with event kind `38383` and status `initiated`:
 ]
 ```
 
-Clients can query this events by nostr event kind `38383`, nostr event author, dispute status (`s`), type (`z`)
+Clients can query these events by nostr event kind `38386`, nostr event author, dispute status (`s`), type (`z`)

--- a/docs/protocol/message_suggestions_for_actions.md
+++ b/docs/protocol/message_suggestions_for_actions.md
@@ -144,3 +144,9 @@ Mostro also handles messages with the `CantDo` action for various reasons. The d
 
 - **out-of-range-sats-amount:**  
   The allowed Sats amount for this Mostro is between min `min_order_amount` and max `max_order_amount`. Please enter an amount within this range.
+
+- **too-many-requests:**
+  User exceeds the allowed request rate.
+
+- **invalid-fiat-currency:**
+  Prevents proceeding with unrecognized fiat currencies.

--- a/docs/protocol/new_buy_order.md
+++ b/docs/protocol/new_buy_order.md
@@ -1,30 +1,27 @@
 # Creating a new buy order
 
-To create a new buy order the user should send a Gift wrap Nostr event to Mostro with the following rumor's content:
+To create a new buy order the user should send a Gift wrap Nostr event to Mostro with the following message:
 
 ```json
-[
-  {
-    "order": {
-      "version": 1,
-      "action": "new-order",
-      "trade_index": 1,
-      "payload": {
-        "order": {
-          "kind": "buy",
-          "status": "pending",
-          "amount": 0,
-          "fiat_code": "VES",
-          "fiat_amount": 100,
-          "payment_method": "face to face",
-          "premium": 1,
-          "created_at": 0
-        }
+{
+  "order": {
+    "version": 1,
+    "action": "new-order",
+    "trade_index": 1,
+    "payload": {
+      "order": {
+        "kind": "buy",
+        "status": "pending",
+        "amount": 0,
+        "fiat_code": "VES",
+        "fiat_amount": 100,
+        "payment_method": "face to face",
+        "premium": 1,
+        "created_at": 0
       }
     }
-  },
-  "<index N signature of the sha256 hash of the serialized first element of content>"
-]
+  }
+}
 ```
 
 The nostr event will look like this:
@@ -43,7 +40,7 @@ The nostr event will look like this:
 
 ## Confirmation message
 
-Mostro will send back a nip59 event as a confirmation message, the content of the rumor looks like the following:
+Mostro will send back a nip59 event as a confirmation message, the message in the rumor looks like the following:
 
 ```json
 [
@@ -62,8 +59,8 @@ Mostro will send back a nip59 event as a confirmation message, the content of th
           "fiat_amount": 100,
           "payment_method": "face to face",
           "premium": 1,
-          "master_buyer_pubkey": null,
-          "master_seller_pubkey": null,
+          "buyer_trade_pubkey": null,
+          "seller_trade_pubkey": null,
           "buyer_invoice": null,
           "created_at": 1698870173
         }

--- a/docs/protocol/new_buy_order_ln_address.md
+++ b/docs/protocol/new_buy_order_ln_address.md
@@ -47,29 +47,32 @@ The nostr event will look like this:
 Mostro will send back a nip59 event as a confirmation message to the user like the following:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "new-order",
-    "payload": {
-      "order": {
-        "id": "<Order Id>",
-        "kind": "buy",
-        "status": "pending",
-        "amount": 0,
-        "fiat_code": "VES",
-        "fiat_amount": 100,
-        "payment_method": "face to face,mobile",
-        "premium": 1,
-        "master_buyer_pubkey": null,
-        "master_seller_pubkey": null,
-        "buyer_invoice": "mostro_p2p@ln.tips",
-        "created_at": 1698870173
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "new-order",
+      "payload": {
+        "order": {
+          "id": "<Order Id>",
+          "kind": "buy",
+          "status": "pending",
+          "amount": 0,
+          "fiat_code": "VES",
+          "fiat_amount": 100,
+          "payment_method": "face to face,mobile",
+          "premium": 1,
+          "buyer_trade_pubkey": null,
+          "seller_trade_pubkey": null,
+          "buyer_invoice": "mostro_p2p@ln.tips",
+          "created_at": 1698870173
+        }
       }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 Mostro publishes this order as an event kind `38383` with status `pending`:

--- a/docs/protocol/new_sell_order.md
+++ b/docs/protocol/new_sell_order.md
@@ -1,32 +1,29 @@
 # Creating a new sell order
 
-To create a new sell order the user should send a Gift wrap Nostr event to Mostro, the rumor event should have the following rumor's content:
+To create a new sell order the user should send a Gift wrap Nostr event to Mostro, the message should look like this:
 
 ```json
-[
-  {
-    "order": {
-      "version": 1,
-      "action": "new-order",
-      "trade_index": 1,
-      "payload": {
-        "order": {
-          "kind": "sell",
-          "status": "pending",
-          "amount": 0,
-          "fiat_code": "VES",
-          "min_amount": null,
-          "max_amount": null,
-          "fiat_amount": 100,
-          "payment_method": "face to face,bank transfer,mobile",
-          "premium": 1,
-          "created_at": 0
-        }
+{
+  "order": {
+    "version": 1,
+    "action": "new-order",
+    "trade_index": 1,
+    "payload": {
+      "order": {
+        "kind": "sell",
+        "status": "pending",
+        "amount": 0,
+        "fiat_code": "VES",
+        "min_amount": null,
+        "max_amount": null,
+        "fiat_amount": 100,
+        "payment_method": "face to face,bank transfer,mobile",
+        "premium": 1,
+        "created_at": 0
       }
     }
-  },
-  null
-]
+  }
+}
 ```
 
 Let's explain some of the fields:

--- a/docs/protocol/new_sell_range_order.md
+++ b/docs/protocol/new_sell_range_order.md
@@ -1,32 +1,29 @@
 # Creating a new sell range order
 
-To create a new range order the user should send a Gift wrap Nostr event to Mostro with the following rumor's content:
+To create a new range order the user should send a Gift wrap Nostr event to Mostro with the following message:
 
 ```json
-[
-  {
-    "order": {
-      "version": 1,
-      "action": "new-order",
-      "trade_index": 1,
-      "payload": {
-        "order": {
-          "kind": "sell",
-          "status": "pending",
-          "amount": 0,
-          "fiat_code": "VES",
-          "min_amount": 10,
-          "max_amount": 20,
-          "fiat_amount": 0,
-          "payment_method": "face to face",
-          "premium": 1,
-          "created_at": 0
-        }
+{
+  "order": {
+    "version": 1,
+    "action": "new-order",
+    "trade_index": 1,
+    "payload": {
+      "order": {
+        "kind": "sell",
+        "status": "pending",
+        "amount": 0,
+        "fiat_code": "VES",
+        "min_amount": 10,
+        "max_amount": 20,
+        "fiat_amount": 0,
+        "payment_method": "face to face",
+        "premium": 1,
+        "created_at": 0
       }
     }
-  },
-  "<index N signature of the sha256 hash of the serialized first element of content>"
-]
+  }
+}
 ```
 
 Here we have two new fields, `min_amount` and `max_amount`, to define the range of the order. The `fiat_amount` field is set to 0 to indicate that the order is for a range of amounts.
@@ -38,28 +35,31 @@ When a taker takes the order, the amount will be set on the message.
 Mostro will send back a nip59 event as a confirmation message to the user like the following:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order id>",
-    "action": "new-order",
-    "payload": {
-      "order": {
-        "id": "<Order id>",
-        "kind": "sell",
-        "status": "pending",
-        "amount": 0,
-        "fiat_code": "VES",
-        "min_amount": 10,
-        "max_amount": 20,
-        "fiat_amount": 0,
-        "payment_method": "face to face",
-        "premium": 1,
-        "created_at": 1698870173
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order id>",
+      "action": "new-order",
+      "payload": {
+        "order": {
+          "id": "<Order id>",
+          "kind": "sell",
+          "status": "pending",
+          "amount": 0,
+          "fiat_code": "VES",
+          "min_amount": 10,
+          "max_amount": 20,
+          "fiat_amount": 0,
+          "payment_method": "face to face",
+          "premium": 1,
+          "created_at": 1698870173
+        }
       }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 Mostro publishes this order as an event kind `38383` with status `pending`:

--- a/docs/protocol/order_event.md
+++ b/docs/protocol/order_event.md
@@ -1,5 +1,18 @@
 # Peer-to-peer Order events. NIP-69
 
+## Mostro Event Kinds
+
+Mostro uses different event kinds for different types of data:
+
+| Event Type | Kind  | Document (`z` tag) |
+|------------|-------|--------------------|
+| Orders     | 38383 | `order`            |
+| Ratings    | 38384 | `rating`           |
+| Info       | 38385 | `info`             |
+| Disputes   | 38386 | `dispute`          |
+
+This document focuses on the **Order** event (kind `38383`), which is used for the P2P order book.
+
 ## Abstract
 
 Peer-to-peer (P2P) platforms have seen an upturn in recent years, while having more and more options is positive, in the specific case of p2p, having several options contributes to the liquidity split, meaning sometimes there's not enough assets available for trading. If we combine all these individual solutions into one big pool of orders, it will make them much more competitive compared to centralized systems, where a single authority controls the liquidity.
@@ -27,7 +40,7 @@ Events are [addressable events](https://github.com/nostr-protocol/nips/blob/mast
     ["premium", "1"],
     [
       "rating",
-      "{\"total_reviews\":1,\"total_rating\":3.0,\"last_rating\":3,\"max_rate\":5,\"min_rate\":1}"
+      "{\"total_reviews\":1,\"total_rating\":3.0,\"last_rating\":3,\"max_rate\":5,\"min_rate\":1,\"days\":21}"
     ],
     ["source", "https://t.me/p2plightning/xxxxxxx"],
     ["network", "mainnet"],
@@ -35,7 +48,8 @@ Events are [addressable events](https://github.com/nostr-protocol/nips/blob/mast
     ["name", "Nakamoto"],
     ["g", "<geohash>"],
     ["bond", "0"],
-    ["expiration", "1719391096"],
+    ["expires_at", "1719391096"],
+    ["expiration", "1719995896"],
     ["y", "lnp2pbot"],
     ["z", "order"]
   ],
@@ -49,7 +63,7 @@ Events are [addressable events](https://github.com/nostr-protocol/nips/blob/mast
 - `d` < Order ID >: A unique identifier for the order.
 - `k` < Order type >: `sell` or `buy`. This specifies the type of transaction in terms of bitcoin. "sell" means selling bitcoin, while "buy" indicates buying bitcoin.
 - `f` < Currency >: The fiat asset being traded, using the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) standard.
-- `s` < Status >: `pending`, `canceled`, `in-progress`, `success`.
+- `s` < Status >: `pending`, `canceled`, `in-progress`, `success`, `expired`.
 - `amt` < Amount >: The amount of Bitcoin to be traded, the amount is defined in satoshis, if `0` means that the amount of satoshis will be obtained from a public API after the taker accepts the order.
 - `fa` < Fiat amount >: The fiat amount being traded, for range orders two values are expected, the minimum and maximum amount.
 - `pm` < Payment method >: The payment method used for the trade, if the order has multiple payment methods, they should be separated by a comma.
@@ -61,7 +75,8 @@ Events are [addressable events](https://github.com/nostr-protocol/nips/blob/mast
 - `name` [Name]: The name of the maker.
 - `g` [Geohash]: The geohash of the operation, it can be useful in a face to face trade.
 - `bond` [Bond]: The bond amount, the bond is a security deposit that both parties must pay.
-- `expiration` < Expiration\>: The expiration date of the order ([NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md)).
+- `expires_at` < Expires At\>: The expiration date of the event being published in `pending` status, after this time the event status SHOULD be changed to `expired`.
+- `expiration` < Expiration\>: The expiration date of the event, after this time the relay SHOULD delete it ([NIP-40](40.md)).
 - `y` < Platform >: The platform that created the order.
 - `z` < Document >: `order`.
 
@@ -74,6 +89,8 @@ Currently implemented on the following platforms:
 - [Mostro](https://github.com/MostroP2P/mostro)
 - [@lnp2pBot](https://github.com/lnp2pBot/bot)
 - [Robosats](https://github.com/RoboSats/robosats/pull/1362)
+- Peach
+- Hodlhodl
 
 ## This document is inspired on
 

--- a/docs/protocol/orders.md
+++ b/docs/protocol/orders.md
@@ -1,0 +1,94 @@
+# Request order details
+
+Clients can request detailed information for existing orders by sending a nip59 Gift wrap message with the action `orders`. This is useful for refreshing stale UI state or restoring a session from the mnemonic seed on a new device.
+
+## Request message
+
+The client sends a message where the payload object includes an `ids` array of order IDs. At least one ID must be provided, and Mostro may reject the request if the array exceeds its configured limits.
+
+```json
+[
+  {
+    "order": {
+      "version": 1,
+      "request_id": 8721,
+      "action": "orders",
+      "payload":  {
+        "ids": [
+          "c7dba9db-f13f-4c3f-a77f-3b82e43c2b1a",
+          "751bc178-801a-4cc4-983c-68682e6fb6af"
+        ]
+      }
+    }
+  },
+  null
+]
+```
+
+Field:
+- `ids`: Array of order ids exactly as published in the order event `d` tag.
+
+The client only can request their own orders; mostrod will not provide information about any ID if it does not belong to the requesting party.
+
+## Mostro response
+
+Mostro replies with the same action and includes a structured payload describing each order that could be resolved, here is how the message look like:
+
+```json
+[
+  {
+    "order": {
+      "version": 1,
+      "request_id": 8721,
+      "action": "orders",
+      "payload": {
+        "orders": [
+          {
+            "id": "c7dba9db-f13f-4c3f-a77f-3b82e43c2b1a",
+            "kind": "sell",
+            "status": "active",
+            "amount": 3307,
+            "fiat_code": "ARS",
+            "min_amount": 1000,
+            "max_amount": 5000,
+            "fiat_amount": 5000,
+            "payment_method": "Mercado Pago,Lemon",
+            "premium": 2,
+            "buyer_trade_pubkey": "<trade pubkey>",
+            "seller_trade_pubkey": "<trade pubkey>",
+            "created_at": 1758889527,
+            "expires_at": 1758975927
+          },
+          {
+            "id": "751bc178-801a-4cc4-983c-68682e6fb6af",
+            "kind": "sell",
+            "status": "fiat-sent",
+            "amount": 1201,
+            "fiat_code": "ARS",
+            "min_amount": null,
+            "max_amount": null,
+            "fiat_amount": 2000,
+            "payment_method": "MODO",
+            "premium": 0,
+            "buyer_trade_pubkey": "<trade pubkey>",
+            "seller_trade_pubkey": "<trade pubkey>",
+            "created_at": 1759168820,
+            "expires_at": 1759255220
+          }
+        ]
+      }
+    }
+  },
+  null
+]
+```
+
+Orders that are missing or unauthorized for the requesting user are not listed in the orders array.
+
+## Limits and rate control
+
+Mostrod enforces per-request limits to protect the daemon. Common policies include a `max_orders_per_response` cap (for example, 20 orders) and a rolling request quota per pubkey.
+
+When a response is truncated because too many ids were requested, Mostrod returns only the first allowed ids. Clients should re-issue the call with the remaining ids after respecting the rate limits.
+
+When a user exceeds the allowed request rate, Mostrod can answer with an error action such as `too-many-requests`. Implementations should surface these conditions to the user and back off accordingly.

--- a/docs/protocol/other_events.md
+++ b/docs/protocol/other_events.md
@@ -1,5 +1,63 @@
 # Other events published by Mostro
 
+Each Mostro instance publishes several types of events to Nostr relays. These include identity metadata, instance status, relay lists, and development fee records. Below, we provide details on each of these events.
+
+## Node Identity (NIP-01 Kind 0)
+
+Each Mostro instance publishes a [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) kind 0 metadata event on startup so that Nostr clients can display the node's profile information. This is the standard Nostr profile mechanism — every relay-aware client already knows how to fetch and display kind 0 metadata.
+
+The event is a **replaceable event**, meaning relays keep only the latest version. It is re-published on every restart, ensuring the profile stays fresh.
+
+The `content` field contains a stringified JSON object with the following optional fields:
+
+```json
+{
+  "name": "Mostro P2P",
+  "about": "A peer-to-peer Bitcoin trading daemon over the Lightning Network",
+  "picture": "https://example.com/mostro-avatar.png",
+  "website": "https://mostro.network"
+}
+```
+
+The full event looks like this:
+
+```json
+[
+  "EVENT",
+  "RAND",
+  {
+    "id": "<Event id>",
+    "pubkey": "<Mostro's pubkey>",
+    "kind": 0,
+    "tags": [],
+    "content": "{\"name\":\"Mostro P2P\",\"about\":\"A peer-to-peer Bitcoin trading daemon over the Lightning Network\",\"picture\":\"https://example.com/mostro-avatar.png\",\"website\":\"https://mostro.network\"}",
+    "sig": "<Mostro's signature>",
+    "created_at": 1731701441
+  }
+]
+```
+
+### Fields
+
+- `name`: Human-readable name for the Mostro instance (e.g., "LatAm Mostro", "Bitcoin Munich Exchange").
+- `about`: Short description of the instance and the community it serves.
+- `picture`: URL to an avatar image. Recommended: square, max 128×128 pixels, PNG or JPEG.
+- `website`: Operator's website URL.
+
+All fields are optional. If no metadata fields are configured, no kind 0 event is published. These fields are configured in the `[mostro]` section of `settings.toml`:
+
+```toml
+[mostro]
+name = "Mostro P2P"
+about = "A peer-to-peer Bitcoin trading daemon over the Lightning Network"
+picture = "https://example.com/mostro-avatar.png"
+website = "https://mostro.network"
+```
+
+This allows clients like Mostro Mobile to display meaningful information about each Mostro instance — its name, description, avatar, and website — so users know which node they are trading on.
+
+## Mostro Instance Status
+
 Each Mostro instance periodically publishes events with relevant information about its status, such as the code version it is using, the latest commit, the fees it charges, allowed exchange limits, the relays it publishes to, and much more. Below, we provide details on these events.
 
 ## Mostro Instance Status
@@ -13,7 +71,7 @@ This event contains specific data about a Mostro instance. The instance is ident
   {
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
-    "kind": 38383
+    "kind": 38385,
     "tags": [
       [
         "d",
@@ -42,6 +100,14 @@ This event contains specific data about a Mostro instance. The instance is ident
       [
         "expiration_seconds",
         "900"
+      ],
+      [
+        "fiat_currencies_accepted",
+        "USD,EUR,ARS,CUP,VES"
+      ],
+      [
+        "max_orders_per_response",
+        "10"
       ],
       [
         "fee",
@@ -115,6 +181,8 @@ Below is an explanation of the meaning of some of the labels in this event, all 
 - `min_order_amount`: The minimum amount of Satoshis allowed for exchange.
 - `expiration_hours`: The maximum time, in hours, that an order can remain in `pending` status before it expires.
 - `expiration_seconds`: The maximum time, in seconds, that an order can remain in `waiting-payment` or `waiting-buyer-invoice` status before being canceled or reverted to `pending` status.
+- `fiat_currencies_accepted`: Fiat currencies accepted by the Mostro. If no currency is specified, all are accepted.
+- `max_orders_per_response`: Maximum complete orders data per response in orders action.
 - `fee`: The fee percentage charged by the instance. For example, "0.006" means a 0.6% fee.
 - `pow`: The Proof of Work required of incoming events.
 - `hold_invoice_expiration_window`: The maximum time, in seconds, for the hold invoice issued by Mostro to be paid by the seller.
@@ -143,7 +211,7 @@ The operator of a Mostro instance decides which relays the events from that inst
     "kind": 10002,
     "tags": [
       ["r", "wss://relay.mostro.network/"],
-      ["r", "wss://nostr.bilthon.dev/"]
+      ["r", "wss://nos.lol/"]
     ],
     "content": "",
     "sig": "<Mostro's signature>",
@@ -154,3 +222,52 @@ The operator of a Mostro instance decides which relays the events from that inst
 ```
 
 The `r` label indicates the relays through which the Mostro instance is publishing its events.
+
+# Development Fee
+
+The development fee mechanism provides sustainable funding for Mostro development by automatically sending a configurable percentage of the Mostro fee to a lightning address on each successful order, this a regular event with kind 8383 which is expected to be stored by relays.
+
+```json
+[
+  "EVENT",
+  "RAND",
+  {
+    "id": "<Event id>",
+    "tags": [
+      [
+        "order-id",
+        "<Order id>"
+      ],
+      [
+        "amount",
+        "8" // sats amount
+      ],
+      [
+        "hash",
+        "ca2f47b7c2169b8c42ef135e8ee32706e1fd3722b65e5a16f21ce675d2affb6b"
+      ],
+      [
+        "destination",
+        "dev@mostro.network"
+      ],
+      [
+        "network",
+        "mainnet"
+      ],
+      [
+        "y",
+        "mostro"
+      ],
+      [
+        "z",
+        "dev-fee-payment"
+      ]
+    ],
+    "content": "",
+    "sig": "<Mostro's signature>",
+    "pubkey": "<Mostro's pubkey>",
+    "created_at": 1768256716,
+    "kind": 8383
+  }
+]
+```

--- a/docs/protocol/overview.md
+++ b/docs/protocol/overview.md
@@ -1,10 +1,21 @@
 ## Overview
 
-In order to have a shared order's book, Mostro daemon send [Addressable Events](https://github.com/nostr-protocol/nips/blob/master/01.md#kinds) with `38383` as event `kind`, you can find more details about that specific event [here](./order_event.md)
+**See also:** [User Guide (English)](https://mostro.network/docs-english/) | [Guía de Usuario (Español)](https://mostro.network/docs-spanish/) | [Run Your Own Node](https://mostro.community/guide)
+
+Mostro uses [Addressable Events](https://github.com/nostr-protocol/nips/blob/master/01.md#kinds) to publish different types of information. Each event type has its own `kind`:
+
+| Event Type | Kind  | Description |
+|------------|-------|-------------|
+| Orders     | 38383 | P2P order events for the shared order book |
+| Ratings    | 38384 | User rating events |
+| Info       | 38385 | Mostro instance status and information |
+| Disputes   | 38386 | Dispute events |
+
+You can find more details about the order event [here](./order_event.md)
 
 ## The Message
 
-All **_messages_** from/to Mostro should be [Gift wrap Nostr events](https://github.com/nostr-protocol/nips/blob/master/59.md), the `content` of the `rumor` event is an `array`, the `first element should be a JSON-serialized string` (with no white space or line breaks), the `second element is the signature` of the sha256 hash of the serialized first element, here the structure of the first element:
+All **_messages_** from/to Mostro should be [Gift wrap Nostr events](https://github.com/nostr-protocol/nips/blob/master/59.md), the `content` of the `rumor` event is a JSON-serialized `array` as a string (with no white space or line breaks), the first element is the message, the second element is the `signature` of the sha256 hash of the serialized first element, here the structure of the first element:
 
 - [Wrapper](https://docs.rs/mostro-core/latest/mostro_core/message/enum.Message.html): Wrapper of the **_Message_**
   - <`version` integer>: Version of the protocol, currently `1`
@@ -39,4 +50,34 @@ Here an example of a `new-order` order **_message_**:
     }
   }
 }
+```
+
+## Payment Request Array Structure
+
+The `payment_request` field in the payload can have different structures depending on the use case:
+
+1. **Lightning invoice from buyer/seller to Mostro** (action: `add-invoice`):
+   - With amount: `[null, "lnbc..."]`
+   - Without amount (0-amount invoice): `[null, "lnbc...", amount_in_sats]`
+
+2. **Lightning address**:
+   - Taking a sell order with fixed amount: `[null, "user@domain.com"]`
+   - Taking a sell Range order: `[null, "user@domain.com", fiat_amount]`
+
+## Optional Fields
+
+Some fields in order objects may be `null` or omitted depending on the context:
+
+- `request_id`: Optional field that clients can include to correlate responses with requests. Mostro will echo this value back in responses.
+- `trade_index`: Required for users maintaining reputation, omitted when using full privacy mode.
+- `expires_at`: Unix timestamp when the order expires. Present in order confirmations and updates, but set to `0` or `null` when creating new orders.
+- `created_at`: Unix timestamp when the order was created. Set to `0` or current time when creating orders; Mostro will set the actual timestamp.
+- Signature (second array element): Required for reputation mode (signs the first element with trade key), set to `null` in full privacy mode or for Mostro responses.
+
+## Payment Method Format
+
+Payment methods can be specified like this:
+
+```json
+   ["pm", "face to face", "bank transfer", "mobile"]
 ```

--- a/docs/protocol/release.md
+++ b/docs/protocol/release.md
@@ -13,7 +13,7 @@ After confirming the buyer sent the fiat money, the seller should send a message
       "payload": null
     }
   },
-  "<index N signature of the sha256 hash of the serialized first element of content>"
+  null
 ]
 ```
 
@@ -57,14 +57,17 @@ And a message to the buyer to let him know that the sats were released:
 Right after seller release sats Mostro will attempt to pay the buyer's lightning invoice. When the payment succeeds, Mostro will send a message to the buyer indicating that the purchase was completed:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "purchase-completed",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "purchase-completed",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 Mostro updates the addressable event with the `d` tag `<Order Id>` to change the status to `success`:
@@ -104,44 +107,50 @@ Mostro updates the addressable event with the `d` tag `<Order Id>` to change the
 If the order is a range order probably after release a child order would need to be created, Mostro can't know which would be the next `trade pubkey`, so the client of the maker must send this information, here how the message must look like:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "4fd93fc9-e909-4fc9-acef-9976122b5dfa",
-    "action": "release",
-    "payload": {
-      "next_trade": ["<trade pubkey>", <trade index>]
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "4fd93fc9-e909-4fc9-acef-9976122b5dfa",
+      "action": "release",
+      "payload": {
+        "next_trade": ["<trade pubkey>", <trade index>]
+      }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 Mostro will send to the maker the newly child order created with the same `trade_index` received in the payload, if the maker is the buyer the `trade_index` would be the one sent in the payload of the `fiat-sent` message by the buyer, the `trade_index` will be used by the client to get the next key, the message will look like this:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "4fd93fc9-e909-4fc9-acef-9976122b5dfa",
-    "action": "new-order",
-    "trade_index": <trade index>,
-    "request_id": "123456",
-    "payload": {
-      "order": {
-        "id": "4fd93fc9-e909-4fc9-acef-9976122b5dfa",
-        "kind": "sell",
-        "status": "pending",
-        "amount": 0,
-        "fiat_code": "VES",
-        "min_amount": <min amount>,
-        "max_amount": <max amount>,
-        "fiat_amount": 0,
-        "payment_method": "face to face",
-        "premium": 1,
-        "created_at": 123456789,
-        "expires_at": 123456789
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "4fd93fc9-e909-4fc9-acef-9976122b5dfa",
+      "action": "new-order",
+      "trade_index": <trade index>,
+      "request_id": "123456",
+      "payload": {
+        "order": {
+          "id": "4fd93fc9-e909-4fc9-acef-9976122b5dfa",
+          "kind": "sell",
+          "status": "pending",
+          "amount": 0,
+          "fiat_code": "VES",
+          "min_amount": <min amount>,
+          "max_amount": <max amount>,
+          "fiat_amount": 0,
+          "payment_method": "face to face",
+          "premium": 1,
+          "created_at": 123456789,
+          "expires_at": 123456789
+        }
       }
     }
-  }
-}
+  },
+  null
+]
 ```

--- a/docs/protocol/restore_session.md
+++ b/docs/protocol/restore_session.md
@@ -7,13 +7,16 @@ To restore a session from the mnemonic seed on a new device (e.g., moving from m
 Client sends a Gift wrap Nostr event to Mostro with the following rumor's content:
 
 ```json
-{
-  "restore": {
-    "version": 1,
-    "action": "restore-session",
-    "payload": null
-  }
-}
+[
+  {
+    "restore": {
+      "version": 1,
+      "action": "restore-session",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 ## Response
@@ -21,47 +24,50 @@ Client sends a Gift wrap Nostr event to Mostro with the following rumor's conten
 Mostro will respond with a message containing all non-finalized orders (e.g., statuses such as `pending`, `active`, `fiat-sent`, `waiting-buyer-invoice`, `waiting-payment`, `settled-hold-invoice`) and any active disputes. The response format will be:
 
 ```json
-{
-  "restore": {
-    "version": 1,
-    "action": "restore-session",
-    "payload": {
-      "restore_data": {
-        "orders": [
-          {
-            "id": "<Order Id>",
-            "trade_index": 1,
-            "status": "pending"
-          },
-          {
-            "id": "<Order Id>",
-            "trade_index": 2,
-            "status": "active"
-          },
-          {
-            "id": "<Order Id>",
-            "trade_index": 3,
-            "status": "fiat-sent"
-          }
-        ],
-        "disputes": [
-          {
-            "dispute_id": "<Dispute Id>",
-            "order_id": "<Order Id>",
-            "trade_index": 4,
-            "status": "initiated"
-          }
-        ]
+[
+  {
+    "restore": {
+      "version": 1,
+      "action": "restore-session",
+      "payload": {
+        "restore_data": {
+          "orders": [
+            {
+              "order_id": "<Order Id>",
+              "trade_index": 1,
+              "status": "pending"
+            },
+            {
+              "order_id": "<Order Id>",
+              "trade_index": 2,
+              "status": "active"
+            },
+            {
+              "order_id": "<Order Id>",
+              "trade_index": 3,
+              "status": "fiat-sent"
+            }
+          ],
+          "disputes": [
+            {
+              "dispute_id": "<Dispute Id>",
+              "order_id": "<Order Id>",
+              "trade_index": 4,
+              "status": "initiated"
+            }
+          ]
+        }
       }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 ### Fields
 
 * `restore_data`: Wrapper object that contains the session recovery data.
-* `restore_data.orders`: An array of active or ongoing orders with their `id`, `trade_index`, and current `status`.
+* `restore_data.orders`: An array of active or ongoing orders with their `order_id`, `trade_index`, and current `status`.
 * `restore_data.disputes`: An array of ongoing disputes with `dispute_id`, the associated `order_id`, and `trade_index` and current `status` of the dispute.
 
 ## Example Use Case
@@ -75,23 +81,26 @@ A user has the following:
 When switching to desktop, after restoring the mnemonic, the client sends `restore-session` and receives:
 
 ```json
-{
-  "restore": {
-    "version": 1,
-    "action": "restore-session",
-    "payload": {
-      "restore_data": {
-        "orders": [
-          { "id": "abc-123", "trade_index": 1, "status": "pending" },
-          { "id": "def-456", "trade_index": 2, "status": "pending" },
-          { "id": "ghi-789", "trade_index": 3, "status": "active" },
-          { "id": "xyz-999", "trade_index": 4, "status": "dispute" }
-        ],
-        "disputes": [
-          { "dispute_id": "dis-001", "order_id": "xyz-999", "trade_index": 4, "status": "initiated" }
-        ]
+[
+  {
+    "restore": {
+      "version": 1,
+      "action": "restore-session",
+      "payload": {
+        "restore_data": {
+          "orders": [
+            { "order_id": "abc-123", "trade_index": 1, "status": "pending" },
+            { "order_id": "def-456", "trade_index": 2, "status": "pending" },
+            { "order_id": "ghi-789", "trade_index": 3, "status": "active" },
+            { "order_id": "xyz-999", "trade_index": 4, "status": "dispute" }
+          ],
+          "disputes": [
+            { "dispute_id": "dis-001", "order_id": "xyz-999", "trade_index": 4, "status": "initiated" }
+          ]
+        }
       }
     }
-  }
-}
+  },
+  null
+]
 ```

--- a/docs/protocol/seller_pay_hold_invoice.md
+++ b/docs/protocol/seller_pay_hold_invoice.md
@@ -50,8 +50,8 @@ After the hold invoice is paid and the buyer already sent the invoice to receive
           "fiat_amount": 100,
           "payment_method": "face to face",
           "premium": 1,
-          "master_buyer_pubkey": "<Buyer's trade pubkey>",
-          "master_seller_pubkey": "<Seller's trade pubkey>",
+          "buyer_trade_pubkey": "<Buyer's trade pubkey>",
+          "seller_trade_pubkey": "<Seller's trade pubkey>",
           "buyer_invoice": null,
           "created_at": 1698937797
         }
@@ -81,8 +81,8 @@ Mostro also send a message to the buyer, this way they can both write to each ot
           "fiat_amount": 100,
           "payment_method": "face to face",
           "premium": 1,
-          "master_buyer_pubkey": "<Buyer's trade pubkey>",
-          "master_seller_pubkey": "<Seller's trade pubkey>",
+          "buyer_trade_pubkey": "<Buyer's trade pubkey>",
+          "seller_trade_pubkey": "<Seller's trade pubkey>",
           "buyer_invoice": null,
           "created_at": 1698937797
         }

--- a/docs/protocol/take_buy.md
+++ b/docs/protocol/take_buy.md
@@ -36,29 +36,32 @@ The event to send to Mostro would look like this:
 Mostro respond to the seller with a message with the following content:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "pay-invoice",
-    "payload": {
-      "payment_request": [
-        {
-          "id": "<Order Id>",
-          "kind": "buy",
-          "status": "waiting-payment",
-          "amount": 7851,
-          "fiat_code": "VES",
-          "fiat_amount": 100,
-          "payment_method": "face to face",
-          "premium": 1,
-          "created_at": 1698957793
-        },
-        "lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e"
-      ]
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "pay-invoice",
+      "payload": {
+        "payment_request": [
+          {
+            "id": "<Order Id>",
+            "kind": "buy",
+            "status": "waiting-payment",
+            "amount": 7851,
+            "fiat_code": "VES",
+            "fiat_amount": 100,
+            "payment_method": "face to face",
+            "premium": 1,
+            "created_at": 1698957793
+          },
+          "lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e"
+        ]
+      }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 Mostro updates the addressable event with `d` tag `<Order Id>` to change the status to `in-progress`:
@@ -74,7 +77,7 @@ Mostro updates the addressable event with `d` tag `<Order Id>` to change the sta
     "kind": 38383,
     "tags": [
       ["d", "<Order Id>"],
-      ["k", "sell"],
+      ["k", "buy"],
       ["f", "VES"],
       ["s", "in-progress"],
       ["amt", "7851"],
@@ -96,14 +99,17 @@ Mostro updates the addressable event with `d` tag `<Order Id>` to change the sta
 And send a message to the buyer with the following content:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "waiting-seller-to-pay",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "waiting-seller-to-pay",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 ## Seller pays LN invoice
@@ -111,37 +117,43 @@ And send a message to the buyer with the following content:
 After seller pays the hold invoice Mostro send a message to the seller with the following content:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "waiting-buyer-invoice",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "waiting-buyer-invoice",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 Mostro sends a message to the buyer with the following content:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "add-invoice",
-    "payload": {
-      "order": {
-        "id": "<Order Id>",
-        "status": "waiting-buyer-invoice",
-        "amount": 7851,
-        "fiat_code": "VES",
-        "fiat_amount": 100,
-        "payment_method": "face to face",
-        "premium": 1,
-        "created_at": null
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "add-invoice",
+      "payload": {
+        "order": {
+          "id": "<Order Id>",
+          "status": "waiting-buyer-invoice",
+          "amount": 7851,
+          "fiat_code": "VES",
+          "fiat_amount": 100,
+          "payment_method": "face to face",
+          "premium": 1,
+          "created_at": null
+        }
       }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 ## Buyer sends LN invoice
@@ -149,19 +161,22 @@ Mostro sends a message to the buyer with the following content:
 Buyer sends the LN invoice to Mostro.
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "add-invoice",
-    "payload": {
-      "payment_request": [
-        null,
-        "lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e"
-      ]
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "add-invoice",
+      "payload": {
+        "payment_request": [
+          null,
+          "lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e"
+        ]
+      }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 Now both parties have an `active` order and they can keep going with the trade.

--- a/docs/protocol/take_buy_range_order.md
+++ b/docs/protocol/take_buy_range_order.md
@@ -15,10 +15,10 @@ If the order fiat amount is a range like `10-20` the seller must indicate a fiat
       }
     }
   },
-  "<index N signature of the sha256 hash of the serialized first element of content>"
+  null
 ]
 ```
 
 ## Mostro response
 
-Response is the same as we explained in the [Taking a buy order](./take_buy.md) section.
+Response is the same as we explained in the [Taking a buy order](./take_buy.md) section with the seller receiving a hold invoice to pay and the buyer waiting for that payment.

--- a/docs/protocol/take_sell.md
+++ b/docs/protocol/take_sell.md
@@ -36,8 +36,8 @@ In order to continue the buyer needs to send a lightning network invoice to Most
           "fiat_amount": 100,
           "payment_method": "face to face",
           "premium": 1,
-          "buyer_pubkey": null,
-          "seller_pubkey": null
+          "buyer_trade_pubkey": null,
+          "seller_trade_pubkey": null
         }
       }
     }

--- a/docs/protocol/take_sell_ln_address.md
+++ b/docs/protocol/take_sell_ln_address.md
@@ -11,7 +11,7 @@ The buyer can use a [lightning address](https://github.com/andrerfneves/lightnin
       "action": "take-sell",
       "trade_index": 1,
       "payload": {
-        "payment_request": [null, "mostro_p2p@ln.tips"]
+        "payment_request": [null, "mostro_p2p@ln.tips", null]
       }
     }
   },

--- a/docs/protocol/take_sell_range_order.md
+++ b/docs/protocol/take_sell_range_order.md
@@ -40,8 +40,8 @@ In order to continue the buyer needs to send a lightning network invoice to Most
           "fiat_amount": 15,
           "payment_method": "face to face",
           "premium": 1,
-          "master_buyer_pubkey": null,
-          "master_seller_pubkey": null,
+          "buyer_trade_pubkey": null,
+          "seller_trade_pubkey": null,
           "buyer_invoice": null,
           "created_at": null,
           "expires_at": null
@@ -90,14 +90,17 @@ Mostro updates the addressable event with `d` tag `<Order Id>` to change the sta
 The buyer can use a [lightning address](https://github.com/andrerfneves/lightning-address) to receive funds and avoid to create and send lightning invoices on each trade, with a range order we set the fiat amount as the third element of the `payment_request` array, to acomplish this the buyer will send a message in a Gift wrap Nostr event to Mostro with the following rumor's content:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "take-sell",
-    "payload": {
-      "payment_request": [null, "mostro_p2p@ln.tips", 15]
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "take-sell",
+      "payload": {
+        "payment_request": [null, "mostro_p2p@ln.tips", 15]
+      }
     }
-  }
-}
+  },
+  null
+]
 ```

--- a/docs/protocol/user_rating.md
+++ b/docs/protocol/user_rating.md
@@ -3,14 +3,17 @@
 After a successful trade Mostro send a Gift wrap Nostr event to both parties to let them know they can rate each other, here an example how the message look like:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "rate",
-    "payload": null
-  }
-}
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "rate",
+      "payload": null
+    }
+  },
+  null
+]
 ```
 
 After a Mostro client receive this message, the user can rate the other party, the rating is a number between 1 and 5, to rate the client must receive user's input and create a new Gift wrap Nostr event to send to Mostro with this content:
@@ -36,16 +39,19 @@ After a Mostro client receive this message, the user can rate the other party, t
 If Mostro received the correct message, it will send back a confirmation message to the user with the action `rate-received`:
 
 ```json
-{
-  "order": {
-    "version": 1,
-    "id": "<Order Id>",
-    "action": "rate-received",
-    "payload": {
-      "rating_user": 5
+[
+  {
+    "order": {
+      "version": 1,
+      "id": "<Order Id>",
+      "action": "rate-received",
+      "payload": {
+        "rating_user": 5
+      }
     }
-  }
-}
+  },
+  null
+]
 ```
 
 Mostro updates the addressable rating event, in this event the `d` tag will be the user pubkey `<Seller's trade pubkey>` and looks like this:
@@ -58,14 +64,16 @@ Mostro updates the addressable rating event, in this event the `d` tag will be t
     "id": "<Event id>",
     "pubkey": "<Mostro's pubkey>",
     "created_at": 1702637077,
-    "kind": 38383,
+    "kind": 38384,
     "tags": [
       ["d", "<Seller's trade pubkey>"],
       ["total_reviews", "1"],
       ["total_rating", "2"],
       ["last_rating", "1"],
-      ["max_rate", "2"],
-      ["min_rate", "5"],
+      ["max_rate", "5"],
+      ["min_rate", "1"],
+      ["days", "21"],
+      ["y", "mostro"],
       ["z", "rating"]
     ],
     "content": "",
@@ -73,3 +81,15 @@ Mostro updates the addressable rating event, in this event the `d` tag will be t
   }
 ]
 ```
+
+## Tags
+
+- `d` < User trade pubkey >: The trade pubkey of the rated user.
+- `total_reviews` < Total reviews >: The total number of reviews the user has received.
+- `total_rating` < Total rating >: The overall reputation rating of the user.
+- `last_rating` < Last rating >: The rating received in the most recent review.
+- `max_rate` < Max rate >: The highest rating the user has received.
+- `min_rate` < Min rate >: The lowest rating the user has received.
+- `days` < Days >: The number of days since the user's first trade.
+- `y` < Platform >: The platform that created the rating.
+- `z` < Document >: `rating`.


### PR DESCRIPTION
In this PR, all the protocol documentation is updated to match exactly what is in [https://github.com/MostroP2P/protocol](https://github.com/MostroP2P/protocol).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new protocol documentation for dispute chat messaging, last trade index queries, and order detail requests.
  * Updated protocol event structures across multiple message types for standardization.
  * Updated event kind references throughout protocol documentation.
  * Corrected grammar and terminology in protocol descriptions.
  * Renamed public field identifiers in message payloads for clarity.
  * Added new error reason codes for request rate limits and currency validation.
  * Expanded overview with comprehensive event-kind mapping table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->