### PR TITLE
fix: clarify timeout cancellation notification

### DIFF
--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -148,8 +148,15 @@ class NotificationDataExtractor {
         break;
         
       case Action.canceled:
-        // Canceled orders don't generate persistent notifications
-        return null;
+        final order = event.getPayload<Order>();
+        final currentSession = session;
+
+        // Maker-side expirations arrive as canceled events for a pending order with no peer.
+        // Preserve that context so the notification copy can explain the timeout clearly.
+        if (order?.status == Status.pending && currentSession?.peer == null) {
+          values['cancellation_reason'] = 'peer_timeout';
+        }
+        break;
         
       case Action.cooperativeCancelInitiatedByYou:
         // No additional values needed

--- a/lib/features/notifications/utils/notification_message_mapper.dart
+++ b/lib/features/notifications/utils/notification_message_mapper.dart
@@ -314,6 +314,8 @@ class NotificationMessageMapper {
         return s.notification_order_canceled_title;
       case 'notification_order_canceled_message':
         return s.notification_order_canceled_message;
+      case 'notification_order_canceled_peer_timeout_message':
+        return s.notification_order_canceled_peer_timeout_message;
       case 'notification_cooperative_cancel_initiated_by_you_title':
         return s.notification_cooperative_cancel_initiated_by_you_title;
       case 'notification_cooperative_cancel_initiated_by_you_message':

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1130,6 +1130,7 @@
     "notification_dispute_started_message": "A dispute has been initiated",
     "notification_order_canceled_title": "Order canceled",
     "notification_order_canceled_message": "The order has been canceled",
+    "notification_order_canceled_peer_timeout_message": "The counterparty did not respond in time. The order has been canceled.",
     "notification_cooperative_cancel_initiated_by_you_title": "Cancellation requested",
     "notification_cooperative_cancel_initiated_by_you_message": "You requested to cancel the order, waiting for peer confirmation",
     "notification_cooperative_cancel_initiated_by_peer_title": "Cancellation request",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1044,6 +1044,7 @@
     "notification_dispute_started_message": "Se ha iniciado una disputa",
     "notification_order_canceled_title": "Orden cancelada",
     "notification_order_canceled_message": "La orden ha sido cancelada",
+    "notification_order_canceled_peer_timeout_message": "La contraparte no respondió a tiempo. La orden ha sido cancelada.",
     "notification_cooperative_cancel_initiated_by_you_title": "Cancelación solicitada",
     "notification_cooperative_cancel_initiated_by_you_message": "Solicitaste cancelar la orden, esperando confirmación del par",
     "notification_cooperative_cancel_initiated_by_peer_title": "Solicitud de cancelación",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1130,6 +1130,7 @@
     "notification_dispute_started_message": "Un différend a été initié",
     "notification_order_canceled_title": "Commande annulée",
     "notification_order_canceled_message": "La commande a été annulée",
+    "notification_order_canceled_peer_timeout_message": "La contrepartie n'a pas répondu à temps. La commande a été annulée.",
     "notification_cooperative_cancel_initiated_by_you_title": "Annulation demandée",
     "notification_cooperative_cancel_initiated_by_you_message": "Vous avez demandé d'annuler la commande, en attente de confirmation du pair",
     "notification_cooperative_cancel_initiated_by_peer_title": "Demande d'annulation",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1103,6 +1103,7 @@
     "notification_dispute_started_message": "È stata avviata una disputa",
     "notification_order_canceled_title": "Ordine annullato",
     "notification_order_canceled_message": "L'ordine è stato annullato",
+    "notification_order_canceled_peer_timeout_message": "La controparte non ha risposto in tempo. L'ordine è stato annullato.",
     "notification_cooperative_cancel_initiated_by_you_title": "Cancellazione richiesta",
     "notification_cooperative_cancel_initiated_by_you_message": "Hai richiesto di annullare l'ordine, in attesa della conferma del peer",
     "notification_cooperative_cancel_initiated_by_peer_title": "Richiesta di cancellazione",

--- a/test/features/notifications/notification_message_mapper_test.dart
+++ b/test/features/notifications/notification_message_mapper_test.dart
@@ -1,0 +1,104 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/data/models/enums/role.dart';
+import 'package:mostro_mobile/data/models/enums/status.dart';
+import 'package:mostro_mobile/features/notifications/utils/notification_data_extractor.dart';
+import 'package:mostro_mobile/features/notifications/utils/notification_message_mapper.dart';
+
+void main() {
+  group('NotificationMessageMapper', () {
+    test('returns timeout-specific message key for expired counterparty cancellations', () {
+      final key = NotificationMessageMapper.getMessageKeyWithContext(
+        Action.canceled,
+        const {'cancellation_reason': 'peer_timeout'},
+      );
+
+      expect(key, 'notification_order_canceled_peer_timeout_message');
+    });
+
+    test('keeps generic cancellation copy for other canceled orders', () {
+      final key = NotificationMessageMapper.getMessageKeyWithContext(
+        Action.canceled,
+        const {},
+      );
+
+      expect(key, 'notification_order_canceled_message');
+    });
+  });
+
+  group('NotificationDataExtractor', () {
+    test('tags maker-side timeout cancellations with peer_timeout reason', () async {
+      final message = MostroMessage(
+        id: 'order-123',
+        action: Action.canceled,
+        payload: const Order(
+          id: 'order-123',
+          kind: OrderType.sell,
+          status: Status.pending,
+          fiatCode: 'USD',
+          fiatAmount: 100,
+          paymentMethod: 'Cash',
+        ),
+      );
+
+      final session = Session(
+        masterKey: NostrKeyPairs(private: '1' * 64, public: '2' * 64),
+        tradeKey: NostrKeyPairs(private: '3' * 64, public: '4' * 64),
+        keyIndex: 0,
+        fullPrivacy: false,
+        startTime: DateTime.utc(2026, 1, 1),
+        orderId: 'order-123',
+        role: Role.seller,
+      );
+
+      final notification = await NotificationDataExtractor.extractFromMostroMessage(
+        message,
+        null,
+        session: session,
+      );
+
+      expect(notification, isNotNull);
+      expect(notification!.action, Action.canceled);
+      expect(notification.values['cancellation_reason'], 'peer_timeout');
+    });
+
+    test('does not tag cancellations after a peer was established', () async {
+      final message = MostroMessage(
+        id: 'order-123',
+        action: Action.canceled,
+        payload: const Order(
+          id: 'order-123',
+          kind: OrderType.sell,
+          status: Status.pending,
+          fiatCode: 'USD',
+          fiatAmount: 100,
+          paymentMethod: 'Cash',
+          buyerTradePubkey: '5' * 64,
+        ),
+      );
+
+      final session = Session(
+        masterKey: NostrKeyPairs(private: '1' * 64, public: '2' * 64),
+        tradeKey: NostrKeyPairs(private: '3' * 64, public: '4' * 64),
+        keyIndex: 0,
+        fullPrivacy: false,
+        startTime: DateTime.utc(2026, 1, 1),
+        orderId: 'order-123',
+        role: Role.seller,
+        peer: Peer(publicKey: '5' * 64),
+      );
+
+      final notification = await NotificationDataExtractor.extractFromMostroMessage(
+        message,
+        null,
+        session: session,
+      );
+
+      expect(notification, isNotNull);
+      expect(notification!.values.containsKey('cancellation_reason'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What
- preserve timeout context for maker-side `canceled` events in notification data
- map timeout-driven cancellations to a dedicated localized notification message
- add unit coverage for the new cancellation context mapping

## Why
Fixes #532. When an order expires because the counterparty never responds, the current notification copy is too generic and can imply the user canceled the order themselves.

## Verification
- Added `test/features/notifications/notification_message_mapper_test.dart`
- Local Flutter verification could not be run in this environment because `flutter` is not installed on PATH here, so CI should run `flutter pub get`, code generation, and tests on the branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Orders canceled due to counterparty timeout now display a specific notification message, localized in English, Spanish, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->