### PR TITLE
fix(notifications): clarify timeout cancellation copy

### DIFF
--- a/lib/features/notifications/utils/notification_message_mapper.dart
+++ b/lib/features/notifications/utils/notification_message_mapper.dart
@@ -94,11 +94,19 @@ class NotificationMessageMapper {
   /// Maps an action to its corresponding notification message key with context values
   static String getMessageKeyWithContext(mostro.Action action, Map<String, dynamic>? values) {
     // Handle special cases with context
-    if (values != null && action == mostro.Action.addInvoice) {
-      if (values.containsKey('fiat_amount') && values.containsKey('failed_at')) {
+    if (values != null) {
+      if (action == mostro.Action.addInvoice &&
+          values.containsKey('fiat_amount') &&
+          values.containsKey('failed_at')) {
         return 'notification_add_invoice_after_failure_message';
       }
+
+      if (action == mostro.Action.canceled &&
+          values['reason'] == 'counterparty-timeout') {
+        return 'notification_order_canceled_by_timeout_message';
+      }
     }
+
     // Fall back to normal message key
     return getMessageKey(action);
   }
@@ -314,6 +322,8 @@ class NotificationMessageMapper {
         return s.notification_order_canceled_title;
       case 'notification_order_canceled_message':
         return s.notification_order_canceled_message;
+      case 'notification_order_canceled_by_timeout_message':
+        return s.notification_order_canceled_by_timeout_message;
       case 'notification_cooperative_cancel_initiated_by_you_title':
         return s.notification_cooperative_cancel_initiated_by_you_title;
       case 'notification_cooperative_cancel_initiated_by_you_message':

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1130,6 +1130,7 @@
     "notification_dispute_started_message": "A dispute has been initiated",
     "notification_order_canceled_title": "Order canceled",
     "notification_order_canceled_message": "The order has been canceled",
+    "notification_order_canceled_by_timeout_message": "The counterparty did not respond in time. The order has been canceled.",
     "notification_cooperative_cancel_initiated_by_you_title": "Cancellation requested",
     "notification_cooperative_cancel_initiated_by_you_message": "You requested to cancel the order, waiting for peer confirmation",
     "notification_cooperative_cancel_initiated_by_peer_title": "Cancellation request",

--- a/test/features/notifications/notification_message_mapper_test.dart
+++ b/test/features/notifications/notification_message_mapper_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart' as mostro;
+import 'package:mostro_mobile/features/notifications/utils/notification_message_mapper.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+
+void main() {
+  group('NotificationMessageMapper', () {
+    testWidgets('uses timeout-specific cancellation copy when reason is counterparty-timeout', (tester) async {
+      late BuildContext context;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: Builder(
+            builder: (buildContext) {
+              context = buildContext;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final message = NotificationMessageMapper.getLocalizedMessage(
+        context,
+        mostro.Action.canceled,
+        values: const {'reason': 'counterparty-timeout'},
+      );
+
+      expect(
+        message,
+        'The counterparty did not respond in time. The order has been canceled.',
+      );
+    });
+
+    testWidgets('keeps generic cancellation copy for other cancellation reasons', (tester) async {
+      late BuildContext context;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: Builder(
+            builder: (buildContext) {
+              context = buildContext;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final message = NotificationMessageMapper.getLocalizedMessage(
+        context,
+        mostro.Action.canceled,
+        values: const {'reason': 'user-canceled'},
+      );
+
+      expect(message, 'The order has been canceled');
+    });
+  });
+}


### PR DESCRIPTION
## Why
When an order expires because the counterparty never responds, the app currently shows the same generic cancellation copy used for user-initiated cancellations. That makes a timeout look like an action the user took, which is misleading.

## What changed
- add a timeout-specific notification message for `Action.canceled`
- select that message when notification payloads include `reason=counterparty-timeout`
- add a regression test covering both timeout and non-timeout cancellation messages

## Verification
- `python3 -m json.tool lib/l10n/intl_en.arb`
- added `test/features/notifications/notification_message_mapper_test.dart`
- `flutter test test/features/notifications/notification_message_mapper_test.dart` could not be run in this environment because `flutter` is not installed

Closes #532.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual notification messages when orders are canceled due to counterparty timeout
  * Added notification support for invoice add failures

* **Localization**
  * New English translation for timeout-related order cancellations

* **Tests**
  * Added test coverage for notification message mapping with different cancellation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->