### PR TITLE
fix: improve cancellation message when order expires

### DIFF
--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -297,6 +297,9 @@ class OrderState {
       case Action.adminCancel:
       case Action.cooperativeCancelAccepted:
       case Action.holdInvoicePaymentCanceled:
+        if (payloadStatus == Status.expired) {
+          return Status.expired;
+        }
         return Status.canceled;
 
       // Actions that should set status to cooperatively canceled (pending cancellation)

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -70,6 +70,9 @@ class MostroMessageDetail extends ConsumerWidget {
                 24;
         return S.of(context)!.newOrder(expHrs.toString());
       case actions.Action.canceled:
+        if (tradeState.status == Status.expired) {
+          return S.of(context)!.canceledByTimeout;
+        }
         return S.of(context)!.canceled(orderPayload?.id ?? '');
       case actions.Action.payInvoice:
         final expSecs = ref

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -11,6 +11,7 @@
         }
     },
     "canceled": "You have canceled the order ID: {id}.",
+    "canceledByTimeout": "The counterparty did not respond in time. The order has been canceled.",
     "payInvoice": "Please pay this hold invoice of {amount} Sats for {fiat_code} {fiat_amount} to start the operation. If you do not pay it within {expiration_seconds} minutes, the trade will be canceled.",
     "@payInvoice": {
         "placeholders": {

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -10,6 +10,7 @@
         }
     },
     "canceled": "Has cancelado la orden ID: {id}.",
+    "canceledByTimeout": "Tu contraparte no respondió a tiempo. La orden ha sido cancelada.",
     "payInvoice": "Por favor paga esta factura retenida de {amount} Sats por {fiat_amount} {fiat_code} para iniciar la operación. Si no la pagas antes de {expiration_seconds} minutos, el intercambio será cancelado.",
     "@payInvoice": {
         "placeholders": {


### PR DESCRIPTION
Improves the cancellation message shown to the user when an order expires due to counterparty inactivity. Instead of saying 'You have canceled the order', it now says 'The counterparty did not respond in time. The order has been canceled.' if the order status is expired.\n\nFixes #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order status handling: Orders now correctly display as "expired" when the counterparty fails to respond in time, rather than showing as canceled.
  * Enhanced user messaging: Added a specific timeout-related message to clarify when orders expire due to inactivity, now available in English and Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->