### PR TITLE
fix: resolve dependency conflicts and update google_fonts to v8

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 class AppTheme {
   // Original colors
@@ -98,12 +97,14 @@ class AppTheme {
       ),
       dialogTheme: DialogThemeData(
         backgroundColor: dark2,
-        titleTextStyle: GoogleFonts.robotoCondensed(
+        titleTextStyle: const TextStyle(
+          fontFamily: 'Roboto Condensed',
           fontWeight: FontWeight.bold,
           fontSize: 20.0,
           color: cream1,
         ),
-        contentTextStyle: GoogleFonts.robotoCondensed(
+        contentTextStyle: const TextStyle(
+          fontFamily: 'Roboto Condensed',
           fontWeight: FontWeight.w400,
           fontSize: 16.0,
           color: grey,
@@ -117,7 +118,8 @@ class AppTheme {
         style: ElevatedButton.styleFrom(
           foregroundColor: Colors.black,
           backgroundColor: mostroGreen,
-          textStyle: GoogleFonts.robotoCondensed(
+          textStyle: const TextStyle(
+            fontFamily: 'Roboto Condensed',
             fontWeight: FontWeight.w500,
             fontSize: 14.0,
           ),
@@ -133,7 +135,8 @@ class AppTheme {
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(
           foregroundColor: mostroGreen,
-          textStyle: GoogleFonts.robotoCondensed(
+          textStyle: const TextStyle(
+            fontFamily: 'Roboto Condensed',
             fontWeight: FontWeight.w500,
             fontSize: 14.0,
           ),
@@ -143,7 +146,8 @@ class AppTheme {
         style: OutlinedButton.styleFrom(
           foregroundColor: mostroGreen,
           side: const BorderSide(color: mostroGreen),
-          textStyle: GoogleFonts.robotoCondensed(
+          textStyle: const TextStyle(
+            fontFamily: 'Roboto Condensed',
             fontWeight: FontWeight.w500,
             fontSize: 14.0,
           ),
@@ -174,58 +178,28 @@ class AppTheme {
         color: cream1,
         size: 24.0,
       ),
-      listTileTheme: ListTileThemeData(
+      listTileTheme: const ListTileThemeData(
         titleTextStyle: TextStyle(
           color: grey,
-          fontFamily: GoogleFonts.robotoCondensed().fontFamily,
+          fontFamily: 'Roboto Condensed',
         ),
       ),
     );
   }
 
   static TextTheme _buildTextTheme() {
-    return GoogleFonts.robotoCondensedTextTheme(
-      const TextTheme(
-        displayLarge: TextStyle(
-          fontSize: 24.0,
-        ),
-        displayMedium: TextStyle(
-          fontWeight: FontWeight.w700,
-          fontSize: 20.0,
-        ),
-        displaySmall: TextStyle(
-          fontWeight: FontWeight.w700,
-          fontSize: 16.0,
-        ),
-        headlineMedium: TextStyle(
-          fontWeight: FontWeight.w700,
-          fontSize: 16.0,
-        ),
-        headlineSmall: TextStyle(
-          fontWeight: FontWeight.w500,
-          fontSize: 14.0,
-        ),
-        titleMedium: TextStyle(
-          fontWeight: FontWeight.w500,
-          fontSize: 16.0,
-        ),
-        titleLarge: TextStyle(
-          fontWeight: FontWeight.w500,
-          fontSize: 18.0,
-        ),
-        bodyLarge: TextStyle(
-          fontWeight: FontWeight.w400,
-          fontSize: 16.0,
-        ),
-        bodyMedium: TextStyle(
-          fontWeight: FontWeight.w400,
-          fontSize: 14.0,
-        ),
-        labelLarge: TextStyle(
-          fontWeight: FontWeight.w500,
-          fontSize: 14.0,
-        ),
-      ),
+    const fontFamily = 'Roboto Condensed';
+    return const TextTheme(
+      displayLarge: TextStyle(fontFamily: fontFamily, fontSize: 24.0),
+      displayMedium: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w700, fontSize: 20.0),
+      displaySmall: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w700, fontSize: 16.0),
+      headlineMedium: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w700, fontSize: 16.0),
+      headlineSmall: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w500, fontSize: 14.0),
+      titleMedium: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w500, fontSize: 16.0),
+      titleLarge: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w500, fontSize: 18.0),
+      bodyLarge: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w400, fontSize: 16.0),
+      bodyMedium: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w400, fontSize: 14.0),
+      labelLarge: TextStyle(fontFamily: fontFamily, fontWeight: FontWeight.w500, fontSize: 14.0),
     ).apply(
       bodyColor: cream1,
       displayColor: cream1,

--- a/lib/features/order/widgets/order_app_bar.dart
+++ b/lib/features/order/widgets/order_app_bar.dart
@@ -22,7 +22,7 @@ class OrderAppBar extends StatelessWidget implements PreferredSizeWidget {
       ),
       title: Text(
         title,
-        style: TextStyle(
+        style: const TextStyle(
           color: AppTheme.cream1,
           fontFamily: 'Roboto Condensed',
         ),

--- a/lib/features/order/widgets/order_app_bar.dart
+++ b/lib/features/order/widgets/order_app_bar.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 
@@ -25,7 +24,7 @@ class OrderAppBar extends StatelessWidget implements PreferredSizeWidget {
         title,
         style: TextStyle(
           color: AppTheme.cream1,
-          fontFamily: GoogleFonts.robotoCondensed().fontFamily,
+          fontFamily: 'Roboto Condensed',
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -807,14 +807,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "16.0.0"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: db9df7a5898d894eeda4c78143f35c30a243558be439518972366880b80bf88e
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.2"
   graphs:
     dependency: transitive
     description:
@@ -1956,4 +1948,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.32.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -18,21 +18,21 @@ packages:
     source: hosted
     version: "1.3.65"
   analyzer:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer
-      sha256: f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c
+      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.0"
+    version: "8.4.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce
+      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.10"
   app_links:
     dependency: "direct main"
     description:
@@ -229,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -349,26 +349,26 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2"
+      sha256: "91f2a81e9f0abb4b9f3bb529f78b6227ce6050300d1ae5b1e2c69c66c7a566d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+7.7.0"
+    version: "1.0.0+8.4.0"
   dart_nostr:
     dependency: "direct main"
     description:
       name: dart_nostr
-      sha256: d7ffb5159be6ab174c8af4457d5112c925eb2c2294ce1251707ae680c90e15db
+      sha256: d526a8b62ba023e650d2285af2c3a3e7bcf56cdb7a306086c3397b0b93bdd148
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.1"
+    version: "9.2.5"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   dbus:
     dependency: transitive
     description:
@@ -811,10 +811,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      sha256: db9df7a5898d894eeda4c78143f35c30a243558be439518972366880b80bf88e
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "8.0.2"
   graphs:
     dependency: transitive
     description:
@@ -1104,26 +1104,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -1710,26 +1710,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.16"
   timeago:
     dependency: "direct main"
     description:
@@ -1890,14 +1890,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.3"
   webdriver:
     dependency: transitive
     description:
@@ -1947,5 +1955,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <=3.9.9"
-  flutter: ">=3.32.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   equatable: ^2.0.5
   logger: ^2.5.0
   local_auth: ^2.3.0
-  google_fonts: ^8.0.0
   timeago: ^3.7.0
   flutter_riverpod: ^2.6.1
   collection: ^1.18.0
@@ -108,7 +107,7 @@ dependencies:
 
 dependency_overrides:
   bip340: ^0.2.0
-  analyzer: '>=7.0.0 <9.0.0'
+  analyzer: ^8.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   equatable: ^2.0.5
   logger: ^2.5.0
   local_auth: ^2.3.0
-  google_fonts: ^6.2.1
+  google_fonts: ^8.0.0
   timeago: ^3.7.0
   flutter_riverpod: ^2.6.1
   collection: ^1.18.0
@@ -108,6 +108,7 @@ dependencies:
 
 dependency_overrides:
   bip340: ^0.2.0
+  analyzer: '>=7.0.0 <9.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Add analyzer override (>=7.0.0 <9.0.0) to unblock pub resolution; riverpod_generator 2.6.5 declares analyzer ^7 but the current Flutter SDK pins test_api 0.7.10 which pulls in test 1.30 requiring analyzer
  >=8.0.0 — the override lets both coexist without a full Riverpod 3.x
  migration
- Upgrade google_fonts ^6.2.1 → ^8.0.0; 6.x used FontWeight as a const map key which the current Dart SDK no longer allows
- Replace GoogleFonts.robotoCondensed* calls in app_theme.dart and order_app_bar.dart with the locally bundled 'Roboto Condensed' font family (already declared in pubspec.yaml assets/fonts), removing the runtime google_fonts dependency for that typeface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched typography to use the app’s bundled Roboto Condensed styling; visual appearance preserved with no expected changes.
* **Chores**
  * Removed an external font package and cleaned up dependency configuration for slimmer installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->