### PR TITLE
feat: increase session expiration from 72 hours to 30 days

### DIFF
--- a/docs/architecture/APP_INITIALIZATION_ANALYSIS.md
+++ b/docs/architecture/APP_INITIALIZATION_ANALYSIS.md
@@ -286,7 +286,7 @@ Future<void> init() async {
 
 **Critical Aspects**:
 - Loads sessions from Sembast database
-- Filters expired sessions (older than 72 hours)
+- Filters expired sessions (older than 720 hours / 30 days)
 - Updates `state` which triggers all listeners
 - **Must complete before SubscriptionManager setup**
 

--- a/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
+++ b/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
@@ -216,7 +216,7 @@ Sessions are persisted using `SessionStorage` (`lib/data/repositories/session_st
 
 - **Active Sessions**: Stored in memory (`SessionNotifier._sessions` map)
 - **Persistent Storage**: Serialized to Sembast for app restart recovery
-- **Cleanup**: Automatic cleanup of expired sessions (72 hours default)
+- **Cleanup**: Automatic cleanup of expired sessions (720 hours / 30 days default)
 
 ### Session Recovery from Mnemonic
 
@@ -292,7 +292,7 @@ Sessions can be deleted through several mechanisms:
 1. **Automatic Cleanup**: 10-second timer when no response from Mostro (both session types)
 2. **Timeout Detection**: Real-time detection via public events (taker scenarios)
 3. **Cancellation**: When orders are cancelled (pending/waiting states only)
-4. **Expiration**: Periodic cleanup of sessions older than 72 hours
+4. **Expiration**: Periodic cleanup of sessions older than 720 hours (30 days)
 5. **Manual**: User-initiated session cleanup through settings
 
 #### **Session Cleanup Implementation**

--- a/docs/architecture/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
+++ b/docs/architecture/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
@@ -202,7 +202,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
 ```
 
 **Key Features**:
-- **Automatic expiration**: Removes sessions older than 36 hours (Config.sessionExpirationHours)
+- **Automatic expiration**: Removes sessions older than 720 hours / 30 days (Config.sessionExpirationHours)
 - **Periodic cleanup**: Scheduled cleanup every 30 minutes to prevent memory leaks
 - **State synchronization**: Updates trigger automatic UI updates
 - **Storage persistence**: Sessions survive app restarts
@@ -675,7 +675,7 @@ final expHours = mostroInstance?.expirationHours ?? 24;       // Default 24h for
 final expSecs = mostroInstance?.expirationSeconds ?? 900;     // Default 15min for waiting
 
 // Session expiration
-const sessionExpirationHours = 36; // Defined in Config class (lib/core/config.dart)
+const sessionExpirationHours = 720; // Defined in Config class (lib/core/config.dart)
 const cleanupIntervalMinutes = 30;  // Cleanup frequency
 ```
 
@@ -684,7 +684,7 @@ const cleanupIntervalMinutes = 30;  // Cleanup frequency
 ```dart
 // lib/core/config.dart
 class Config {
-  static const int sessionExpirationHours = 72;
+  static const int sessionExpirationHours = 720;
 }
 
 // Timeout durations (currently hardcoded, could be made configurable)

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -48,7 +48,7 @@ class Config {
   static const int expirationSeconds = 900;
   static const int expirationHours = 24;
   static const int cleanupIntervalMinutes = 30;
-  static const int sessionExpirationHours = 72;
+  static const int sessionExpirationHours = 720;
 
   // Notification configuration
   static String notificationChannelId = 'mostro_mobile';


### PR DESCRIPTION
  - Users reported orders disappearing too quickly from My Trades
  - Increased Config.sessionExpirationHours from 72 to 720 (30 days)
  - Updated architecture documentation to reflect the new expiration window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session management documentation to reflect revised expiration timelines.

* **Chores**
  * Extended session expiration window from 3 days to 30 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->