### PR TITLE
feat: add configurable trade history retention in settings

### DIFF
--- a/docs/architecture/APP_INITIALIZATION_ANALYSIS.md
+++ b/docs/architecture/APP_INITIALIZATION_ANALYSIS.md
@@ -286,7 +286,7 @@ Future<void> init() async {
 
 **Critical Aspects**:
 - Loads sessions from Sembast database
-- Filters expired sessions (older than 720 hours / 30 days)
+- Filters expired sessions based on user-configured retention period (default: 720 hours / 30 days, configurable in Settings). Expired sessions and all associated data (events, messages, notifications, read status) are cascade-deleted. If set to "never", all sessions are loaded without filtering.
 - Updates `state` which triggers all listeners
 - **Must complete before SubscriptionManager setup**
 

--- a/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
+++ b/docs/architecture/SESSION_AND_KEY_MANAGEMENT.md
@@ -216,7 +216,7 @@ Sessions are persisted using `SessionStorage` (`lib/data/repositories/session_st
 
 - **Active Sessions**: Stored in memory (`SessionNotifier._sessions` map)
 - **Persistent Storage**: Serialized to Sembast for app restart recovery
-- **Cleanup**: Automatic cleanup of expired sessions (720 hours / 30 days default)
+- **Cleanup**: User-configurable automatic cleanup (presets: 1 week, 1 month, 3 months, 6 months, 1 year, never). Default: 1 month (720 hours). When a session expires, all associated data is cascade-deleted: chat events, dispute chat events, mostro messages, notifications, and read status keys.
 
 ### Session Recovery from Mnemonic
 
@@ -292,7 +292,7 @@ Sessions can be deleted through several mechanisms:
 1. **Automatic Cleanup**: 10-second timer when no response from Mostro (both session types)
 2. **Timeout Detection**: Real-time detection via public events (taker scenarios)
 3. **Cancellation**: When orders are cancelled (pending/waiting states only)
-4. **Expiration**: Periodic cleanup of sessions older than 720 hours (30 days)
+4. **Expiration**: Periodic cleanup based on user-configured retention period (default 30 days, configurable in Settings: 1 week / 1 month / 3 months / 6 months / 1 year / never). Cascade-deletes all associated data (events, messages, notifications, read status).
 5. **Manual**: User-initiated session cleanup through settings
 
 #### **Session Cleanup Implementation**

--- a/docs/architecture/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
+++ b/docs/architecture/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
@@ -174,38 +174,92 @@ class SessionNotifier extends StateNotifier<List<Session>> {
   final Map<int, Session> _requestIdToSession = {}; // For temporary orders
   Timer? _cleanupTimer;
 
+  // Reads from user settings, falls back to Config.sessionExpirationHours (720h)
+  // Value of 0 means "never" (no automatic cleanup)
+  int get _expirationHours =>
+      _settings.sessionExpirationHours ?? Config.sessionExpirationHours;
+
+  bool get _isForever => _expirationHours == 0;
+
   Future<void> init() async {
-    // Load all sessions and expire old ones
     final allSessions = await _storage.getAllSessions();
-    final cutoff = DateTime.now()
-        .subtract(const Duration(hours: Config.sessionExpirationHours));
-    
-    for (final session in allSessions) {
-      if (session.startTime.isAfter(cutoff)) {
+    if (_isForever) {
+      // "Never" mode: load all sessions without filtering
+      for (final session in allSessions) {
         _sessions[session.orderId!] = session;
-      } else {
-        await _storage.deleteSession(session.orderId!);
-        _sessions.remove(session.orderId!);
+      }
+    } else {
+      final cutoff = DateTime.now()
+          .subtract(Duration(hours: _expirationHours));
+      for (final session in allSessions) {
+        if (session.startTime.isAfter(cutoff)) {
+          _sessions[session.orderId!] = session;
+        } else {
+          await _storage.deleteSession(session.orderId!);
+          _sessions.remove(session.orderId!);
+          await _cleanupSessionData(session); // Cascade delete all associated data
+        }
       }
     }
-    
-    state = sessions; // Triggers all listeners
-    _scheduleCleanup(); // Schedule periodic cleanup
+    _emitState();
+    _scheduleCleanup();
   }
 
-  Future<void> deleteSession(String sessionId) async {
-    _sessions.remove(sessionId);
-    await _storage.deleteSession(sessionId);
-    state = sessions; // Update state to trigger UI updates
+  void _cleanup() async {
+    if (_isForever) return; // Skip cleanup entirely in "never" mode
+    // ... same cascade logic as init()
+  }
+
+  /// Deletes all data associated with an expired session
+  Future<void> _cleanupSessionData(Session session) async {
+    final orderId = session.orderId!;
+    // 1. Chat events from eventStore (keyed by order_id)
+    await eventStore.deleteWhere(Filter.equals('order_id', orderId));
+    // 2. Dispute chat events from eventStore (keyed by dispute_id)
+    if (session.disputeId != null) {
+      await eventStore.deleteWhere(Filter.equals('dispute_id', session.disputeId));
+    }
+    // 3. Mostro protocol messages from mostroStorage
+    await mostroStore.deleteAllMessagesByOrderId(orderId);
+    // 4. Notifications from notificationsRepository
+    await notificationsStore.deleteWhere(Filter.equals('orderId', orderId));
+    // 5. Chat/dispute read status from SharedPreferences
+    await prefs.remove('chat_last_read_$orderId');
+    if (session.disputeId != null) {
+      await prefs.remove('dispute_last_read_${session.disputeId}');
+    }
   }
 }
 ```
 
 **Key Features**:
-- **Automatic expiration**: Removes sessions older than 720 hours / 30 days (Config.sessionExpirationHours)
-- **Periodic cleanup**: Scheduled cleanup every 30 minutes to prevent memory leaks
+- **User-configurable expiration**: Users choose retention period in Settings (1 week, 1 month, 3 months, 6 months, 1 year, or never)
+- **Default**: 1 month (720 hours), stored in `Settings.sessionExpirationHours`, falls back to `Config.sessionExpirationHours`
+- **"Never" mode**: Value `0` disables automatic cleanup entirely — sessions and data persist indefinitely
+- **Cascading cleanup**: When a session expires, ALL associated data is deleted (see below)
+- **Periodic cleanup**: Scheduled every 30 minutes (`Config.cleanupIntervalMinutes`)
 - **State synchronization**: Updates trigger automatic UI updates
 - **Storage persistence**: Sessions survive app restarts
+
+#### What Gets Cleaned Up
+
+When a session expires, the following data is deleted:
+
+| Storage | What's deleted | Filter |
+|---|---|---|
+| sessionStorage | Session record | `orderId` |
+| eventStore | Chat gift wrap events | `order_id = orderId` |
+| eventStore | Dispute chat gift wrap events | `dispute_id = disputeId` |
+| mostroStorage | Mostro protocol messages | `id = orderId` |
+| notificationsRepository | Order notifications | `orderId = orderId` |
+| SharedPreferences | Chat read status | `chat_last_read_{orderId}` |
+| SharedPreferences | Dispute read status | `dispute_last_read_{disputeId}` |
+
+#### What Is NOT Cleaned Up (by design)
+
+| Storage | What remains | Why |
+|---|---|---|
+| eventStore | MostroService dedup stubs (`id` + `created_at` only) | These are the only deduplication mechanism. Deleting them could cause duplicate event processing if a relay re-delivers old events. They have no `order_id` field and are ~100 bytes each — negligible impact. |
 
 ### Session Provider Pattern
 
@@ -674,7 +728,7 @@ The system uses dynamic configuration from the Mostro Instance Nostr event:
 final expHours = mostroInstance?.expirationHours ?? 24;       // Default 24h for pending
 final expSecs = mostroInstance?.expirationSeconds ?? 900;     // Default 15min for waiting
 
-// Session expiration
+// Session expiration (user-configurable, this is the default fallback)
 const sessionExpirationHours = 720; // Defined in Config class (lib/core/config.dart)
 const cleanupIntervalMinutes = 30;  // Cleanup frequency
 ```
@@ -684,8 +738,17 @@ const cleanupIntervalMinutes = 30;  // Cleanup frequency
 ```dart
 // lib/core/config.dart
 class Config {
-  static const int sessionExpirationHours = 720;
+  static const int sessionExpirationHours = 720; // Default: 30 days
+  static const int cleanupIntervalMinutes = 30;
 }
+
+// User-configurable presets (stored in Settings.sessionExpirationHours):
+//   168  = 1 week
+//   720  = 1 month (default)
+//   2160 = 3 months
+//   4320 = 6 months
+//   8760 = 1 year
+//   0    = never (no automatic cleanup)
 
 // Timeout durations (currently hardcoded, could be made configurable)
 static const Duration sessionCleanupTimeout = Duration(seconds: 5);
@@ -765,8 +828,9 @@ final session = ref.read(sessionNotifierProvider.notifier).getSessionByOrderId(o
 **Memory Management**:
 - Automatic timer cleanup when no listeners
 - Proper provider disposal handling
-- Session cleanup removes expired entries
+- Session cleanup removes expired entries and all associated data (events, messages, notifications, read status)
 - Race condition flags prevent resource leaks
+- MostroService dedup stubs are intentionally retained to prevent duplicate event processing
 
 ---
 

--- a/lib/data/models/enums/status.dart
+++ b/lib/data/models/enums/status.dart
@@ -27,6 +27,21 @@ enum Status {
     );
   }
 
+  /// Whether this status represents a completed/final state
+  /// where the session can be safely deleted during cleanup.
+  bool get isTerminal => switch (this) {
+        Status.success ||
+        Status.canceled ||
+        Status.canceledByAdmin ||
+        Status.settledByAdmin ||
+        Status.completedByAdmin ||
+        Status.cooperativelyCanceled ||
+        Status.expired ||
+        Status.settledHoldInvoice =>
+          true,
+        _ => false,
+      };
+
   @override
   String toString() {
     return value;

--- a/lib/data/repositories/notifications_history_repository.dart
+++ b/lib/data/repositories/notifications_history_repository.dart
@@ -11,6 +11,7 @@ abstract class NotificationsRepository {
   Future<void> markAsRead(String notificationId);
   Future<void> markAllAsRead();
   Future<void> deleteNotification(String notificationId);
+  Future<void> deleteByOrderId(String orderId);
   Future<void> clearAll();
   Stream<List<NotificationModel>> watchNotifications();
   Future<List<NotificationModel>> getUnreadNotifications();
@@ -110,6 +111,11 @@ class NotificationsStorage extends BaseStorage<NotificationModel>
   @override
   Future<void> deleteNotification(String notificationId) async {
     await deleteItem(notificationId);
+  }
+
+  @override
+  Future<void> deleteByOrderId(String orderId) async {
+    await deleteWhere(Filter.equals('orderId', orderId));
   }
 
   @override

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -12,6 +12,7 @@ class Settings {
   final bool pushNotificationsEnabled;
   final bool notificationSoundEnabled;
   final bool notificationVibrationEnabled;
+  final int? sessionExpirationHours;
 
   Settings({
     required this.relays,
@@ -26,6 +27,7 @@ class Settings {
     this.pushNotificationsEnabled = true,
     this.notificationSoundEnabled = true,
     this.notificationVibrationEnabled = true,
+    this.sessionExpirationHours,
   });
 
   Settings copyWith({
@@ -42,6 +44,8 @@ class Settings {
     bool? pushNotificationsEnabled,
     bool? notificationSoundEnabled,
     bool? notificationVibrationEnabled,
+    int? sessionExpirationHours,
+    bool clearSessionExpiration = false,
   }) {
     return Settings(
       relays: relays ?? this.relays,
@@ -58,6 +62,9 @@ class Settings {
       pushNotificationsEnabled: pushNotificationsEnabled ?? this.pushNotificationsEnabled,
       notificationSoundEnabled: notificationSoundEnabled ?? this.notificationSoundEnabled,
       notificationVibrationEnabled: notificationVibrationEnabled ?? this.notificationVibrationEnabled,
+      sessionExpirationHours: clearSessionExpiration
+          ? null
+          : (sessionExpirationHours ?? this.sessionExpirationHours),
     );
   }
 
@@ -73,6 +80,7 @@ class Settings {
         'pushNotificationsEnabled': pushNotificationsEnabled,
         'notificationSoundEnabled': notificationSoundEnabled,
         'notificationVibrationEnabled': notificationVibrationEnabled,
+        'sessionExpirationHours': sessionExpirationHours,
       };
 
   factory Settings.fromJson(Map<String, dynamic> json) {
@@ -90,6 +98,7 @@ class Settings {
       pushNotificationsEnabled: json['pushNotificationsEnabled'] as bool? ?? true,
       notificationSoundEnabled: json['notificationSoundEnabled'] as bool? ?? true,
       notificationVibrationEnabled: json['notificationVibrationEnabled'] as bool? ?? true,
+      sessionExpirationHours: json['sessionExpirationHours'] as int?,
     );
   }
 }

--- a/lib/features/settings/settings_notifier.dart
+++ b/lib/features/settings/settings_notifier.dart
@@ -205,5 +205,12 @@ class SettingsNotifier extends StateNotifier<Settings> {
     await _saveToPrefs();
   }
 
+  Future<void> updateSessionExpirationHours(int newValue) async {
+    final oldValue = state.sessionExpirationHours;
+    state = state.copyWith(sessionExpirationHours: newValue);
+    await _saveToPrefs();
+    logger.i('Session expiration changed: $oldValue → $newValue hours');
+  }
+
   Settings get settings => state.copyWith();
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -14,6 +14,7 @@ import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/shared/widgets/currency_selection_dialog.dart';
 import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/widgets/language_selector.dart';
+import 'package:mostro_mobile/shared/widgets/trade_history_selector.dart';
 import 'package:mostro_mobile/features/wallet/widgets/wallet_status_card.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
@@ -107,6 +108,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
                   // Notification Settings Card
                   _buildNotificationSettingsCard(context),
+                  const SizedBox(height: 16),
+
+                  // Trade History Card
+                  _buildTradeHistoryCard(context),
                   const SizedBox(height: 16),
 
                   // Dev Tools Card
@@ -221,6 +226,69 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
               ),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTradeHistoryCard(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppTheme.backgroundCard,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(
+                  LucideIcons.history,
+                  color: AppTheme.activeColor,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  S.of(context)!.tradeHistory,
+                  style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const Spacer(),
+                InkWell(
+                  onTap: () => _showInfoDialog(
+                    context,
+                    S.of(context)!.tradeHistory,
+                    S.of(context)!.tradeHistoryInfoText,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                  child: const Padding(
+                    padding: EdgeInsets.all(8.0),
+                    child: Icon(
+                      Icons.info_outline,
+                      size: 20,
+                      color: AppTheme.textSecondary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Text(
+              S.of(context)!.tradeHistoryDescription,
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 14,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const TradeHistorySelector(),
           ],
         ),
       ),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -260,23 +260,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
-                const Spacer(),
-                InkWell(
-                  onTap: () => _showInfoDialog(
-                    context,
-                    S.of(context)!.tradeHistory,
-                    S.of(context)!.tradeHistoryInfoText,
-                  ),
-                  borderRadius: BorderRadius.circular(12),
-                  child: const Padding(
-                    padding: EdgeInsets.all(8.0),
-                    child: Icon(
-                      Icons.info_outline,
-                      size: 20,
-                      color: AppTheme.textSecondary,
-                    ),
-                  ),
-                ),
               ],
             ),
             const SizedBox(height: 20),

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1532,5 +1532,14 @@
     "communityDisclaimerTitle": "Wichtiger Hinweis",
     "communityDisclaimerBody": "Das Mostro-Entwicklungsteam ist nicht verantwortlich fuer die Nutzung der Plattform durch Node-Betreiber. Jeder Betreiber kontrolliert seinen eigenen Mostro-Node und ist allein verantwortlich fuer seine Handlungen. Mit der Nutzung von Mostro akzeptieren Sie die volle Verantwortung fuer Ihre Transaktionen und erkennen an, dass das Entwicklungsteam keine Kontrolle ueber einzelne Node-Betreiber hat.",
     "communityDisclaimerAccept": "Akzeptieren",
-    "tooManyRequests": "Zu viele Anfragen, bitte versuche es später erneut."
+    "tooManyRequests": "Zu viele Anfragen, bitte versuche es später erneut.",
+    "tradeHistory": "Trade-Verlauf",
+    "tradeHistoryDescription": "Wähle, wie lange deine abgeschlossenen Trades gespeichert werden. Ältere Trades werden automatisch entfernt.",
+    "tradeHistoryInfoText": "Diese Einstellung steuert, wie lange deine Trade-Sitzungen und Chat-Nachrichten auf deinem Gerät gespeichert werden. Nach dem gewählten Zeitraum werden sie automatisch gelöscht.",
+    "oneWeek": "1 Woche",
+    "oneMonth": "1 Monat",
+    "threeMonths": "3 Monate",
+    "sixMonths": "6 Monate",
+    "oneYear": "1 Jahr",
+    "never": "Nie"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1532,5 +1532,14 @@
     "communityDisclaimerTitle": "Important Notice",
     "communityDisclaimerBody": "The Mostro development team is not responsible for how node operators use the platform. Each operator controls their own Mostro node and is solely responsible for their actions. By using Mostro, you accept full responsibility for your trades and acknowledge that the development team has no control over individual node operators.",
     "communityDisclaimerAccept": "Accept",
-    "tooManyRequests": "Too many requests, please try again later."
+    "tooManyRequests": "Too many requests, please try again later.",
+    "tradeHistory": "Trade history",
+    "tradeHistoryDescription": "Choose how long to keep your completed trades. Older trades will be automatically removed.",
+    "tradeHistoryInfoText": "This setting controls how long your trade sessions and chat messages are stored on your device. After the selected period, they are automatically deleted.",
+    "oneWeek": "1 week",
+    "oneMonth": "1 month",
+    "threeMonths": "3 months",
+    "sixMonths": "6 months",
+    "oneYear": "1 year",
+    "never": "Never"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1507,5 +1507,14 @@
     "communityDisclaimerTitle": "Aviso Importante",
     "communityDisclaimerBody": "El equipo de desarrollo de Mostro no se hace responsable del uso que los operadores de nodos hagan de la plataforma. Cada operador controla su propio nodo Mostro y es el unico responsable de sus acciones. Al usar Mostro, aceptas la plena responsabilidad de tus operaciones y reconoces que el equipo de desarrollo no tiene control sobre los operadores de nodos individuales.",
     "communityDisclaimerAccept": "Aceptar",
-    "tooManyRequests": "Demasiadas solicitudes, por favor inténtalo más tarde."
+    "tooManyRequests": "Demasiadas solicitudes, por favor inténtalo más tarde.",
+    "tradeHistory": "Historial de trades",
+    "tradeHistoryDescription": "Elige cuánto tiempo conservar tus trades completados. Los más antiguos se eliminarán automáticamente.",
+    "tradeHistoryInfoText": "Esta configuración controla cuánto tiempo se almacenan tus sesiones de trade y mensajes de chat en tu dispositivo. Después del periodo seleccionado, se eliminan automáticamente.",
+    "oneWeek": "1 semana",
+    "oneMonth": "1 mes",
+    "threeMonths": "3 meses",
+    "sixMonths": "6 meses",
+    "oneYear": "1 año",
+    "never": "Nunca"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1532,5 +1532,14 @@
     "communityDisclaimerTitle": "Avis Important",
     "communityDisclaimerBody": "L'equipe de developpement de Mostro n'est pas responsable de l'utilisation que font les operateurs de noeuds de la plateforme. Chaque operateur controle son propre noeud Mostro et est seul responsable de ses actions. En utilisant Mostro, vous acceptez l'entiere responsabilite de vos transactions et reconnaissez que l'equipe de developpement n'a aucun controle sur les operateurs de noeuds individuels.",
     "communityDisclaimerAccept": "Accepter",
-    "tooManyRequests": "Trop de requêtes, veuillez réessayer plus tard."
+    "tooManyRequests": "Trop de requêtes, veuillez réessayer plus tard.",
+    "tradeHistory": "Historique des trades",
+    "tradeHistoryDescription": "Choisissez combien de temps conserver vos trades terminés. Les plus anciens seront automatiquement supprimés.",
+    "tradeHistoryInfoText": "Ce paramètre contrôle la durée de stockage de vos sessions de trade et messages de chat sur votre appareil. Après la période sélectionnée, ils sont automatiquement supprimés.",
+    "oneWeek": "1 semaine",
+    "oneMonth": "1 mois",
+    "threeMonths": "3 mois",
+    "sixMonths": "6 mois",
+    "oneYear": "1 an",
+    "never": "Jamais"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1566,5 +1566,14 @@
     "communityDisclaimerTitle": "Avviso Importante",
     "communityDisclaimerBody": "Il team di sviluppo di Mostro non e' responsabile di come gli operatori dei nodi utilizzano la piattaforma. Ogni operatore controlla il proprio nodo Mostro ed e' l'unico responsabile delle proprie azioni. Utilizzando Mostro, accetti la piena responsabilita' per le tue operazioni e riconosci che il team di sviluppo non ha alcun controllo sui singoli operatori dei nodi.",
     "communityDisclaimerAccept": "Accetta",
-    "tooManyRequests": "Troppe richieste, riprova più tardi."
+    "tooManyRequests": "Troppe richieste, riprova più tardi.",
+    "tradeHistory": "Cronologia trade",
+    "tradeHistoryDescription": "Scegli per quanto tempo conservare i trade completati. I più vecchi verranno rimossi automaticamente.",
+    "tradeHistoryInfoText": "Questa impostazione controlla per quanto tempo le sessioni di trade e i messaggi di chat vengono memorizzati sul tuo dispositivo. Dopo il periodo selezionato, vengono eliminati automaticamente.",
+    "oneWeek": "1 settimana",
+    "oneMonth": "1 mese",
+    "threeMonths": "3 mesi",
+    "sixMonths": "6 mesi",
+    "oneYear": "1 anno",
+    "never": "Mai"
 }

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -43,16 +43,27 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     this._settings,
   ) : super([]);
 
+  int get _expirationHours =>
+      _settings.sessionExpirationHours ?? Config.sessionExpirationHours;
+
+  bool get _isForever => _expirationHours == 0;
+
   Future<void> init() async {
     final allSessions = await _storage.getAllSessions();
-    final cutoff = DateTime.now()
-        .subtract(const Duration(hours: Config.sessionExpirationHours));
-    for (final session in allSessions) {
-      if (session.startTime.isAfter(cutoff)) {
+    if (_isForever) {
+      for (final session in allSessions) {
         _sessions[session.orderId!] = session;
-      } else {
-        await _storage.deleteSession(session.orderId!);
-        _sessions.remove(session.orderId!);
+      }
+    } else {
+      final cutoff = DateTime.now()
+          .subtract(Duration(hours: _expirationHours));
+      for (final session in allSessions) {
+        if (session.startTime.isAfter(cutoff)) {
+          _sessions[session.orderId!] = session;
+        } else {
+          await _storage.deleteSession(session.orderId!);
+          _sessions.remove(session.orderId!);
+        }
       }
     }
     _emitState();
@@ -76,8 +87,10 @@ class SessionNotifier extends StateNotifier<List<Session>> {
   }
 
   void _cleanup() async {
+    if (_isForever) return;
+
     final cutoff = DateTime.now()
-        .subtract(const Duration(hours: Config.sessionExpirationHours));
+        .subtract(Duration(hours: _expirationHours));
     final expiredSessions = await _storage.getAllSessions();
     for (final session in expiredSessions) {
       if (session.startTime.isBefore(cutoff)) {

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -8,7 +8,6 @@ import 'package:mostro_mobile/data/repositories/session_storage.dart';
 import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/shared/providers/notifications_history_repository_provider.dart';
-import 'package:mostro_mobile/data/repositories/notifications_history_repository.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:sembast/sembast.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -62,8 +61,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     }
     final eventStore = ref.read(eventStorageProvider);
     final mostroStore = ref.read(mostroStorageProvider);
-    final notificationsStore =
-        ref.read(notificationsRepositoryProvider) as NotificationsStorage;
+    final notificationsRepo = ref.read(notificationsRepositoryProvider);
 
     await eventStore.deleteWhere(Filter.equals('order_id', orderId));
     if (session.disputeId != null) {
@@ -71,7 +69,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
           Filter.equals('dispute_id', session.disputeId));
     }
     await mostroStore.deleteAllMessagesByOrderId(orderId);
-    await notificationsStore.deleteWhere(Filter.equals('orderId', orderId));
+    await notificationsRepo.deleteByOrderId(orderId);
 
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('chat_last_read_$orderId');

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -11,6 +11,7 @@ import 'package:mostro_mobile/shared/providers/notifications_history_repository_
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:sembast/sembast.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/services/push_notification_service.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
@@ -78,6 +79,18 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     }
   }
 
+  /// Returns true if the session has an active (non-terminal) trade
+  /// and should be protected from cleanup.
+  Future<bool> _isActiveSession(Session session) async {
+    final orderId = session.orderId;
+    if (orderId == null) return false;
+    final mostroStore = ref.read(mostroStorageProvider);
+    final lastMessage = await mostroStore.getLatestMessageById(orderId);
+    if (lastMessage == null) return false;
+    final order = lastMessage.getPayload<Order>();
+    return order != null && !order.status.isTerminal;
+  }
+
   Future<void> init() async {
     final allSessions = await _storage.getAllSessions();
     if (_isForever) {
@@ -91,6 +104,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
         if (session.startTime.isAfter(cutoff)) {
           _sessions[session.orderId!] = session;
         } else {
+          if (await _isActiveSession(session)) {
+            logger.i('Skipping cleanup for active session ${session.orderId}');
+            _sessions[session.orderId!] = session;
+            continue;
+          }
           await _storage.deleteSession(session.orderId!);
           _sessions.remove(session.orderId!);
           try {
@@ -130,6 +148,10 @@ class SessionNotifier extends StateNotifier<List<Session>> {
 
     for (final session in expiredSessions) {
       if (session.startTime.isBefore(cutoff)) {
+        if (await _isActiveSession(session)) {
+          logger.i('Skipping cleanup for active session ${session.orderId}');
+          continue;
+        }
         await _storage.deleteSession(session.orderId!);
         _sessions.remove(session.orderId!);
         try {

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -55,7 +55,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
   bool get _isForever => _expirationHours == 0;
 
   Future<void> _cleanupSessionData(Session session) async {
-    final orderId = session.orderId!;
+    final orderId = session.orderId;
+    if (orderId == null) {
+      logger.w('Skipping cleanup for session with null orderId');
+      return;
+    }
     final eventStore = ref.read(eventStorageProvider);
     final mostroStore = ref.read(mostroStorageProvider);
     final notificationsStore =

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -5,7 +5,13 @@ import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/models/enums/role.dart';
 import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/data/repositories/session_storage.dart';
+import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
+import 'package:mostro_mobile/shared/providers/notifications_history_repository_provider.dart';
+import 'package:mostro_mobile/data/repositories/notifications_history_repository.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
+import 'package:sembast/sembast.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/services/push_notification_service.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
@@ -48,6 +54,28 @@ class SessionNotifier extends StateNotifier<List<Session>> {
 
   bool get _isForever => _expirationHours == 0;
 
+  Future<void> _cleanupSessionData(Session session) async {
+    final orderId = session.orderId!;
+    final eventStore = ref.read(eventStorageProvider);
+    final mostroStore = ref.read(mostroStorageProvider);
+    final notificationsStore =
+        ref.read(notificationsRepositoryProvider) as NotificationsStorage;
+
+    await eventStore.deleteWhere(Filter.equals('order_id', orderId));
+    if (session.disputeId != null) {
+      await eventStore.deleteWhere(
+          Filter.equals('dispute_id', session.disputeId));
+    }
+    await mostroStore.deleteAllMessagesByOrderId(orderId);
+    await notificationsStore.deleteWhere(Filter.equals('orderId', orderId));
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('chat_last_read_$orderId');
+    if (session.disputeId != null) {
+      await prefs.remove('dispute_last_read_${session.disputeId}');
+    }
+  }
+
   Future<void> init() async {
     final allSessions = await _storage.getAllSessions();
     if (_isForever) {
@@ -63,6 +91,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
         } else {
           await _storage.deleteSession(session.orderId!);
           _sessions.remove(session.orderId!);
+          await _cleanupSessionData(session);
         }
       }
     }
@@ -92,10 +121,12 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     final cutoff = DateTime.now()
         .subtract(Duration(hours: _expirationHours));
     final expiredSessions = await _storage.getAllSessions();
+
     for (final session in expiredSessions) {
       if (session.startTime.isBefore(cutoff)) {
         await _storage.deleteSession(session.orderId!);
         _sessions.remove(session.orderId!);
+        await _cleanupSessionData(session);
       }
     }
 

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -93,7 +93,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
         } else {
           await _storage.deleteSession(session.orderId!);
           _sessions.remove(session.orderId!);
-          await _cleanupSessionData(session);
+          try {
+            await _cleanupSessionData(session);
+          } catch (e) {
+            logger.e('Failed to cleanup data for session ${session.orderId}: $e');
+          }
         }
       }
     }
@@ -128,7 +132,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       if (session.startTime.isBefore(cutoff)) {
         await _storage.deleteSession(session.orderId!);
         _sessions.remove(session.orderId!);
-        await _cleanupSessionData(session);
+        try {
+          await _cleanupSessionData(session);
+        } catch (e) {
+          logger.e('Failed to cleanup data for session ${session.orderId}: $e');
+        }
       }
     }
 

--- a/lib/shared/providers/app_init_provider.dart
+++ b/lib/shared/providers/app_init_provider.dart
@@ -41,10 +41,15 @@ final appInitializerProvider = FutureProvider<void>((ref) async {
     ref.read(backgroundServiceProvider).updateSettings(next);
   });
 
-  final cutoff = DateTime.now().subtract(const Duration(hours: Config.sessionExpirationHours));
+  final settings = ref.read(settingsProvider);
+  final expirationHours = settings.sessionExpirationHours ?? Config.sessionExpirationHours;
+  final isForever = expirationHours == 0;
+  final cutoff = isForever
+      ? null
+      : DateTime.now().subtract(Duration(hours: expirationHours));
 
   for (final session in sessionManager.sessions) {
-    if(session.orderId == null || session.startTime.isBefore(cutoff)) continue;
+    if(session.orderId == null || (cutoff != null && session.startTime.isBefore(cutoff))) continue;
 
     ref.read(orderNotifierProvider(session.orderId!).notifier);
 

--- a/lib/shared/widgets/trade_history_selector.dart
+++ b/lib/shared/widgets/trade_history_selector.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/core/config.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+
+class TradeHistorySelector extends ConsumerWidget {
+  const TradeHistorySelector({super.key});
+
+  static const Map<int, String> _optionKeys = {
+    168: 'oneWeek',
+    720: 'oneMonth',
+    2160: 'threeMonths',
+    4320: 'sixMonths',
+    8760: 'oneYear',
+    0: 'never',
+  };
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(settingsProvider);
+    final currentValue = settings.sessionExpirationHours;
+
+    // Map null (no user preference) to Config default, which is 720
+    final effectiveValue = currentValue ?? Config.sessionExpirationHours;
+    // If stored value doesn't match any preset, show default (1 month)
+    final displayValue =
+        _optionKeys.containsKey(effectiveValue) ? effectiveValue : 720;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppTheme.dark1,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<int>(
+          value: displayValue,
+          isExpanded: true,
+          dropdownColor: AppTheme.dark1,
+          style: const TextStyle(color: AppTheme.cream1),
+          icon: const Icon(Icons.arrow_drop_down, color: AppTheme.cream1),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          items: _optionKeys.entries.map((entry) {
+            final hours = entry.key;
+            final labelKey = entry.value;
+            final displayName = _getLocalizedLabel(context, labelKey);
+
+            return DropdownMenuItem<int>(
+              value: hours,
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.schedule,
+                    color: AppTheme.mostroGreen,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    displayName,
+                    style: const TextStyle(
+                      color: AppTheme.cream1,
+                      fontSize: 16,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }).toList(),
+          onChanged: (int? newValue) {
+            if (newValue != null) {
+              ref
+                  .read(settingsProvider.notifier)
+                  .updateSessionExpirationHours(newValue);
+            }
+          },
+        ),
+      ),
+    );
+  }
+
+  String _getLocalizedLabel(BuildContext context, String key) {
+    switch (key) {
+      case 'oneWeek':
+        return S.of(context)!.oneWeek;
+      case 'oneMonth':
+        return S.of(context)!.oneMonth;
+      case 'threeMonths':
+        return S.of(context)!.threeMonths;
+      case 'sixMonths':
+        return S.of(context)!.sixMonths;
+      case 'oneYear':
+        return S.of(context)!.oneYear;
+      case 'never':
+        return S.of(context)!.never;
+      default:
+        return key;
+    }
+  }
+}

--- a/lib/shared/widgets/trade_history_selector.dart
+++ b/lib/shared/widgets/trade_history_selector.dart
@@ -71,13 +71,50 @@ class TradeHistorySelector extends ConsumerWidget {
             );
           }).toList(),
           onChanged: (int? newValue) {
-            if (newValue != null) {
-              ref
-                  .read(settingsProvider.notifier)
-                  .updateSessionExpirationHours(newValue);
+            if (newValue != null && newValue != displayValue) {
+              _showConfirmationDialog(context, ref, newValue);
             }
           },
         ),
+      ),
+    );
+  }
+
+  void _showConfirmationDialog(
+      BuildContext context, WidgetRef ref, int newValue) {
+    showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppTheme.dark1,
+        title: Text(
+          S.of(context)!.tradeHistory,
+          style: const TextStyle(color: AppTheme.cream1),
+        ),
+        content: Text(
+          S.of(context)!.tradeHistoryInfoText,
+          style: const TextStyle(color: AppTheme.textSecondary),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(
+              S.of(context)!.cancel,
+              style: const TextStyle(color: AppTheme.textSecondary),
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              ref
+                  .read(settingsProvider.notifier)
+                  .updateSessionExpirationHours(newValue);
+              Navigator.of(dialogContext).pop();
+            },
+            child: Text(
+              S.of(context)!.confirm,
+              style: const TextStyle(color: AppTheme.mostroGreen),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/shared/widgets/trade_history_selector.dart
+++ b/lib/shared/widgets/trade_history_selector.dart
@@ -53,7 +53,7 @@ class TradeHistorySelector extends ConsumerWidget {
               value: hours,
               child: Row(
                 children: [
-                  Icon(
+                  const Icon(
                     Icons.schedule,
                     color: AppTheme.mostroGreen,
                     size: 20,

--- a/lib/shared/widgets/trade_history_selector.dart
+++ b/lib/shared/widgets/trade_history_selector.dart
@@ -24,9 +24,12 @@ class TradeHistorySelector extends ConsumerWidget {
 
     // Map null (no user preference) to Config default, which is 720
     final effectiveValue = currentValue ?? Config.sessionExpirationHours;
-    // If stored value doesn't match any preset, show default (1 month)
+    // If stored value doesn't match any preset, fall back to config default
+    final defaultValue = _optionKeys.containsKey(Config.sessionExpirationHours)
+        ? Config.sessionExpirationHours
+        : _optionKeys.keys.first;
     final displayValue =
-        _optionKeys.containsKey(effectiveValue) ? effectiveValue : 720;
+        _optionKeys.containsKey(effectiveValue) ? effectiveValue : defaultValue;
 
     return Container(
       decoration: BoxDecoration(

--- a/test/features/settings/session_expiration_test.dart
+++ b/test/features/settings/session_expiration_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/core/config.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+
+void main() {
+  group('Session expiration settings', () {
+    test('default settings have null sessionExpirationHours', () {
+      final settings = Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+      );
+      expect(settings.sessionExpirationHours, isNull);
+    });
+
+    test('Config default is 720 hours (30 days)', () {
+      expect(Config.sessionExpirationHours, 720);
+    });
+
+    test('null sessionExpirationHours falls back to Config default', () {
+      final settings = Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+      );
+      final effectiveHours =
+          settings.sessionExpirationHours ?? Config.sessionExpirationHours;
+      expect(effectiveHours, 720);
+    });
+
+    test('sessionExpirationHours persists through copyWith', () {
+      final settings = Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+        sessionExpirationHours: 168,
+      );
+      final updated = settings.copyWith(defaultFiatCode: 'USD');
+      expect(updated.sessionExpirationHours, 168);
+    });
+
+    test('sessionExpirationHours can be updated via copyWith', () {
+      final settings = Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+        sessionExpirationHours: 168,
+      );
+      final updated = settings.copyWith(sessionExpirationHours: 8760);
+      expect(updated.sessionExpirationHours, 8760);
+    });
+
+    test('sessionExpirationHours can be cleared via copyWith', () {
+      final settings = Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+        sessionExpirationHours: 168,
+      );
+      final updated = settings.copyWith(clearSessionExpiration: true);
+      expect(updated.sessionExpirationHours, isNull);
+    });
+
+    test('zero means never (no cleanup)', () {
+      final settings = Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+        sessionExpirationHours: 0,
+      );
+      final isForever = (settings.sessionExpirationHours ?? Config.sessionExpirationHours) == 0;
+      expect(isForever, isTrue);
+    });
+
+    test('serialization roundtrip preserves sessionExpirationHours', () {
+      final settings = Settings(
+        relays: ['wss://relay.test'],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+        sessionExpirationHours: 4320,
+      );
+      final json = settings.toJson();
+      final restored = Settings.fromJson(json);
+      expect(restored.sessionExpirationHours, 4320);
+    });
+
+    test('serialization roundtrip preserves null sessionExpirationHours', () {
+      final settings = Settings(
+        relays: ['wss://relay.test'],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+      );
+      final json = settings.toJson();
+      final restored = Settings.fromJson(json);
+      expect(restored.sessionExpirationHours, isNull);
+    });
+
+    test('fromJson handles missing sessionExpirationHours (backward compat)', () {
+      final json = {
+        'relays': <String>[],
+        'fullPrivacyMode': false,
+        'mostroPublicKey': 'test',
+      };
+      final settings = Settings.fromJson(json);
+      expect(settings.sessionExpirationHours, isNull);
+    });
+
+    test('all preset values are valid', () {
+      const presets = [168, 720, 2160, 4320, 8760, 0];
+      for (final hours in presets) {
+        final settings = Settings(
+          relays: [],
+          fullPrivacyMode: false,
+          mostroPublicKey: 'test',
+          sessionExpirationHours: hours,
+        );
+        final json = settings.toJson();
+        final restored = Settings.fromJson(json);
+        expect(restored.sessionExpirationHours, hours);
+      }
+    });
+  });
+}


### PR DESCRIPTION
  - Add session expiration selector with 6 presets: 1 week, 1 month, 3 months, 6 months, 1 year, never
  - Default remains 1 month (720 hours), stored in Settings and persisted via SharedPreferences
  - SessionNotifier reads expiration from user settings with Config fallback
  - Value 0 means never delete, protected by explicit guards in init() and cleanup()
  - New Trade History card in settings screen between Notifications and Dev Tools
  - Localization keys added for EN, ES, IT, FR, DE
  - 11 unit tests covering serialization, presets, backward compatibility, and never mode
  - Includes log output when user changes the setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-configurable session expiration (hours) with presets (1w/1m/3m/6m/1y/never); new Trade History settings card and selector; setting is persisted.

* **Behavior**
  * Expiration now cascades deletion of expired sessions and associated data; “never” loads all sessions (no cutoff).

* **Internationalization**
  * Added DE/EN/ES/FR/IT translations for trade-history UI and options.

* **Tests**
  * Added tests for defaults, updates, clearing, serialization, and presets.

* **Documentation**
  * Updated docs covering retention, “never” mode, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->