### PR TITLE
feat: in-app snackbar notifications for chat messages outside chat screen

### DIFF
--- a/lib/features/chat/notifiers/chat_room_notifier.dart
+++ b/lib/features/chat/notifiers/chat_room_notifier.dart
@@ -12,7 +12,9 @@ import 'package:mostro_mobile/services/encrypted_image_upload_service.dart';
 import 'package:mostro_mobile/services/encrypted_file_upload_service.dart';
 import 'package:sembast/sembast.dart';
 
+import 'package:mostro_mobile/features/chat/providers/active_chat_screens_provider.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
+import 'package:mostro_mobile/features/notifications/providers/notifications_provider.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
@@ -177,6 +179,8 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
         updatedMessages.sort((a, b) => b.createdAt!.compareTo(a.createdAt!));
         state = state.copy(messages: updatedMessages);
         logger.d('New message added from relay, total messages: ${updatedMessages.length}');
+
+        _maybeShowInAppNotification(chat, session);
       } else {
         logger.d('Message already exists in state, skipping duplicate');
       }
@@ -277,6 +281,24 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       }
     } catch (e, stackTrace) {
       logger.e('Failed to send message: $e', stackTrace: stackTrace);
+    }
+  }
+
+  /// Show an in-app snackbar for new incoming P2P messages when the user is
+  /// not currently on this chat screen. Self-messages (relay echo of messages
+  /// sent by the current user) are suppressed.
+  void _maybeShowInAppNotification(NostrEvent chat, Session session) {
+    try {
+      if (chat.pubkey == session.tradeKey.public) return;
+
+      final activeScreens = ref.read(activeChatScreensProvider);
+      if (activeScreens.contains(orderId)) return;
+
+      ref
+          .read(notificationActionsProvider.notifier)
+          .showCustomMessage('chatNewMessage');
+    } catch (e) {
+      logger.w('Failed to show in-app chat notification: $e');
     }
   }
 

--- a/lib/features/chat/providers/active_chat_screens_provider.dart
+++ b/lib/features/chat/providers/active_chat_screens_provider.dart
@@ -7,6 +7,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// The set stores opaque chat identifiers (order IDs for P2P chats, dispute
 /// IDs for dispute chats). Both spaces are disjoint in practice, so a single
 /// set is sufficient.
+///
+/// Single-instance assumption: the navigation graph guarantees at most one
+/// screen instance per chatId at any point in time. All entry points
+/// (chat_list_item.dart, trade_detail_screen.dart, disputes_list.dart) use
+/// context.push() from screens that are not themselves chat screens, so a
+/// second push of the same chatId can only happen after the first screen has
+/// been popped and its dispose() — which calls unregister() — has already run.
+/// A reference-counted `Map<String, int>` is therefore unnecessary.
 class ActiveChatScreensNotifier extends StateNotifier<Set<String>> {
   ActiveChatScreensNotifier() : super(const <String>{});
 

--- a/lib/features/chat/providers/active_chat_screens_provider.dart
+++ b/lib/features/chat/providers/active_chat_screens_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Tracks which chat screens are currently open in the foreground so that
+/// incoming chat events can suppress the in-app snackbar when the user is
+/// already reading the conversation.
+///
+/// The set stores opaque chat identifiers (order IDs for P2P chats, dispute
+/// IDs for dispute chats). Both spaces are disjoint in practice, so a single
+/// set is sufficient.
+class ActiveChatScreensNotifier extends StateNotifier<Set<String>> {
+  ActiveChatScreensNotifier() : super(const <String>{});
+
+  void register(String chatId) {
+    if (state.contains(chatId)) return;
+    state = {...state, chatId};
+  }
+
+  void unregister(String chatId) {
+    if (!state.contains(chatId)) return;
+    state = state.where((id) => id != chatId).toSet();
+  }
+
+  bool isActive(String chatId) => state.contains(chatId);
+}
+
+final activeChatScreensProvider =
+    StateNotifierProvider<ActiveChatScreensNotifier, Set<String>>(
+  (ref) => ActiveChatScreensNotifier(),
+);

--- a/lib/features/chat/screens/chat_room_screen.dart
+++ b/lib/features/chat/screens/chat_room_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/features/chat/providers/active_chat_screens_provider.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
 import 'package:mostro_mobile/features/chat/widgets/chat_error_screen.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
@@ -33,7 +34,21 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
   bool _wasKeyboardVisible = false;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref
+          .read(activeChatScreensProvider.notifier)
+          .register(widget.orderId);
+    });
+  }
+
+  @override
   void dispose() {
+    ref
+        .read(activeChatScreensProvider.notifier)
+        .unregister(widget.orderId);
     _scrollController.dispose();
     super.dispose();
   }

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/features/chat/providers/active_chat_screens_provider.dart';
+import 'package:mostro_mobile/features/notifications/providers/notifications_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/chat/utils/message_type_helpers.dart';
 import 'package:mostro_mobile/services/encrypted_image_upload_service.dart';
@@ -221,12 +223,32 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
 
       state = state.copyWith(messages: deduped);
 
+      if (isFromAdmin) {
+        _maybeShowInAppNotification();
+      }
+
       // Fire-and-forget: pre-download media after message is in state
       unawaited(_processMessageContent(unwrappedEvent));
       logger.i('Added dispute chat message for dispute: $disputeId '
           '(from ${isFromAdmin ? "admin" : "user"})');
     } catch (e, stackTrace) {
       logger.e('Error processing dispute chat event: $e', stackTrace: stackTrace);
+    }
+  }
+
+  /// Show an in-app snackbar for incoming admin messages when the user is not
+  /// currently on this dispute chat screen. Messages the user sent themselves
+  /// are filtered upstream (`isFromAdmin`).
+  void _maybeShowInAppNotification() {
+    try {
+      final activeScreens = ref.read(activeChatScreensProvider);
+      if (activeScreens.contains(disputeId)) return;
+
+      ref
+          .read(notificationActionsProvider.notifier)
+          .showCustomMessage('disputeChatNewMessage');
+    } catch (e) {
+      logger.w('Failed to show in-app dispute chat notification: $e');
     }
   }
 

--- a/lib/features/disputes/screens/dispute_chat_screen.dart
+++ b/lib/features/disputes/screens/dispute_chat_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/enums.dart' as enums;
+import 'package:mostro_mobile/features/chat/providers/active_chat_screens_provider.dart';
 import 'package:mostro_mobile/features/disputes/widgets/dispute_communication_section.dart';
 import 'package:mostro_mobile/features/disputes/widgets/dispute_message_input.dart';
 import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
@@ -31,11 +32,23 @@ class _DisputeChatScreenState extends ConsumerState<DisputeChatScreen> {
     super.initState();
     // Mark dispute as read when screen is opened
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       DisputeReadStatusService.markDisputeAsRead(widget.disputeId);
       // Notify that the dispute has been marked as read
-      ref.read(disputeReadStatusProvider(widget.disputeId).notifier).state = 
+      ref.read(disputeReadStatusProvider(widget.disputeId).notifier).state =
           DateTime.now().millisecondsSinceEpoch;
+      ref
+          .read(activeChatScreensProvider.notifier)
+          .register(widget.disputeId);
     });
+  }
+
+  @override
+  void dispose() {
+    ref
+        .read(activeChatScreensProvider.notifier)
+        .unregister(widget.disputeId);
+    super.dispose();
   }
 
   @override

--- a/lib/shared/widgets/notification_listener_widget.dart
+++ b/lib/shared/widgets/notification_listener_widget.dart
@@ -74,6 +74,12 @@ class NotificationListenerWidget extends ConsumerWidget {
             case 'lightningAddressUsed':
               message = S.of(context)!.lightningAddressUsed;
               break;
+            case 'chatNewMessage':
+              message = S.of(context)!.notification_new_message_message;
+              break;
+            case 'disputeChatNewMessage':
+              message = S.of(context)!.notification_admin_message_message;
+              break;
             default:
               message = next.customMessage!;
           }

--- a/test/features/chat/providers/active_chat_screens_provider_test.dart
+++ b/test/features/chat/providers/active_chat_screens_provider_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/chat/providers/active_chat_screens_provider.dart';
+
+void main() {
+  group('ActiveChatScreensNotifier', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('starts empty', () {
+      expect(container.read(activeChatScreensProvider), isEmpty);
+    });
+
+    test('register adds id to the set and isActive returns true', () {
+      final notifier = container.read(activeChatScreensProvider.notifier);
+
+      notifier.register('order-1');
+
+      expect(container.read(activeChatScreensProvider), contains('order-1'));
+      expect(notifier.isActive('order-1'), isTrue);
+      expect(notifier.isActive('order-2'), isFalse);
+    });
+
+    test('register is idempotent', () {
+      final notifier = container.read(activeChatScreensProvider.notifier);
+
+      notifier.register('order-1');
+      final first = container.read(activeChatScreensProvider);
+      notifier.register('order-1');
+      final second = container.read(activeChatScreensProvider);
+
+      expect(second, equals(first));
+      expect(second.length, 1);
+    });
+
+    test('unregister removes the id', () {
+      final notifier = container.read(activeChatScreensProvider.notifier);
+
+      notifier.register('order-1');
+      notifier.register('order-2');
+      notifier.unregister('order-1');
+
+      final state = container.read(activeChatScreensProvider);
+      expect(state, isNot(contains('order-1')));
+      expect(state, contains('order-2'));
+    });
+
+    test('unregister of unknown id is a no-op', () {
+      final notifier = container.read(activeChatScreensProvider.notifier);
+
+      notifier.register('order-1');
+      notifier.unregister('order-unknown');
+
+      final state = container.read(activeChatScreensProvider);
+      expect(state, contains('order-1'));
+      expect(state.length, 1);
+    });
+
+    test('orderIds and disputeIds can coexist without conflict', () {
+      final notifier = container.read(activeChatScreensProvider.notifier);
+
+      notifier.register('order-123');
+      notifier.register('dispute-abc');
+
+      expect(notifier.isActive('order-123'), isTrue);
+      expect(notifier.isActive('dispute-abc'), isTrue);
+
+      notifier.unregister('order-123');
+
+      expect(notifier.isActive('order-123'), isFalse);
+      expect(notifier.isActive('dispute-abc'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3 of the [chat notifications plan](docs/plans/CHAT_NOTIFICATIONS_PLAN.md): show a transient snackbar when a P2P chat or dispute chat message arrives while the user is inside the app but **not** on that specific chat screen (e.g. browsing the order book).

Follows Phase 1 (#498, admin DMs in background) and Phase 2 (#529, P2P chat in background).

## How it works

- New `activeChatScreensProvider` tracks a `Set<String>` of chat IDs whose screens are currently open. `ChatRoomScreen` and `DisputeChatScreen` register on `initState` and unregister on `dispose`.
- `ChatRoomNotifier._onChatEvent` fires `showCustomMessage('chatNewMessage')` for incoming P2P messages when the chat's `orderId` is not in the registry. Self-messages (relay echoes of sent messages) are filtered by comparing `event.pubkey` against `session.tradeKey.public`.
- `DisputeChatNotifier._onChatEvent` fires `showCustomMessage('disputeChatNewMessage')` for incoming admin messages, gated by the existing `isFromAdmin` check.
- `NotificationListenerWidget` resolves the two new keys to the existing ARB strings `notification_new_message_message` and `notification_admin_message_message` (already present in en/es/it/de/fr).

No content is exposed in the snackbar; no history entry is persisted; snackbar is not tappable.

## Test plan

- [ ] Open the app on the order book. Have the counterparty send a P2P chat message — snackbar appears at the top.
- [ ] Open the P2P chat screen and have the counterparty send a message — no snackbar.
- [ ] Leave the chat screen, receive another message — snackbar appears again.
- [ ] Send a message yourself — no snackbar (self-echo suppressed).
- [ ] Repeat the flow for a dispute in progress: admin sends a message from outside the dispute chat → snackbar with the admin-message string; from inside → no snackbar.
- [ ] Verify Mostro protocol notifications (order updates, cancellations, timeouts) still work as before.
- [ ] `flutter analyze` — zero issues.
- [ ] `flutter test` — all tests pass, including the new `ActiveChatScreensNotifier` unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app notifications for new chat messages.
  * Notifications suppressed when the corresponding chat is already open.
  * Notifications added for new messages in dispute chats.

* **Tests**
  * Added tests covering tracking of active chat screens (register/unregister and idempotency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->