### PR TITLE
fix: prevent wrong role text on canceled order detail screen

### DIFF
--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -126,8 +126,7 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
           order.currency!,
           currencyData,
         );
-        final amountString =
-            '${order.fiatAmount} ${order.currency} $currencyFlag';
+        final amountString = '${order.fiatAmount} $currencyFlag';
         String priceText = '';
         if (order.amount == '0') {
           final premium = order.premium;

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -231,12 +231,18 @@ class TradeDetailScreen extends ConsumerWidget {
       context,
     );
 
+    final isCanceledWithoutSession =
+        tradeState.status == Status.canceled && session == null;
+    final titleText = isCanceledWithoutSession
+        ? S.of(context)!.canceledTradeTitle(satAmount)
+        : selling == S.of(context)!.selling
+            ? S.of(context)!.youAreSellingTitle(satAmount)
+            : S.of(context)!.youAreBuyingTitle(satAmount);
+
     return Column(
       children: [
         OrderAmountCard(
-          title: selling == S.of(context)!.selling
-              ? S.of(context)!.youAreSellingTitle(satAmount)
-              : S.of(context)!.youAreBuyingTitle(satAmount),
+          title: titleText,
           amount: _displayFiatAmount(tradeState.order!, isPending: isPending),
           currency: tradeState.order!.fiatCode,
           priceText: priceText,

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -286,6 +286,7 @@
     },
     "youAreSellingTitle": "Du verkaufst {sats} Sats",
     "youAreBuyingTitle": "Du kaufst {sats} Sats",
+    "canceledTradeTitle": "Handel über {sats} Sats",
     "forAmount": "für {amount}",
     "timeLeftLabel": "Verbleibende Zeit: {time}",
     "@timeLeftLabel": {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -284,9 +284,9 @@
             }
         }
     },
-    "youAreSellingTitle": "Du verkaufst {sats} Sats",
-    "youAreBuyingTitle": "Du kaufst {sats} Sats",
-    "canceledTradeTitle": "Handel über {sats} Sats",
+    "youAreSellingTitle": "Du verkaufst{sats} Sats",
+    "youAreBuyingTitle": "Du kaufst{sats} Sats",
+    "canceledTradeTitle": "Handel über{sats} Sats",
     "forAmount": "für {amount}",
     "timeLeftLabel": "Verbleibende Zeit: {time}",
     "@timeLeftLabel": {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -286,6 +286,7 @@
     },
     "youAreSellingTitle": "You are selling{sats} sats",
     "youAreBuyingTitle": "You are buying{sats} sats",
+    "canceledTradeTitle": "Trade of{sats} sats",
     "forAmount": "for {amount}",
     "timeLeftLabel": "Time Left: {time}",
     "@timeLeftLabel": {

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -650,9 +650,9 @@
             }
         }
     },
-    "youAreSellingTitle": "Estás vendiendo {sats} sats",
-    "youAreBuyingTitle": "Estás comprando {sats} sats",
-    "canceledTradeTitle": "Intercambio de {sats} sats",
+    "youAreSellingTitle": "Estás vendiendo{sats} sats",
+    "youAreBuyingTitle": "Estás comprando{sats} sats",
+    "canceledTradeTitle": "Intercambio de{sats} sats",
     "forAmount": "por {amount}",
     "timeLeftLabel": "Tiempo restante: {time}",
     "@timeLeftLabel": {

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -652,6 +652,7 @@
     },
     "youAreSellingTitle": "Estás vendiendo {sats} sats",
     "youAreBuyingTitle": "Estás comprando {sats} sats",
+    "canceledTradeTitle": "Intercambio de {sats} sats",
     "forAmount": "por {amount}",
     "timeLeftLabel": "Tiempo restante: {time}",
     "@timeLeftLabel": {

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -286,6 +286,7 @@
     },
     "youAreSellingTitle": "Vous vendez{sats} sats",
     "youAreBuyingTitle": "Vous achetez{sats} sats",
+    "canceledTradeTitle": "Échange de{sats} sats",
     "forAmount": "pour {amount}",
     "timeLeftLabel": "Temps restant : {time}",
     "@timeLeftLabel": {

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -710,6 +710,14 @@
             }
         }
     },
+    "canceledTradeTitle": "Scambio di {sats} sats",
+    "@canceledTradeTitle": {
+        "placeholders": {
+            "sats": {
+                "description": "Amount of satoshis in a canceled trade"
+            }
+        }
+    },
     "forAmount": "per {amount}",
     "@forAmount": {
         "placeholders": {

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -694,7 +694,7 @@
             }
         }
     },
-    "youAreSellingTitle": "Stai vendendo {sats} sats",
+    "youAreSellingTitle": "Stai vendendo{sats} sats",
     "@youAreSellingTitle": {
         "placeholders": {
             "sats": {
@@ -702,7 +702,7 @@
             }
         }
     },
-    "youAreBuyingTitle": "Stai comprando {sats} sats",
+    "youAreBuyingTitle": "Stai comprando{sats} sats",
     "@youAreBuyingTitle": {
         "placeholders": {
             "sats": {
@@ -710,7 +710,7 @@
             }
         }
     },
-    "canceledTradeTitle": "Scambio di {sats} sats",
+    "canceledTradeTitle": "Scambio di{sats} sats",
     "@canceledTradeTitle": {
         "placeholders": {
             "sats": {

--- a/lib/shared/widgets/order_cards.dart
+++ b/lib/shared/widgets/order_cards.dart
@@ -33,7 +33,7 @@ class OrderAmountCard extends ConsumerWidget {
     final currencyData = ref.watch(currencyCodesProvider).asData?.value;
     final currencyFlag =
         CurrencyUtils.getFlagFromCurrencyData(currency, currencyData);
-    final amountString = '$amount $currency $currencyFlag';
+    final amountString = '$amount $currencyFlag';
 
 
     return CustomCard(


### PR DESCRIPTION
fix #577 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade detail titles now show a dedicated canceled-trade title that includes the trade amount, improving clarity when a trade is canceled without an associated session.
* **Chores**
  * Updated localized title strings (EN, DE, ES, FR, IT) and adjusted placeholder spacing so amounts render consistently across languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->