### PR TITLE
feat: filter offers by maker's account age in order book

### DIFF
--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -12,6 +12,7 @@ final currencyFilterProvider = StateProvider<List<String>>((ref) => []);
 final paymentMethodFilterProvider = StateProvider<List<String>>((ref) => []);
 final ratingFilterProvider = StateProvider<({double min, double max})>((ref) => (min: 0.0, max: 5.0));
 final premiumRangeFilterProvider = StateProvider<({double min, double max})>((ref) => (min: -10.0, max: 10.0));
+final minDaysFilterProvider = StateProvider<int>((ref) => 0);
 
 final filteredOrdersProvider = Provider<List<NostrEvent>>((ref) {
   final allOrdersAsync = ref.watch(orderEventsProvider);
@@ -20,6 +21,7 @@ final filteredOrdersProvider = Provider<List<NostrEvent>>((ref) {
   final selectedPaymentMethods = ref.watch(paymentMethodFilterProvider);
   final ratingRange = ref.watch(ratingFilterProvider);
   final premiumRange = ref.watch(premiumRangeFilterProvider);
+  final minDays = ref.watch(minDaysFilterProvider);
 
   return allOrdersAsync.maybeWhen(
     data: (allOrders) {
@@ -51,6 +53,11 @@ final filteredOrdersProvider = Provider<List<NostrEvent>>((ref) {
             return methodsLower.any(pmLower.contains);
           });
         });
+      }
+
+      // Apply minimum days filter (maker's account age as reported in rating.days)
+      if (minDays > 0) {
+        filtered = filtered.where((o) => (o.rating?.days ?? 0) >= minDays);
       }
 
       // Apply rating filter

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1101,6 +1101,8 @@
     "clear": "Löschen",
     "min": "Min",
     "max": "Max",
+    "daysOfUse": "Nutzungstage",
+    "days": "Tage",
     "@_comment_timeout_messages": "Nachrichten für Zeitüberschreitungen",
     "orderTimeoutTaker": "Du hast nicht rechtzeitig geantwortet. Die Order wird neu veröffentlicht.",
     "orderTimeoutMaker": "Dein Handelspartner hat nicht rechtzeitig geantwortet. Die Order wird neu veröffentlicht.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1101,6 +1101,8 @@
     "clear": "Clear",
     "min": "Min",
     "max": "Max",
+    "daysOfUse": "Days of use",
+    "days": "Days",
     "@_comment_timeout_messages": "Timeout notification messages",
     "orderTimeoutTaker": "You didn't respond in time. The order will be republished",
     "orderTimeoutMaker": "Your counterpart didn't respond in time. The order will be republished",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1013,6 +1013,8 @@
     "clear": "Limpiar",
     "min": "Mín",
     "max": "Máx",
+    "daysOfUse": "Días de uso",
+    "days": "Días",
     "selectCurrency": "Seleccionar Moneda",
     "noCurrencySelected": "Ninguna moneda seleccionada",
     "@_comment_timeout_messages": "Mensajes de notificación de timeout",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1101,6 +1101,8 @@
     "clear": "Effacer",
     "min": "Min",
     "max": "Max",
+    "daysOfUse": "Jours d'utilisation",
+    "days": "Jours",
     "@_comment_timeout_messages": "Timeout notification messages",
     "orderTimeoutTaker": "Vous n'avez pas répondu à temps. La commande sera republiée",
     "orderTimeoutMaker": "Votre contrepartie n'a pas répondu à temps. La commande sera republiée",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1072,6 +1072,8 @@
     "clear": "Cancella",
     "min": "Min",
     "max": "Max",
+    "daysOfUse": "Giorni di utilizzo",
+    "days": "Giorni",
     "selectCurrency": "Seleziona Valuta",
     "noCurrencySelected": "Nessuna valuta selezionata",
     "@_comment_timeout_messages": "Messaggi di notifica timeout",

--- a/lib/shared/widgets/order_filter.dart
+++ b/lib/shared/widgets/order_filter.dart
@@ -672,7 +672,7 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
                   Text(
                     "${S.of(context)!.days}: 0",
                     style: const TextStyle(
-                      color: AppTheme.textSecondary,
+                      color: AppTheme.sellColor,
                       fontSize: 12,
                       fontWeight: FontWeight.w500,
                     ),
@@ -684,7 +684,7 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
                       "${S.of(context)!.days}: ${minDays > 20 ? minDays : 20}",
                       textAlign: TextAlign.end,
                       style: const TextStyle(
-                        color: AppTheme.textSecondary,
+                        color: AppTheme.buyColor,
                         fontSize: 12,
                         fontWeight: FontWeight.w500,
                       ),
@@ -714,7 +714,7 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
                   min: 0.0,
                   max: 20.0,
                   divisions: 20,
-                  label: minDays.toString(),
+                  label: minDays.clamp(0, 20).toString(),
                   onChanged: (value) {
                     final v = value.round();
                     setState(() {

--- a/lib/shared/widgets/order_filter.dart
+++ b/lib/shared/widgets/order_filter.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
@@ -253,6 +254,8 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
   double ratingMax = 5.0;
   double premiumMin = -10.0;
   double premiumMax = 10.0;
+  int minDays = 0;
+  final TextEditingController _daysController = TextEditingController(text: '0');
 
   // Options for the multi-select fields.
   
@@ -284,7 +287,8 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
       final paymentMethods = ref.read(paymentMethodFilterProvider);
       final currentRatingRange = ref.read(ratingFilterProvider);
       final currentPremiumRange = ref.read(premiumRangeFilterProvider);
-      
+      final currentMinDays = ref.read(minDaysFilterProvider);
+
       setState(() {
         selectedFiatCurrencies = List.from(currencies);
         selectedPaymentMethods = List.from(paymentMethods);
@@ -293,8 +297,16 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
         ratingMax = rMax;
         premiumMin = currentPremiumRange.min;
         premiumMax = currentPremiumRange.max;
+        minDays = currentMinDays;
+        _daysController.text = currentMinDays.toString();
       });
     });
+  }
+
+  @override
+  void dispose() {
+    _daysController.dispose();
+    super.dispose();
   }
 
   @override
@@ -640,6 +652,136 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
               ),
             ],
           ),
+          const SizedBox(height: 12),
+          // Minimum days of use filter (maker's account age).
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                S.of(context)!.daysOfUse,
+                style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.3,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Text(
+                    "${S.of(context)!.days}: 0",
+                    style: const TextStyle(
+                      color: AppTheme.textSecondary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const Spacer(),
+                  SizedBox(
+                    width: 72,
+                    child: Text(
+                      "${S.of(context)!.days}: ${minDays > 20 ? minDays : 20}",
+                      textAlign: TextAlign.end,
+                      style: const TextStyle(
+                        color: AppTheme.textSecondary,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              SliderTheme(
+                data: SliderTheme.of(context).copyWith(
+                  activeTrackColor: AppTheme.textSecondary,
+                  inactiveTrackColor: AppTheme.backgroundInput,
+                  thumbColor: AppTheme.textSecondary,
+                  overlayColor: AppTheme.textSecondary.withValues(alpha: 0.2),
+                  valueIndicatorColor: AppTheme.textSecondary,
+                  valueIndicatorTextStyle: const TextStyle(
+                    color: AppTheme.backgroundDark,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  trackHeight: 4,
+                  thumbShape: const RoundSliderThumbShape(
+                    enabledThumbRadius: 8,
+                  ),
+                ),
+                child: Slider(
+                  value: minDays.clamp(0, 20).toDouble(),
+                  min: 0.0,
+                  max: 20.0,
+                  divisions: 20,
+                  label: minDays.toString(),
+                  onChanged: (value) {
+                    final v = value.round();
+                    setState(() {
+                      minDays = v;
+                    });
+                    _daysController.text = v.toString();
+                    _daysController.selection = TextSelection.collapsed(
+                      offset: _daysController.text.length,
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: SizedBox(
+                  width: 72,
+                  height: 32,
+                  child: TextField(
+                    controller: _daysController,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'^\d{0,4}$')),
+                    ],
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    decoration: InputDecoration(
+                      filled: true,
+                      fillColor: AppTheme.backgroundInput,
+                      contentPadding: EdgeInsets.zero,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.2),
+                          width: 1,
+                        ),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.2),
+                          width: 1,
+                        ),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(
+                          color: AppTheme.textSecondary,
+                          width: 1.5,
+                        ),
+                      ),
+                    ),
+                    onChanged: (text) {
+                      final parsed = int.tryParse(text);
+                      setState(() {
+                        minDays = parsed == null ? 0 : parsed.clamp(0, 9999);
+                      });
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
                 ],
               ),
             ),
@@ -663,12 +805,15 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
                         ratingMax = 5.0;
                         premiumMin = -10.0;
                         premiumMax = 10.0;
+                        minDays = 0;
+                        _daysController.text = '0';
                       });
-                      
+
                       ref.read(currencyFilterProvider.notifier).state = [];
                       ref.read(paymentMethodFilterProvider.notifier).state = [];
                       ref.read(ratingFilterProvider.notifier).state = (min: 0.0, max: 5.0);
                       ref.read(premiumRangeFilterProvider.notifier).state = (min: -10.0, max: 10.0);
+                      ref.read(minDaysFilterProvider.notifier).state = 0;
                       
                       Navigator.of(context).pop();
                     },
@@ -707,6 +852,7 @@ class OrderFilterState extends ConsumerState<OrderFilter> {
                       ref.read(paymentMethodFilterProvider.notifier).state = selectedPaymentMethods;
                       ref.read(ratingFilterProvider.notifier).state = (min: ratingMin, max: ratingMax);
                       ref.read(premiumRangeFilterProvider.notifier).state = (min: premiumMin, max: premiumMax);
+                      ref.read(minDaysFilterProvider.notifier).state = minDays;
                       
                       Navigator.of(context).pop();
                     },


### PR DESCRIPTION
fix #574 
  - New Days of use filter in the order book filter dialog, reading the days field from the rating tag of kind 38383 events.
  - Slider 0..20 with the same gray palette as the reputation and premium filters, adjacent text input accepts higher values (clamped to 0..9999).
  - Right-side label switches from Days: 20 to the typed value when the user enters a higher number.
  - New minDaysFilterProvider in home_order_providers.dart; offers are excluded when rating.days < minDays.
  - Localization keys daysOfUse and days added to en, es, it, de and fr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Days of use" filter (0–20) to the order filter UI with a slider and numeric input that stay in sync. Clear resets the field; Apply persists the selection. Orders now respect a minimum-days constraint when set.

* **Localization**
  * Added "Days of use" and "Days" translations for German, English, Spanish, French, and Italian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->