### PR TITLE
feat(restore): specific messages for cant-do responses

### DIFF
--- a/lib/data/models/last_trade_index_response.dart
+++ b/lib/data/models/last_trade_index_response.dart
@@ -2,8 +2,12 @@ import 'package:mostro_mobile/data/models/payload.dart';
 
 class LastTradeIndexResponse implements Payload {
   final int tradeIndex;
+  final bool noHistoryFound;
 
-  const LastTradeIndexResponse({required this.tradeIndex});
+  const LastTradeIndexResponse({
+    required this.tradeIndex,
+    this.noHistoryFound = false,
+  });
 
   @override
   String get type => 'last-trade-index';

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -430,6 +430,12 @@ class RestoreService {
         final cantDoWrapper = messageData['cant-do'] as Map<String, dynamic>?;
         final cantDoPayload = cantDoWrapper?['payload'] as Map<String, dynamic>?;
         final reasonStr = _extractCantDoReason(cantDoPayload);
+        if (reasonStr == CantDoReason.invalidTradeIndex.value) {
+          logger.w(
+            'Restore: Mostro returned cant-do: invalid_trade_index for last trade index',
+          );
+          throw const RestoreInvalidTradeIndexException();
+        }
         final isNotFound = reasonStr == CantDoReason.notFound.value;
         logger.w(
           'Restore: Mostro returned cant-do for last trade index '
@@ -993,11 +999,12 @@ class RestoreService {
         error: e,
         stackTrace: stack,
       );
+      final errorKey = e is RestoreInvalidTradeIndexException
+          ? 'invalid_trade_index'
+          : 'restore_error';
       ref
           .read(restoreProgressProvider.notifier)
-          .showError(
-            'restore_error',
-          ); // overlay displays localized restoreErrorMessage
+          .showError(errorKey); // overlay maps the key to a localized message
     } finally {
       // Cleanup: always cancel subscription and clear keys
       logger.i('Restore: cleaning up subscription and keys');
@@ -1096,6 +1103,15 @@ class RestoreService {
     }
     return null;
   }
+}
+
+/// Thrown when Mostro responds with cant-do: invalid_trade_index to
+/// Action.lastTradeIndex during the restore flow.
+class RestoreInvalidTradeIndexException implements Exception {
+  const RestoreInvalidTradeIndexException();
+
+  @override
+  String toString() => 'RestoreInvalidTradeIndexException';
 }
 
 final restoreServiceProvider = Provider<RestoreService>((ref) {

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/enums/cant_do_reason.dart';
 import 'package:mostro_mobile/data/models/enums/role.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
 import 'package:mostro_mobile/data/models/enums/status.dart';
@@ -424,12 +425,20 @@ class RestoreService {
       final contentList = jsonDecode(rumor.content!) as List<dynamic>;
       final messageData = contentList[0] as Map<String, dynamic>;
 
-      // Check if Mostro returned cant-do (not found)
+      // Check if Mostro returned cant-do
       if (messageData.containsKey('cant-do')) {
+        final cantDoWrapper = messageData['cant-do'] as Map<String, dynamic>?;
+        final cantDoPayload = cantDoWrapper?['payload'] as Map<String, dynamic>?;
+        final reasonStr = _extractCantDoReason(cantDoPayload);
+        final isNotFound = reasonStr == CantDoReason.notFound.value;
         logger.w(
-          'Restore: Mostro returned cant-do for last trade index, defaulting to 0',
+          'Restore: Mostro returned cant-do for last trade index '
+          '(reason: ${reasonStr ?? 'unknown'}), defaulting to 0',
         );
-        return LastTradeIndexResponse(tradeIndex: 0);
+        return LastTradeIndexResponse(
+          tradeIndex: 0,
+          noHistoryFound: isNotFound,
+        );
       }
 
       // Extract trade_index from restore wrapper
@@ -873,6 +882,7 @@ class RestoreService {
     _operationInProgress = true;
     _operationCompleter = Completer<bool>();
     bool success = false;
+    bool noHistoryFound = false;
     try {
       // Clear existing data
       await _clearAll();
@@ -928,7 +938,12 @@ class RestoreService {
         );
         final lastTradeIndex = lastTradeIndexResponse.tradeIndex;
         await keyManager.setCurrentKeyIndex(lastTradeIndex + 1);
-        progress.completeRestore();
+        if (lastTradeIndexResponse.noHistoryFound) {
+          progress.completeAsNewUser();
+        } else {
+          progress.completeRestore();
+        }
+        success = true;
         return true;
       }
 
@@ -953,6 +968,7 @@ class RestoreService {
         lastTradeIndexEvent,
       );
       final lastTradeIndex = lastTradeIndexResponse.tradeIndex;
+      noHistoryFound = lastTradeIndexResponse.noHistoryFound;
 
       // IMPORTANT: Cancel temporary subscription before proceeding to avoid interference
       await _tempSubscription?.cancel();
@@ -994,10 +1010,15 @@ class RestoreService {
       _operationCompleter?.complete(success);
       _operationCompleter = null;
 
-      // Only call completeRestore if not in error state
+      // Only call completeRestore if not in error state and not already finalized
       final currentState = ref.read(restoreProgressProvider);
-      if (currentState.step != RestoreStep.error) {
-        ref.read(restoreProgressProvider.notifier).completeRestore();
+      if (currentState.step != RestoreStep.error &&
+          currentState.step != RestoreStep.completed) {
+        if (noHistoryFound) {
+          ref.read(restoreProgressProvider.notifier).completeAsNewUser();
+        } else {
+          ref.read(restoreProgressProvider.notifier).completeRestore();
+        }
       }
     }
 
@@ -1059,6 +1080,21 @@ class RestoreService {
       _operationCompleter?.complete(false);
       _operationCompleter = null;
     }
+  }
+
+  // Extracts the cant-do reason string from the inner payload.
+  // Mostro wire format: payload may be {"cant_do": "<reason>"} or
+  // {"cant_do": {"cant-do": "<reason>"}}.
+  String? _extractCantDoReason(Map<String, dynamic>? payload) {
+    if (payload == null) return null;
+    final raw = payload['cant_do'];
+    if (raw == null) return null;
+    if (raw is String) return raw;
+    if (raw is Map<String, dynamic>) {
+      final inner = raw['cant-do'];
+      return inner?.toString();
+    }
+    return null;
   }
 }
 

--- a/lib/features/restore/restore_overlay.dart
+++ b/lib/features/restore/restore_overlay.dart
@@ -63,6 +63,19 @@ class RestoreOverlay extends ConsumerWidget {
                 ),
                 textAlign: TextAlign.center,
               ),
+              if (state.step == RestoreStep.completed &&
+                  state.noHistoryFound) ...[
+                SizedBox(height: isSmallScreen ? 6 : 8),
+                Text(
+                  S.of(context)!.restoreNoPreviousData,
+                  style: TextStyle(
+                    color: AppTheme.textSecondary.withValues(alpha: 0.75),
+                    fontSize: messageFontSize - 1,
+                    fontStyle: FontStyle.italic,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
               SizedBox(height: isSmallScreen ? 16 : 24),
               _buildProgressIndicator(state, iconSize),
             ],

--- a/lib/features/restore/restore_overlay.dart
+++ b/lib/features/restore/restore_overlay.dart
@@ -76,6 +76,19 @@ class RestoreOverlay extends ConsumerWidget {
                   textAlign: TextAlign.center,
                 ),
               ],
+              if (state.step == RestoreStep.error &&
+                  state.errorMessage == 'invalid_trade_index') ...[
+                SizedBox(height: isSmallScreen ? 6 : 8),
+                Text(
+                  S.of(context)!.restoreInvalidTradeIndex,
+                  style: TextStyle(
+                    color: AppTheme.textSecondary.withValues(alpha: 0.75),
+                    fontSize: messageFontSize - 1,
+                    fontStyle: FontStyle.italic,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
               SizedBox(height: isSmallScreen ? 16 : 24),
               _buildProgressIndicator(state, iconSize),
             ],

--- a/lib/features/restore/restore_progress_notifier.dart
+++ b/lib/features/restore/restore_progress_notifier.dart
@@ -68,6 +68,24 @@ class RestoreProgressNotifier extends StateNotifier<RestoreProgressState> {
     });
   }
 
+  void completeAsNewUser() {
+    logger.i('Restore completed: no previous history for this Mostro');
+    _cancelTimeoutTimer();
+
+    state = state.copyWith(
+      step: RestoreStep.completed,
+      noHistoryFound: true,
+    );
+
+    // Extended auto-hide so the user has time to read the secondary line.
+    _cancelAutoHideTimer();
+    _autoHideTimer = Timer(const Duration(seconds: 5), () {
+      if (mounted) {
+        hide();
+      }
+    });
+  }
+
   void showError(String message) {
     logger.w('Restore error: $message');
     _cancelTimeoutTimer();

--- a/lib/features/restore/restore_progress_state.dart
+++ b/lib/features/restore/restore_progress_state.dart
@@ -14,6 +14,7 @@ class RestoreProgressState {
   final int totalProgress;
   final String? errorMessage;
   final bool isVisible;
+  final bool noHistoryFound;
 
   const RestoreProgressState({
     required this.step,
@@ -21,6 +22,7 @@ class RestoreProgressState {
     this.totalProgress = 0,
     this.errorMessage,
     this.isVisible = false,
+    this.noHistoryFound = false,
   });
 
   RestoreProgressState copyWith({
@@ -29,6 +31,7 @@ class RestoreProgressState {
     int? totalProgress,
     String? errorMessage,
     bool? isVisible,
+    bool? noHistoryFound,
   }) {
     return RestoreProgressState(
       step: step ?? this.step,
@@ -36,6 +39,7 @@ class RestoreProgressState {
       totalProgress: totalProgress ?? this.totalProgress,
       errorMessage: errorMessage ?? this.errorMessage,
       isVisible: isVisible ?? this.isVisible,
+      noHistoryFound: noHistoryFound ?? this.noHistoryFound,
     );
   }
 

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1246,6 +1246,7 @@
     "restoreNoPreviousData": "Keine vorherigen Daten für diesen Nutzer in diesem Mostro",
     "restoreError": "Wiederherstellungsfehler",
     "restoreErrorMessage": "Fehler beim Wiederherstellen der Nutzerdaten. Bitte prüfe deine Verbindung und versuche es erneut.",
+    "restoreInvalidTradeIndex": "Ungültiger Trade-Index",
     "@_comment_file_messaging": "Dateiversand-Strings",
     "download": "Herunterladen",
     "openFile": "Datei öffnen",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1243,6 +1243,7 @@
     "restoreProcessingRoles": "Rollen werden verarbeitet...",
     "restoreFinalizing": "Wiederherstellung wird abgeschlossen...",
     "restoreCompleted": "Wiederherstellung abgeschlossen!",
+    "restoreNoPreviousData": "Keine vorherigen Daten für diesen Nutzer in diesem Mostro",
     "restoreError": "Wiederherstellungsfehler",
     "restoreErrorMessage": "Fehler beim Wiederherstellen der Nutzerdaten. Bitte prüfe deine Verbindung und versuche es erneut.",
     "@_comment_file_messaging": "Dateiversand-Strings",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1246,6 +1246,7 @@
     "restoreNoPreviousData": "No previous data for this user in this Mostro",
     "restoreError": "Restore error",
     "restoreErrorMessage": "Error restoring user data. Please check your connection and try again.",
+    "restoreInvalidTradeIndex": "Invalid trade index",
     "@_comment_file_messaging": "File messaging strings",
     "download": "Download",
     "openFile": "Open File",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1243,6 +1243,7 @@
     "restoreProcessingRoles": "Processing roles...",
     "restoreFinalizing": "Finalizing restore...",
     "restoreCompleted": "Restore completed!",
+    "restoreNoPreviousData": "No previous data for this user in this Mostro",
     "restoreError": "Restore error",
     "restoreErrorMessage": "Error restoring user data. Please check your connection and try again.",
     "@_comment_file_messaging": "File messaging strings",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1218,6 +1218,7 @@
     "restoreProcessingRoles": "Procesando roles...",
     "restoreFinalizing": "Finalizando restauración...",
     "restoreCompleted": "¡Restauración completada!",
+    "restoreNoPreviousData": "No hay datos previos de este usuario en este Mostro",
     "restoreError": "Error de restauración",
     "restoreErrorMessage": "Error al restaurar datos del usuario. Verifica tu conexión e inténtalo más tarde.",
     "@_comment_file_messaging": "File messaging strings",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1221,6 +1221,7 @@
     "restoreNoPreviousData": "No hay datos previos de este usuario en este Mostro",
     "restoreError": "Error de restauración",
     "restoreErrorMessage": "Error al restaurar datos del usuario. Verifica tu conexión e inténtalo más tarde.",
+    "restoreInvalidTradeIndex": "Índice de trade inválido",
     "@_comment_file_messaging": "File messaging strings",
     "download": "Descargar",
     "openFile": "Abrir Archivo",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1246,6 +1246,7 @@
     "restoreNoPreviousData": "Aucune donnée précédente pour cet utilisateur sur ce Mostro",
     "restoreError": "Erreur de restauration",
     "restoreErrorMessage": "Erreur lors de la restauration des données utilisateur. Veuillez vérifier votre connexion et réessayer.",
+    "restoreInvalidTradeIndex": "Index de trade invalide",
     "@_comment_file_messaging": "File messaging strings",
     "download": "Télécharger",
     "openFile": "Ouvrir le fichier",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1243,6 +1243,7 @@
     "restoreProcessingRoles": "Traitement des rôles...",
     "restoreFinalizing": "Finalisation de la restauration...",
     "restoreCompleted": "Restauration terminée !",
+    "restoreNoPreviousData": "Aucune donnée précédente pour cet utilisateur sur ce Mostro",
     "restoreError": "Erreur de restauration",
     "restoreErrorMessage": "Erreur lors de la restauration des données utilisateur. Veuillez vérifier votre connexion et réessayer.",
     "@_comment_file_messaging": "File messaging strings",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1287,6 +1287,7 @@
     "restoreNoPreviousData": "Nessun dato precedente per questo utente in questo Mostro",
     "restoreError": "Errore di ripristino",
     "restoreErrorMessage": "Errore nel ripristino dei dati utente. Verifica la tua connessione e riprova più tardi.",
+    "restoreInvalidTradeIndex": "Indice di trade non valido",
     "@_comment_file_messaging": "File messaging strings",
     "download": "Scarica",
     "openFile": "Apri File",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1284,6 +1284,7 @@
     "restoreProcessingRoles": "Elaborazione ruoli...",
     "restoreFinalizing": "Finalizzazione ripristino...",
     "restoreCompleted": "Ripristino completato!",
+    "restoreNoPreviousData": "Nessun dato precedente per questo utente in questo Mostro",
     "restoreError": "Errore di ripristino",
     "restoreErrorMessage": "Errore nel ripristino dei dati utente. Verifica la tua connessione e riprova più tardi.",
     "@_comment_file_messaging": "File messaging strings",


### PR DESCRIPTION
  - Map `cant-do` responses from `Action.lastTradeIndex` to specific user-facing messages instead of a single generic error.                                                                                                              
  - `not_found`: complete restore as new user with informative subtext ("No previous data for this user in this Mostro"). Same green icon as a normal successful restore, with extended auto-hide so the user can read it.          
  - `invalid_trade_index`: show the error overlay with a specific subtext ("Invalid trade index"). Same red icon as a regular error.                                                                                                      
  - Any other `cant-do` reason or timeout: keep the existing generic error message and behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved restoration flow with clearer messaging when restoring accounts with no previous data.
  * Enhanced error handling and messaging for trade index-related restoration issues.

* **Localization**
  * Added translations for new restore-related messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->