### PR TITLE
feat: P2P chat push wake-up + register mostro_pubkey whitelist field

### DIFF
--- a/docs/plans/CHAT_NOTIFICATIONS_PLAN.md
+++ b/docs/plans/CHAT_NOTIFICATIONS_PLAN.md
@@ -107,7 +107,7 @@ New keys for all 3 languages (en, es, it):
 
 ---
 
-### Phase 2: P2P Chat Background Notifications (IN REVIEW)
+### Phase 2: P2P Chat Background Notifications (COMPLETE)
 
 **Status:** Open PR, pending merge.
 
@@ -163,7 +163,7 @@ Ensure the `p2pUnwrap` extension method is accessible from the background isolat
 
 ---
 
-### Phase 3: In-App Notifications (Foreground, Outside Chat Screen) — PENDING
+### Phase 3: In-App Notifications (Foreground, Outside Chat Screen) — (COMPLETE)
 
 **Scope:** When the user is in the app but NOT on the specific chat screen, show a temporary in-app notification (toast/snackbar).
 
@@ -244,67 +244,89 @@ Add a simple mechanism to track if a specific chat screen is open:
 
 **Scope:** When the app is completely killed, P2P chat messages should wake the app via FCM.
 
-**Problem:** Push server monitors relays for `tradeKey.public` in the `p` tag. P2P chat events use `sharedKey.public` — the push server doesn't know about these keys and cannot decrypt or match them.
+**Problem:** The push server's Nostr listener monitors relays for `kind 1059` events and looks up tokens by the `p` tag. P2P chat events use `sharedKey.public` as the `p` tag — the push server has no `sharedKey → token` mapping and cannot match them via the listener path.
 
-**Solution: Sender-triggered notification**
+**Solution: Sender-triggered notification via existing `/api/notify`**
 
-When User A sends a P2P chat message to User B:
-1. Publish encrypted event to relay (existing)
-2. Call push server: `POST /api/notify { "trade_pubkey": "<peer's tradeKey.public>" }`
+The push server already exposes `POST /api/notify` (see `mostro-push-server/docs/api.md`). When User A sends a P2P chat message to User B:
+1. Publish encrypted event to relay (existing).
+2. Call `POST /api/notify { "trade_pubkey": "<peer's tradeKey.public>" }` — fire-and-forget.
 
 This works because:
-- User A knows `session.peer.publicKey` (the counterparty's trade pubkey)
-- The push server already has User B's `tradeKey → FCM token` mapping
-- No new data revealed — push server already knows the trade pubkey
-- No message content transmitted — just a "wake up" signal
-- Push server doesn't learn the sharedKey ↔ tradeKey relationship
+- User A knows `session.peer.publicKey` (the counterparty's trade pubkey).
+- The push server already has User B's `tradeKey → FCM token` mapping.
+- No new data revealed — the trade pubkey is the same identifier used in `/api/register`.
+- No message content transmitted — only a "wake up" signal.
+- Push server never learns the `sharedKey ↔ tradeKey` relationship.
 
-**Why this approach vs registering sharedKey:**
-- No additional pubkey registration needed
-- Push server doesn't learn the sharedKey ↔ tradeKey relationship
-- Simpler server-side implementation
-- Same privacy guarantees as existing Mostro event notifications
+**Why this approach vs registering `sharedKey`:**
+- No additional pubkey registration needed.
+- Push server doesn't learn the `sharedKey ↔ tradeKey` relationship.
+- Simpler server-side implementation.
+- Same privacy guarantees as existing Mostro event notifications.
 
 #### 4.1 Add `notifyPeer()` to `PushNotificationService`
 
+The endpoint is **strictly fire-and-forget** because of the privacy contract enforced server-side (see `mostro-push-server/CLAUDE.md` "Hard constraints"):
+
+- Always `202 { "accepted": true }` on parse-valid input — registered vs unregistered pubkeys are **indistinguishable** (status, body, headers, timing). There is no `200`, no `404`.
+- `400` only on JSON parse failure or invalid pubkey (64 hex chars).
+- `429` on rate-limit hit. Body is **byte-identical** between per-IP and per-pubkey paths; clients cannot tell which limiter tripped. `Retry-After` header carries whole seconds (min 1).
+- No `sender_pubkey`, no signature, no `Authorization` header, no `Idempotency-Key` — anything that would let the operator correlate sender and recipient is rejected at the boundary.
+- Inbound `X-Request-Id` is stripped server-side; the response carries a server-generated UUIDv4.
+
+Implementation:
+
 ```dart
-Future<bool> notifyPeer(String peerTradePubkey) async {
-  final response = await http.post(
-    Uri.parse('$_pushServerUrl/api/notify'),
-    headers: {'Content-Type': 'application/json'},
-    body: jsonEncode({'trade_pubkey': peerTradePubkey}),
-  ).timeout(const Duration(seconds: 10));
-  return response.statusCode == 200;
+Future<void> notifyPeer(String peerTradePubkey) async {
+  try {
+    final response = await http.post(
+      Uri.parse('$_pushServerUrl/api/notify'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'trade_pubkey': peerTradePubkey}),
+    ).timeout(const Duration(seconds: 5));
+
+    // 202 = accepted (registered/unregistered indistinguishable by contract).
+    // 400 = malformed pubkey -> client bug, log it.
+    // 429 = rate-limited -> drop silently (fire-and-forget, no retry).
+    if (response.statusCode == 400) {
+      logger.w('notifyPeer: invalid pubkey rejected by server');
+    }
+  } catch (_) {
+    // Network error / timeout: never fail the chat send because of this.
+  }
 }
 ```
 
+No boolean return, no retry loop, no body parsing. The server contract makes any client-side branching on registration state both impossible and unwanted.
+
 #### 4.2 Call `notifyPeer()` after sending P2P chat message
 
-In `ChatRoomNotifier.sendMessage()`, after successful `publishEvent()`:
+In `ChatRoomNotifier.sendMessage()`, immediately after `await publishEvent(wrappedEvent)` succeeds and **before** `eventStore.putItem()` so the wake-up does not depend on local persistence:
 
 ```dart
-// After publishing the wrapped event
-final pushService = ref.read(pushNotificationServiceProvider);
-pushService.notifyPeer(session.peer!.publicKey);
+await ref.read(nostrServiceProvider).publishEvent(wrappedEvent);
+
+// Fire-and-forget: wake the peer's device if registered.
+unawaited(
+  ref.read(pushNotificationServiceProvider).notifyPeer(session.peer!.publicKey),
+);
 ```
 
-Fire-and-forget (don't block on the response, don't fail the send if push fails).
+Fire-and-forget — never block the send and never surface the result to the user.
 
-#### 4.3 Push server changes (external)
+#### 4.3 Push server side — already implemented, verify only
 
-New endpoint needed on the push server:
+`POST /api/notify` is already deployed and documented in [`mostro-push-server/docs/api.md`](https://github.com/MostroP2P/mostro-push-server/blob/main/docs/api.md). No server changes are required for this phase. Quick verification checklist:
 
-```
-POST /api/notify
-Body: { "trade_pubkey": "<64-char hex>" }
-Response: 200 OK | 404 (pubkey not registered)
-```
-
-Simply sends a silent FCM notification to the device registered for that trade pubkey. Same behavior as relay-monitored events, but triggered on-demand.
+- [ ] `curl -i -X POST $SERVER/api/notify -H 'content-type: application/json' -d '{"trade_pubkey":"<64-hex>"}'` returns `202 {"accepted":true}`.
+- [ ] Malformed pubkey returns `400`.
+- [ ] Sustained traffic above the per-pubkey limit returns `429` with `Retry-After`.
+- [ ] Response carries a server-generated `x-request-id`.
 
 **Authentication model: intentionally unauthenticated (consistent with existing design)**
 
-The existing `/api/register` endpoint is also unauthenticated — no signatures, no auth headers. `/api/notify` follows the same model. Alternatives were considered and rejected:
+The existing `/api/register` endpoint is also unauthenticated. `/api/notify` follows the same model. Alternatives were considered and rejected:
 
 - **Sender signature authentication** — rejected because it would reveal the sender's trade pubkey to the push server, breaking the privacy guarantee that the server doesn't learn who is messaging whom.
 - **Registration-time counterparty binding** — rejected because it requires the push server to store counterparty relationships (`A trades with B`), which it currently doesn't know and shouldn't.
@@ -313,29 +335,56 @@ The existing `/api/register` endpoint is also unauthenticated — no signatures,
 
 | Threat | Severity | Mitigation |
 |--------|----------|------------|
-| Data harvest | None | Endpoint accepts a pubkey and returns 200/404. Attacker learns at most whether a pubkey is registered, which is already inferrable from relay observation. |
-| DoS / battery drain | Medium | An attacker could spam notify calls to repeatedly wake a device. **Mitigations:** server-side rate limiting per `trade_pubkey` (e.g., max 5 calls/minute), per-IP rate limiting (e.g., max 60 calls/minute), and exponential backoff on 429 responses in the client. |
-| Unsolicited wake-ups | Low | Silent FCM notifications have minimal user-visible impact. The background service only processes events it can actually decrypt — spurious wake-ups result in a no-op. OS-level battery optimization further limits impact. |
+| Data harvest / enumeration | None | Endpoint always returns `202` regardless of registration state. The 202/400/429 set leaks no information about which pubkeys are registered. |
+| DoS / battery drain | Medium | Server-side rate limits already in place: per-`trade_pubkey` and per-IP limiters (`governor`); spawn pile capped at 50 permits; client is fire-and-forget with no retry on 429. |
+| Unsolicited wake-ups | Low | FCM notifications are silent. The background service only processes events it can decrypt; spurious wake-ups are no-ops. OS battery optimization further limits impact. |
 
-**Required server-side mitigations:**
-- Rate limit per `trade_pubkey`: max 5 calls per minute (429 Too Many Requests)
-- Rate limit per source IP: max 60 calls per minute
-- Client handles 429 with exponential backoff (no retry on chat send failure — fire-and-forget)
+**Server-side rate limits (already configured, defaults):**
+- Per-`trade_pubkey`: `30/min`, burst `10` (env `NOTIFY_RATE_PER_PUBKEY_PER_MIN`).
+- Per-IP: `120/min`, burst `30` (env `NOTIFY_RATE_PER_IP_PER_MIN`).
+- Both must allow the request; on 429 the body is byte-identical to prevent oracle behavior.
 
-#### 4.4 Admin/Dispute Chat Push — Verify existing coverage
+Client handles 429 by dropping the call silently — fire-and-forget on a chat send must never block, retry, or surface an error to the user.
 
-Admin events already use `tradeKey.public` as the `p` tag. The push server's relay monitoring should already cover these. Verify this works end-to-end. If not, add `notifyPeer()` call in `DisputeChatNotifier.sendMessage()` as well.
+#### 4.4 Admin/Dispute Chat Push — no `notifyPeer()` needed
+
+Dispute chat is fully covered by the existing listener path; **no client-side `notifyPeer()` call is required**.
+
+Why: admin DMs in disputes are sent user-to-user as `kind 1059` gift wraps, with `p = recipient's tradeKey.public`. The push server's listener (`src/nostr/listener.rs`) deliberately does **not** apply an `authors` filter — this is a hard constraint in `mostro-push-server/CLAUDE.md` precisely because Gift Wrap uses ephemeral outer keys and admin DMs are not Mostro-daemon-signed. So:
+
+- **Admin → user:** kind 1059 hits the relay → listener picks it up by the `p` tag → token lookup against the user's registered `tradeKey` → silent FCM. Already works.
+- **User → admin:** admins typically run desktop/CLI clients that are not registered with the push server. Out of scope for the mobile app.
+
+The existing Phase 1 code path (DM payload detection in `_decryptAndProcessEvent`) handles the rendering once the device wakes. **Do not add `notifyPeer()` to `DisputeChatNotifier.sendMessage()`** — it would only serve to wake the sender's own counterpart in non-dispute scenarios and muddy the model.
+
+#### 4.5 Align `/api/register` with the trusted-instance whitelist
+
+Out-of-band but tightly adjacent: `mostro-push-server` v1.1 added an opt-in whitelist of trusted Mostro instance pubkeys. When `TRUSTED_WHITELIST_ENABLED=true` and the embedded list is non-empty, `/api/register` requires a `mostro_pubkey` field and rejects clients that omit it with `403 "Mostro instance pubkey required"`.
+
+The flag currently defaults to `false`, so today's clients keep working. To avoid breakage when the operator flips it after the mobile rollout, this PR should add `mostro_pubkey` to the registration body.
+
+```dart
+body: jsonEncode({
+  'trade_pubkey': tradePubkey,
+  'token': fcmToken,
+  'platform': _platform,
+  'mostro_pubkey': selectedMostroNodePubkey, // 64-hex of active Mostro instance
+}),
+```
+
+Source: `MostroNodesNotifier` / `selectedMostroNodeProvider` already tracks the active node. The field is request-only and does not affect response shape, so it is backwards-compatible with servers that ignore it.
 
 **Files to modify:**
-- `lib/services/push_notification_service.dart` — add `notifyPeer()` method
-- `lib/features/chat/notifiers/chat_room_notifier.dart` — call `notifyPeer()` after send
-- `lib/features/disputes/notifiers/dispute_chat_notifier.dart` — call `notifyPeer()` if needed
-- Push server repository (external) — add `/api/notify` endpoint
+- `lib/services/push_notification_service.dart` — add `notifyPeer()`; add `mostro_pubkey` to `registerToken()` body.
+- `lib/features/chat/notifiers/chat_room_notifier.dart` — fire-and-forget `notifyPeer()` after `publishEvent`.
+- (No changes to `DisputeChatNotifier` — see 4.4.)
+- (No changes to push server — already implemented.)
 
 **Tests:**
-- Unit test: verify `notifyPeer()` makes correct HTTP call
-- Unit test: verify `sendMessage()` calls `notifyPeer()` after publish
-- Integration test: end-to-end P2P message → FCM wake → background notification
+- Unit test: `notifyPeer()` posts the expected body and never throws on `202`/`400`/`429`/network error.
+- Unit test: `sendMessage()` invokes `notifyPeer()` exactly once after a successful `publishEvent`, and does not await it.
+- Unit test: `registerToken()` includes `mostro_pubkey` in the request body.
+- Manual / integration: end-to-end P2P message → FCM wake → background notification on a real device.
 
 ---
 
@@ -346,7 +395,7 @@ Admin events already use `tradeKey.public` as the `p` tag. The push server's rel
 | 1 | Admin DM background notifications | Low | 4 | None |
 | 2 | P2P chat background notifications | Low-Medium | 1 | None |
 | 3 | In-app notifications (foreground) | Medium | 5-6 | None |
-| 4 | Push/FCM for P2P chat (app killed) | Medium | 3-4 | New endpoint |
+| 4 | Push/FCM for P2P chat (app killed) + register whitelist alignment | Medium | 2 | None (`/api/notify` already deployed) |
 
 ## Privacy Considerations
 
@@ -367,6 +416,6 @@ Admin events already use `tradeKey.public` as the `p` tag. The push server's rel
 
 3. **Notification tap action:** Should tapping a chat notification navigate to the specific chat room or to the notifications screen? Current trade notifications go to `/notifications`.
 
-4. **Rate limiting for Phase 4:** Exact rate limits for `/api/notify` — needs coordination with push server maintainers.
+4. ~~**Rate limiting for Phase 4:**~~ **Resolved:** server enforces `30/min` per `trade_pubkey` (burst 10) and `120/min` per IP (burst 30). Client is fire-and-forget with no retry on 429.
 
-5. **Dispute chat push verification:** Need to confirm whether the push server's relay monitoring already catches admin DM events targeting `tradeKey.public`, or if explicit notify calls are needed.
+5. ~~**Dispute chat push verification:**~~ **Resolved:** the push-server listener has no `authors` filter (hard constraint), so admin DMs targeting `tradeKey.public` are caught by the listener path. No `notifyPeer()` call is needed for dispute chat.

--- a/lib/features/chat/notifiers/chat_room_notifier.dart
+++ b/lib/features/chat/notifiers/chat_room_notifier.dart
@@ -18,6 +18,7 @@ import 'package:mostro_mobile/features/notifications/providers/notifications_pro
 import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/push_notification_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/features/chat/utils/message_type_helpers.dart';
 import 'package:mostro_mobile/shared/mixins/media_cache_mixin.dart';
@@ -233,6 +234,17 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       } catch (publishError, publishStack) {
         logger.e('Failed to publish message: $publishError', stackTrace: publishStack);
         return;
+      }
+
+      // Wake the peer's device via the push server (fire-and-forget).
+      // Required for P2P chat because the server's Nostr listener only matches
+      // kind 1059 events on the recipient's tradeKey.public, and P2P chat
+      // events use sharedKey.public.
+      final peerPubkey = session.peer?.publicKey;
+      if (peerPubkey != null) {
+        unawaited(
+          ref.read(pushNotificationServiceProvider).notifyPeer(peerPubkey),
+        );
       }
 
       // Persist the wrapped event to disk immediately after successful publish.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -114,6 +114,11 @@ void _initializePushNotificationIntegration(
       return container.read(settingsProvider).pushNotificationsEnabled;
     };
 
+    // Provide the active Mostro instance pubkey for /api/register
+    pushServices.pushService.getMostroPubkey = () {
+      return container.read(settingsProvider).mostroPublicKey;
+    };
+
     debugPrint('Push notification integration initialized');
   } catch (e) {
     debugPrint('Failed to initialize push notification integration: $e');

--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
+import 'package:flutter/foundation.dart' show kIsWeb, debugPrint, visibleForTesting;
 import 'package:http/http.dart' as http;
 import 'package:mostro_mobile/services/logger_service.dart';
 
@@ -26,6 +26,9 @@ String _shortenPubkey(String pubkey, [int maxLength = 16]) {
 class PushNotificationService {
   final FCMService _fcmService;
   final String _pushServerUrl;
+  final http.Client _httpClient;
+  final bool? _isSupportedOverride;
+  final String? _platformOverride;
 
   bool _isInitialized = false;
 
@@ -36,14 +39,26 @@ class PushNotificationService {
   /// Set this from the app to integrate with user preferences
   bool Function()? isPushEnabledInSettings;
 
+  /// Callback returning the active Mostro instance pubkey (64 hex chars).
+  /// Sent in the `mostro_pubkey` field of `/api/register` so the push server
+  /// can apply its trusted-instance whitelist when enabled.
+  String Function()? getMostroPubkey;
+
   PushNotificationService({
     required FCMService fcmService,
     String? pushServerUrl,
+    http.Client? httpClient,
+    @visibleForTesting bool? isSupportedOverride,
+    @visibleForTesting String? platformOverride,
   })  : _fcmService = fcmService,
-        _pushServerUrl = pushServerUrl ?? Config.pushServerUrl;
+        _pushServerUrl = pushServerUrl ?? Config.pushServerUrl,
+        _httpClient = httpClient ?? http.Client(),
+        _isSupportedOverride = isSupportedOverride,
+        _platformOverride = platformOverride;
 
   /// Check if push notifications are supported on this platform
   bool get isSupported {
+    if (_isSupportedOverride != null) return _isSupportedOverride;
     if (kIsWeb) return false;
     return Platform.isAndroid || Platform.isIOS;
   }
@@ -51,7 +66,8 @@ class PushNotificationService {
   bool get isInitialized => _isInitialized;
 
   /// Get the current platform identifier
-  String get _platform => Platform.isIOS ? 'ios' : 'android';
+  String get _platform =>
+      _platformOverride ?? (Platform.isIOS ? 'ios' : 'android');
 
   /// Initialize the service
   Future<bool> initialize() async {
@@ -65,7 +81,7 @@ class PushNotificationService {
     try {
       debugPrint('PushService: Checking server health...');
 
-      final response = await http
+      final response = await _httpClient
           .get(Uri.parse('$_pushServerUrl/api/health'))
           .timeout(const Duration(seconds: 10));
 
@@ -114,16 +130,25 @@ class PushNotificationService {
 
       debugPrint('PushService: Registering token for trade ${_shortenPubkey(tradePubkey)}');
 
-      // Send plaintext token to server (Phase 3 - unencrypted)
-      final response = await http
+      // Send plaintext token to server (Phase 3 - unencrypted).
+      // `mostro_pubkey` enables the server-side trusted-instance whitelist
+      // (gated by TRUSTED_WHITELIST_ENABLED on the server). Servers without
+      // the flag enabled simply ignore the field.
+      final body = <String, dynamic>{
+        'trade_pubkey': tradePubkey,
+        'token': fcmToken,
+        'platform': _platform,
+      };
+      final mostroPubkey = getMostroPubkey?.call();
+      if (mostroPubkey != null && mostroPubkey.isNotEmpty) {
+        body['mostro_pubkey'] = mostroPubkey;
+      }
+
+      final response = await _httpClient
           .post(
             Uri.parse('$_pushServerUrl/api/register'),
             headers: {'Content-Type': 'application/json'},
-            body: jsonEncode({
-              'trade_pubkey': tradePubkey,
-              'token': fcmToken,
-              'platform': _platform,
-            }),
+            body: jsonEncode(body),
           )
           .timeout(const Duration(seconds: 10));
 
@@ -188,6 +213,47 @@ class PushNotificationService {
     }
   }
 
+  /// Wake the peer's device by triggering a silent push via `/api/notify`.
+  ///
+  /// Used after sending a P2P chat message: the push server's Nostr listener
+  /// only matches `kind 1059` events on the recipient's `tradeKey.public`,
+  /// and P2P chat events use `sharedKey.public`. This sender-triggered call
+  /// closes that gap without registering shared keys server-side.
+  ///
+  /// Strictly fire-and-forget. The server contract (see mostro-push-server
+  /// docs/api.md) guarantees indistinguishable responses for registered vs
+  /// unregistered pubkeys, so the caller cannot — and must not try to —
+  /// branch on the outcome:
+  ///
+  /// - 202 `{"accepted":true}` on parse-valid input (always).
+  /// - 400 on malformed pubkey (logged as a client bug).
+  /// - 429 on rate-limit hit (dropped silently, no retry).
+  Future<void> notifyPeer(String peerTradePubkey) async {
+    if (!isSupported) return;
+
+    if (isPushEnabledInSettings != null && !isPushEnabledInSettings!()) {
+      return;
+    }
+
+    try {
+      final response = await _httpClient
+          .post(
+            Uri.parse('$_pushServerUrl/api/notify'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'trade_pubkey': peerTradePubkey}),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      if (response.statusCode == 400) {
+        logger.w(
+            'notifyPeer: invalid pubkey rejected by server (${_shortenPubkey(peerTradePubkey)})');
+      }
+    } catch (e) {
+      // Network error / timeout: never fail the chat send because of this.
+      debugPrint('PushService: notifyPeer transport error (ignored): $e');
+    }
+  }
+
   /// Unregister a device token for a specific trade
   Future<bool> unregisterToken(String tradePubkey) async {
     if (!isSupported) {
@@ -198,7 +264,7 @@ class PushNotificationService {
       debugPrint(
           'PushService: Unregistering token for trade ${_shortenPubkey(tradePubkey)}');
 
-      final response = await http
+      final response = await _httpClient
           .post(
             Uri.parse('$_pushServerUrl/api/unregister'),
             headers: {'Content-Type': 'application/json'},

--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -220,6 +220,13 @@ class PushNotificationService {
   /// and P2P chat events use `sharedKey.public`. This sender-triggered call
   /// closes that gap without registering shared keys server-side.
   ///
+  /// Intentionally NOT gated on `isPushEnabledInSettings`: that flag is the
+  /// local *receive* preference and controls this device's own token
+  /// registration. Whether the peer is woken is governed by the peer's own
+  /// registration state, server-side. Suppressing outgoing notify calls based
+  /// on the sender's local preference would silently break delivery for a
+  /// correctly opted-in recipient.
+  ///
   /// Strictly fire-and-forget. The server contract (see mostro-push-server
   /// docs/api.md) guarantees indistinguishable responses for registered vs
   /// unregistered pubkeys, so the caller cannot — and must not try to —
@@ -230,10 +237,6 @@ class PushNotificationService {
   /// - 429 on rate-limit hit (dropped silently, no retry).
   Future<void> notifyPeer(String peerTradePubkey) async {
     if (!isSupported) return;
-
-    if (isPushEnabledInSettings != null && !isPushEnabledInSettings!()) {
-      return;
-    }
 
     try {
       final response = await _httpClient

--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -152,6 +152,16 @@ class PushNotificationService {
           )
           .timeout(const Duration(seconds: 10));
 
+      // 202 Accepted: treat as success without body parsing. The push server
+      // may switch /api/register to an async/queued ack in the future; accept
+      // it defensively so the client stays forward-compatible.
+      if (response.statusCode == 202) {
+        debugPrint(
+            'PushService: Token registered for trade ${_shortenPubkey(tradePubkey)}');
+        _registeredTradePubkeys.add(tradePubkey);
+        return true;
+      }
+
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
         if (data['success'] == true) {
@@ -253,7 +263,7 @@ class PushNotificationService {
       }
     } catch (e) {
       // Network error / timeout: never fail the chat send because of this.
-      debugPrint('PushService: notifyPeer transport error (ignored): $e');
+      logger.w('PushService: notifyPeer transport error (ignored): $e');
     }
   }
 

--- a/test/services/push_notification_service_test.dart
+++ b/test/services/push_notification_service_test.dart
@@ -1,0 +1,249 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mostro_mobile/services/fcm_service.dart';
+import 'package:mostro_mobile/services/push_notification_service.dart';
+
+import '../mocks.mocks.dart';
+
+class _FakeFcmService extends FCMService {
+  _FakeFcmService(super.prefs, {this.tokenOverride = 'fake-fcm-token'});
+
+  final String? tokenOverride;
+
+  @override
+  Future<String?> getToken() async => tokenOverride;
+}
+
+PushNotificationService _buildService({
+  required MockClient httpClient,
+  String? fcmToken = 'fake-fcm-token',
+  String platform = 'android',
+  bool? isPushEnabled,
+}) {
+  final service = PushNotificationService(
+    fcmService: _FakeFcmService(
+      MockSharedPreferencesAsync(),
+      tokenOverride: fcmToken,
+    ),
+    pushServerUrl: 'https://push.example',
+    httpClient: httpClient,
+    isSupportedOverride: true,
+    platformOverride: platform,
+  );
+  if (isPushEnabled != null) {
+    service.isPushEnabledInSettings = () => isPushEnabled;
+  }
+  return service;
+}
+
+const _validPubkey =
+    'a1b2c3d4e5f67890123456789012345678901234567890123456789012345abc';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PushNotificationService.notifyPeer', () {
+    test('POSTs /api/notify with the trade_pubkey body', () async {
+      http.Request? captured;
+      final mockClient = MockClient((request) async {
+        captured = request;
+        return http.Response('{"accepted":true}', 202);
+      });
+
+      final service = _buildService(httpClient: mockClient);
+      await service.notifyPeer(_validPubkey);
+
+      expect(captured, isNotNull);
+      expect(captured!.method, 'POST');
+      expect(
+        captured!.url.toString(),
+        'https://push.example/api/notify',
+      );
+      expect(
+        captured!.headers['content-type'],
+        contains('application/json'),
+      );
+      final decoded = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(decoded.keys, ['trade_pubkey']);
+      expect(decoded['trade_pubkey'], _validPubkey);
+    });
+
+    test('does not send sender_pubkey, signature, or auth headers', () async {
+      http.Request? captured;
+      final mockClient = MockClient((request) async {
+        captured = request;
+        return http.Response('{"accepted":true}', 202);
+      });
+
+      await _buildService(httpClient: mockClient).notifyPeer(_validPubkey);
+
+      final body = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(body.containsKey('sender_pubkey'), isFalse);
+      expect(body.containsKey('signature'), isFalse);
+      expect(body.containsKey('idempotency_key'), isFalse);
+      expect(captured!.headers.containsKey('authorization'), isFalse);
+      expect(captured!.headers.containsKey('x-request-id'), isFalse);
+    });
+
+    test('swallows 400 responses without throwing', () async {
+      final mockClient = MockClient((_) async => http.Response(
+            '{"success":false,"message":"invalid"}',
+            400,
+          ));
+
+      await expectLater(
+        _buildService(httpClient: mockClient).notifyPeer('not-a-pubkey'),
+        completes,
+      );
+    });
+
+    test('swallows 429 rate-limit responses without retrying', () async {
+      var calls = 0;
+      final mockClient = MockClient((_) async {
+        calls++;
+        return http.Response(
+          '{"success":false,"message":"rate limited"}',
+          429,
+          headers: {'retry-after': '12'},
+        );
+      });
+
+      await _buildService(httpClient: mockClient).notifyPeer(_validPubkey);
+
+      expect(calls, 1, reason: 'fire-and-forget must not retry on 429');
+    });
+
+    test('swallows network errors without throwing', () async {
+      final mockClient = MockClient((_) async {
+        throw const SocketExceptionLike();
+      });
+
+      await expectLater(
+        _buildService(httpClient: mockClient).notifyPeer(_validPubkey),
+        completes,
+      );
+    });
+
+    test('returns early when push notifications are disabled in settings',
+        () async {
+      var called = false;
+      final mockClient = MockClient((_) async {
+        called = true;
+        return http.Response('{"accepted":true}', 202);
+      });
+
+      await _buildService(
+        httpClient: mockClient,
+        isPushEnabled: false,
+      ).notifyPeer(_validPubkey);
+
+      expect(called, isFalse);
+    });
+
+    test('returns early when platform is not supported', () async {
+      var called = false;
+      final mockClient = MockClient((_) async {
+        called = true;
+        return http.Response('{"accepted":true}', 202);
+      });
+
+      final service = PushNotificationService(
+        fcmService: _FakeFcmService(MockSharedPreferencesAsync()),
+        pushServerUrl: 'https://push.example',
+        httpClient: mockClient,
+        isSupportedOverride: false,
+      );
+      await service.notifyPeer(_validPubkey);
+
+      expect(called, isFalse);
+    });
+  });
+
+  group('PushNotificationService.registerToken', () {
+    test('includes mostro_pubkey when callback returns a non-empty value',
+        () async {
+      http.Request? captured;
+      final mockClient = MockClient((request) async {
+        if (request.url.path == '/api/health') {
+          return http.Response('{"status":"ok"}', 200);
+        }
+        captured = request;
+        return http.Response(
+          '{"success":true,"message":"ok","platform":"android"}',
+          200,
+        );
+      });
+
+      final service = _buildService(httpClient: mockClient);
+      service.getMostroPubkey = () =>
+          'deadbeef00000000000000000000000000000000000000000000000000000000';
+
+      final ok = await service.registerToken(_validPubkey);
+
+      expect(ok, isTrue);
+      final body = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(body['trade_pubkey'], _validPubkey);
+      expect(body['token'], 'fake-fcm-token');
+      expect(body['platform'], 'android');
+      expect(
+        body['mostro_pubkey'],
+        'deadbeef00000000000000000000000000000000000000000000000000000000',
+      );
+    });
+
+    test('omits mostro_pubkey when callback is not set', () async {
+      http.Request? captured;
+      final mockClient = MockClient((request) async {
+        if (request.url.path == '/api/health') {
+          return http.Response('{"status":"ok"}', 200);
+        }
+        captured = request;
+        return http.Response(
+          '{"success":true,"message":"ok","platform":"android"}',
+          200,
+        );
+      });
+
+      final service = _buildService(httpClient: mockClient);
+      // getMostroPubkey intentionally left null
+
+      await service.registerToken(_validPubkey);
+
+      final body = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(body.containsKey('mostro_pubkey'), isFalse);
+    });
+
+    test('omits mostro_pubkey when callback returns an empty string',
+        () async {
+      http.Request? captured;
+      final mockClient = MockClient((request) async {
+        if (request.url.path == '/api/health') {
+          return http.Response('{"status":"ok"}', 200);
+        }
+        captured = request;
+        return http.Response(
+          '{"success":true,"message":"ok","platform":"android"}',
+          200,
+        );
+      });
+
+      final service = _buildService(httpClient: mockClient);
+      service.getMostroPubkey = () => '';
+
+      await service.registerToken(_validPubkey);
+
+      final body = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(body.containsKey('mostro_pubkey'), isFalse);
+    });
+  });
+}
+
+// Used to simulate a transport failure inside MockClient without importing dart:io.
+class SocketExceptionLike implements Exception {
+  const SocketExceptionLike();
+  @override
+  String toString() => 'SocketExceptionLike';
+}

--- a/test/services/push_notification_service_test.dart
+++ b/test/services/push_notification_service_test.dart
@@ -127,20 +127,24 @@ void main() {
       );
     });
 
-    test('returns early when push notifications are disabled in settings',
-        () async {
+    test(
+        'still fires when the sender has push disabled locally '
+        '(the flag is a receive preference, not a send guard)', () async {
       var called = false;
       final mockClient = MockClient((_) async {
         called = true;
         return http.Response('{"accepted":true}', 202);
       });
 
+      // Sender turned off their own push notifications. The peer may still
+      // be registered and expecting wake-ups; suppressing the call here
+      // would silently break delivery for a correctly opted-in recipient.
       await _buildService(
         httpClient: mockClient,
         isPushEnabled: false,
       ).notifyPeer(_validPubkey);
 
-      expect(called, isFalse);
+      expect(called, isTrue);
     });
 
     test('returns early when platform is not supported', () async {

--- a/test/services/push_notification_service_test.dart
+++ b/test/services/push_notification_service_test.dart
@@ -167,6 +167,29 @@ void main() {
   });
 
   group('PushNotificationService.registerToken', () {
+    test('treats HTTP 202 Accepted as successful registration', () async {
+      http.Request? captured;
+      final mockClient = MockClient((request) async {
+        if (request.url.path == '/api/health') {
+          return http.Response('{"status":"ok"}', 200);
+        }
+        captured = request;
+        // 202 with no parseable success flag — the server may switch to an
+        // async/queued ack model; the client must accept it as success.
+        return http.Response(
+          '{"success":true,"message":"ok","platform":"android"}',
+          202,
+        );
+      });
+
+      final ok =
+          await _buildService(httpClient: mockClient).registerToken(_validPubkey);
+
+      expect(ok, isTrue);
+      expect(captured, isNotNull);
+      expect(captured!.url.path, '/api/register');
+    });
+
     test('includes mostro_pubkey when callback returns a non-empty value',
         () async {
       http.Request? captured;


### PR DESCRIPTION
## Summary

Closes Phase 4 of the chat notifications plan: wake the peer's device via FCM when a P2P chat message is sent, and align `/api/register` with the push server's trusted-instance whitelist.

- `notifyPeer()` posts to `/api/notify` after `publishEvent` succeeds (fire-and-forget, no retries, swallows 400/429/network errors).
- Required because the push server's Nostr listener only matches kind 1059 events on `tradeKey.public`; P2P chat events use `sharedKey.public`.
- `registerToken()` now includes `mostro_pubkey` when a `getMostroPubkey` callback is set, wired from `settingsProvider.mostroPublicKey` in `main.dart`. Backwards-compatible: servers without the whitelist enabled ignore the field.
- Dispute chat is unchanged: the listener path already covers admin DMs (no client-side notify needed — relies on the server's no-author-filter constraint).
- Updated `docs/plans/CHAT_NOTIFICATIONS_PLAN.md` to match the deployed server contract (202 always, indistinguishable registered/unregistered, byte-identical 429 bodies, real rate limits).

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 368 passed, including 10 new unit tests for `PushNotificationService`
- [x] Manual: end-to-end P2P message wakes the peer's device on a real Android phone with the app killed
- [x] Manual: confirm `mostro_pubkey` appears in `/api/register` body via server logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer-to-peer chat push notifications now work in background and when the app is closed, including a sender-triggered wake-up path for delivery.
  * In-app foreground notifications outside the chat screen are enabled.

* **Documentation**
  * Updated end-to-end chat notification plan and phase statuses to reflect completed stages and clarified push behaviors.

* **Tests**
  * Added tests covering push registration, peer notify behavior, error resilience, and platform support edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/590)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->