### PR TITLE
flatten pay-invoice and add-invoice screens

### DIFF
--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -67,55 +67,42 @@ class _AddLightningInvoiceScreenState
             (amount ?? 0) > 0;
 
         return Scaffold(
-          backgroundColor: AppTheme.backgroundDark,
+          backgroundColor: AppTheme.dark1,
           appBar: OrderAppBar(title: S.of(context)!.addLightningInvoice),
           body: Padding(
-            padding: EdgeInsets.only(
-              bottom: MediaQuery.of(context).viewPadding.bottom,
+            padding: EdgeInsets.fromLTRB(
+              16,
+              16,
+              16,
+              16 + MediaQuery.of(context).viewPadding.bottom,
             ),
-            child: Column(
-              children: [
-                Expanded(
-                child: Container(
-                  margin: const EdgeInsets.all(16),
-                  padding: const EdgeInsets.all(20),
-                  decoration: BoxDecoration(
-                    color: AppTheme.backgroundCard,
-                    borderRadius: BorderRadius.circular(16),
-                    border:
-                        Border.all(color: Colors.white.withValues(alpha: 0.1)),
-                  ),
-                  child: showLnAddressConfirmation
-                      ? _buildLnAddressConfirmation(
-                          orderIdValue: orderIdValue,
-                        )
-                      : showNwcInvoice
-                          ? _buildNwcInvoiceFlow(
-                              amount: amount ?? 0,
-                              fiatAmount: fiatAmount,
-                              fiatCode: fiatCode,
-                              orderIdValue: orderIdValue,
-                            )
-                          : AddLightningInvoiceWidget(
-                              controller: invoiceController,
-                              onSubmit: () async {
-                                final invoice = invoiceController.text.trim();
-                                if (invoice.isNotEmpty) {
-                                  await _submitInvoice(invoice, amount);
-                                }
-                              },
-                              onCancel: () async {
-                                await _cancelOrder();
-                              },
-                              amount: amount ?? 0,
-                              fiatAmount: fiatAmount,
-                              fiatCode: fiatCode,
-                              orderId: orderIdValue,
-                            ),
-                ),
-              ),
-              ],
-            ),
+            child: showLnAddressConfirmation
+                ? _buildLnAddressConfirmation(
+                    orderIdValue: orderIdValue,
+                  )
+                : showNwcInvoice
+                    ? _buildNwcInvoiceFlow(
+                        amount: amount ?? 0,
+                        fiatAmount: fiatAmount,
+                        fiatCode: fiatCode,
+                        orderIdValue: orderIdValue,
+                      )
+                    : AddLightningInvoiceWidget(
+                        controller: invoiceController,
+                        onSubmit: () async {
+                          final invoice = invoiceController.text.trim();
+                          if (invoice.isNotEmpty) {
+                            await _submitInvoice(invoice, amount);
+                          }
+                        },
+                        onCancel: () async {
+                          await _cancelOrder();
+                        },
+                        amount: amount ?? 0,
+                        fiatAmount: fiatAmount,
+                        fiatCode: fiatCode,
+                        orderId: orderIdValue,
+                      ),
           ),
         );
       },

--- a/lib/features/order/screens/pay_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/pay_lightning_invoice_screen.dart
@@ -5,7 +5,6 @@ import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/features/wallet/providers/nwc_provider.dart';
-import 'package:mostro_mobile/shared/widgets/custom_card.dart';
 import 'package:mostro_mobile/shared/widgets/nwc_payment_widget.dart';
 import 'package:mostro_mobile/shared/widgets/pay_lightning_invoice_widget.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
@@ -42,74 +41,76 @@ class _PayLightningInvoiceScreenState
     return Scaffold(
       backgroundColor: AppTheme.dark1,
       appBar: OrderAppBar(title: S.of(context)!.payLightningInvoice),
-      body: CustomCard(
-        padding: const EdgeInsets.all(16),
-        child: Material(
-          color: AppTheme.dark2,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              if (showNwcPayment) ...[
-                // NWC auto-payment flow
-                Text(
-                  S.of(context)!.payInvoiceToContinue(
-                    sats.toString(),
-                    fiatCode,
-                    fiatAmount,
-                    widget.orderId,
-                  ),
-                  style: const TextStyle(color: AppTheme.cream1, fontSize: 18),
-                  textAlign: TextAlign.center,
+      body: Padding(
+        padding: EdgeInsets.fromLTRB(
+          16,
+          16,
+          16,
+          16 + MediaQuery.of(context).viewPadding.bottom,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (showNwcPayment) ...[
+              // NWC auto-payment flow
+              Text(
+                S.of(context)!.payInvoiceToContinue(
+                  sats.toString(),
+                  fiatCode,
+                  fiatAmount,
+                  widget.orderId,
                 ),
-                const SizedBox(height: 24),
-                NwcPaymentWidget(
-                  lnInvoice: lnInvoice,
-                  sats: sats,
-                  onPaymentSuccess: () {
-                    // Payment succeeded — Mostro will update the order state
-                    // automatically via the event stream. We just navigate home.
-                    context.go('/');
-                  },
-                  onFallbackToManual: () {
-                    setState(() => _manualMode = true);
-                  },
-                ),
-                const SizedBox(height: 20),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    ElevatedButton(
-                      onPressed: () async {
-                        context.go('/');
-                        await orderNotifier.cancelOrder();
-                      },
-                      style: ElevatedButton.styleFrom(
-                        foregroundColor: Colors.white,
-                        backgroundColor: Colors.red,
-                      ),
-                      child: Text(S.of(context)!.cancel),
+                style: const TextStyle(color: AppTheme.cream1, fontSize: 18),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              NwcPaymentWidget(
+                lnInvoice: lnInvoice,
+                sats: sats,
+                onPaymentSuccess: () {
+                  // Payment succeeded — Mostro will update the order state
+                  // automatically via the event stream. We just navigate home.
+                  context.go('/');
+                },
+                onFallbackToManual: () {
+                  setState(() => _manualMode = true);
+                },
+              ),
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  ElevatedButton(
+                    onPressed: () async {
+                      context.go('/');
+                      await orderNotifier.cancelOrder();
+                    },
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      backgroundColor: Colors.red,
                     ),
-                  ],
-                ),
-              ] else ...[
-                // Manual payment flow (original)
-                PayLightningInvoiceWidget(
-                  onSubmit: () async {
-                    context.go('/');
-                  },
-                  onCancel: () async {
-                    context.go('/');
-                    await orderNotifier.cancelOrder();
-                  },
-                  lnInvoice: lnInvoice,
-                  sats: sats,
-                  fiatAmount: fiatAmount,
-                  fiatCode: fiatCode,
-                  orderId: widget.orderId,
-                ),
-              ],
+                    child: Text(S.of(context)!.cancel),
+                  ),
+                ],
+              ),
+            ] else ...[
+              // Manual payment flow (original)
+              PayLightningInvoiceWidget(
+                onSubmit: () async {
+                  context.go('/');
+                },
+                onCancel: () async {
+                  context.go('/');
+                  await orderNotifier.cancelOrder();
+                },
+                lnInvoice: lnInvoice,
+                sats: sats,
+                fiatAmount: fiatAmount,
+                fiatCode: fiatCode,
+                orderId: widget.orderId,
+              ),
             ],
-          ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
  - remove inner gray card wrapper from add-invoice screen
  - remove CustomCard and Material wrappers from pay-invoice screen
  - drop unused custom_card import
  - set scaffold background to dark1 on both screens
  - apply consistent padding with safe-area bottom inset
<img width="1182" height="2560" alt="image" src="https://github.com/user-attachments/assets/fb226b5d-0e3e-4fe5-b6c7-5bf5e7820f0f" />

<img width="1182" height="2560" alt="image" src="https://github.com/user-attachments/assets/5754baf8-2d73-4dc2-b8c8-f2ed4f56fc94" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Lightning invoice payment screens with improved spacing and layout consistency for a cleaner visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/593)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->