### PR TITLE
feat(bond): Phase 3 claim slashed bond payout from Mostro

### DIFF
--- a/integration_test/test_helpers.dart
+++ b/integration_test/test_helpers.dart
@@ -291,6 +291,8 @@ class FakeMostroService implements MostroService {
 
   @override
   Future<void> sendInvoice(String orderId, String invoice, int? amount) async {}
+  @override
+  Future<void> sendBondPayoutInvoice(String orderId, String invoice) async {}
 
   @override
   Future<void> cancelOrder(String orderId) async {}

--- a/lib/core/app_routes.dart
+++ b/lib/core/app_routes.dart
@@ -16,6 +16,7 @@ import 'package:mostro_mobile/features/trades/screens/trade_detail_screen.dart';
 import 'package:mostro_mobile/features/trades/screens/trades_screen.dart';
 import 'package:mostro_mobile/features/relays/relays_screen.dart';
 import 'package:mostro_mobile/features/order/screens/add_lightning_invoice_screen.dart';
+import 'package:mostro_mobile/features/order/screens/bond_payout_invoice_screen.dart';
 import 'package:mostro_mobile/features/order/screens/pay_bond_invoice_screen.dart';
 import 'package:mostro_mobile/features/order/screens/pay_lightning_invoice_screen.dart';
 import 'package:mostro_mobile/features/order/screens/take_order_screen.dart';
@@ -293,6 +294,17 @@ GoRouter createRouter(WidgetRef ref) {
                   context: context,
                   state: state,
                   child: PayBondInvoiceScreen(
+                    orderId: state.pathParameters['orderId']!,
+                  ),
+                ),
+          ),
+          GoRoute(
+            path: '/bond_payout/:orderId',
+            pageBuilder: (context, state) =>
+                buildPageWithDefaultTransition<void>(
+                  context: context,
+                  state: state,
+                  child: BondPayoutInvoiceScreen(
                     orderId: state.pathParameters['orderId']!,
                   ),
                 ),

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -1,4 +1,5 @@
 export 'package:mostro_mobile/data/models/amount.dart';
+export 'package:mostro_mobile/data/models/bond_payout_request.dart';
 export 'package:mostro_mobile/data/models/cant_do.dart';
 export 'package:mostro_mobile/data/models/dispute.dart';
 export 'package:mostro_mobile/data/models/mostro_message.dart';

--- a/lib/data/models/bond_payout_request.dart
+++ b/lib/data/models/bond_payout_request.dart
@@ -1,0 +1,120 @@
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/data/models/payload.dart';
+
+class BondPayoutRequest implements Payload {
+  final BondPayoutOrder order;
+  final int slashedAt;
+
+  const BondPayoutRequest({
+    required this.order,
+    required this.slashedAt,
+  });
+
+  @override
+  String get type => 'bond_payout_request';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        type: {
+          'order': order.toJson(),
+          'slashed_at': slashedAt,
+        },
+      };
+
+  factory BondPayoutRequest.fromJson(Map<String, dynamic> json) {
+    final orderJson = json['order'];
+    if (orderJson is! Map<String, dynamic>) {
+      throw const FormatException(
+          'BondPayoutRequest: missing or invalid order field');
+    }
+    final slashedAt = json['slashed_at'];
+    if (slashedAt is! int) {
+      throw const FormatException(
+          'BondPayoutRequest: missing or invalid slashed_at field');
+    }
+    return BondPayoutRequest(
+      order: BondPayoutOrder.fromJson(orderJson),
+      slashedAt: slashedAt,
+    );
+  }
+}
+
+class BondPayoutOrder {
+  final String? id;
+  final OrderType kind;
+  final int amount;
+  final String fiatCode;
+  final int? minAmount;
+  final int? maxAmount;
+  final int fiatAmount;
+  final String paymentMethod;
+  final int premium;
+
+  const BondPayoutOrder({
+    this.id,
+    required this.kind,
+    required this.amount,
+    required this.fiatCode,
+    this.minAmount,
+    this.maxAmount,
+    required this.fiatAmount,
+    required this.paymentMethod,
+    this.premium = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'kind': kind.value,
+        'status': null,
+        'amount': amount,
+        'fiat_code': fiatCode,
+        'min_amount': minAmount,
+        'max_amount': maxAmount,
+        'fiat_amount': fiatAmount,
+        'payment_method': paymentMethod,
+        'premium': premium,
+        'created_at': null,
+        'expires_at': null,
+      };
+
+  factory BondPayoutOrder.fromJson(Map<String, dynamic> json) {
+    int parseInt(String field, {int defaultValue = 0}) {
+      final value = json[field];
+      if (value == null) return defaultValue;
+      if (value is int) return value;
+      if (value is String) {
+        final parsed = int.tryParse(value);
+        if (parsed != null) return parsed;
+      }
+      throw FormatException('BondPayoutOrder: invalid $field: $value');
+    }
+
+    int? parseOptionalInt(String field) {
+      final value = json[field];
+      if (value == null) return null;
+      if (value is int) return value;
+      if (value is String) return int.tryParse(value);
+      return null;
+    }
+
+    String parseString(String field) {
+      final value = json[field];
+      if (value == null) {
+        throw FormatException('BondPayoutOrder: missing $field');
+      }
+      return value.toString();
+    }
+
+    return BondPayoutOrder(
+      id: json['id']?.toString(),
+      kind: OrderType.fromString(parseString('kind')),
+      amount: parseInt('amount'),
+      fiatCode: parseString('fiat_code'),
+      minAmount: parseOptionalInt('min_amount'),
+      maxAmount: parseOptionalInt('max_amount'),
+      fiatAmount: parseInt('fiat_amount'),
+      paymentMethod: parseString('payment_method'),
+      premium: parseInt('premium'),
+    );
+  }
+}

--- a/lib/data/models/bond_payout_request.dart
+++ b/lib/data/models/bond_payout_request.dart
@@ -78,9 +78,11 @@ class BondPayoutOrder {
       };
 
   factory BondPayoutOrder.fromJson(Map<String, dynamic> json) {
-    int parseInt(String field, {int defaultValue = 0}) {
+    int parseInt(String field) {
       final value = json[field];
-      if (value == null) return defaultValue;
+      if (value == null) {
+        throw FormatException('BondPayoutOrder: missing $field');
+      }
       if (value is int) return value;
       if (value is String) {
         final parsed = int.tryParse(value);
@@ -114,7 +116,7 @@ class BondPayoutOrder {
       maxAmount: parseOptionalInt('max_amount'),
       fiatAmount: parseInt('fiat_amount'),
       paymentMethod: parseString('payment_method'),
-      premium: parseInt('premium'),
+      premium: parseOptionalInt('premium') ?? 0,
     );
   }
 }

--- a/lib/data/models/enums/action.dart
+++ b/lib/data/models/enums/action.dart
@@ -4,6 +4,7 @@ enum Action {
   takeBuy('take-buy'),
   payInvoice('pay-invoice'),
   payBondInvoice('pay-bond-invoice'),
+  addBondInvoice('add-bond-invoice'),
   fiatSent('fiat-sent'),
   fiatSentOk('fiat-sent-ok'),
   release('release'),

--- a/lib/data/models/payload.dart
+++ b/lib/data/models/payload.dart
@@ -1,3 +1,4 @@
+import 'package:mostro_mobile/data/models/bond_payout_request.dart';
 import 'package:mostro_mobile/data/models/cant_do.dart';
 import 'package:mostro_mobile/data/models/dispute.dart';
 import 'package:mostro_mobile/data/models/next_trade.dart';
@@ -17,6 +18,8 @@ abstract class Payload {
     // If we check 'order' first, Disputes with nested Orders will be incorrectly parsed as Orders
     if (json.containsKey('dispute')) {
       return Dispute.fromJson(json);
+    } else if (json.containsKey('bond_payout_request')) {
+      return BondPayoutRequest.fromJson(json['bond_payout_request']);
     } else if (json.containsKey('order')) {
       return Order.fromJson(json['order']);
     } else if (json.containsKey('payment_request')) {

--- a/lib/features/mostro/mostro_instance.dart
+++ b/lib/features/mostro/mostro_instance.dart
@@ -22,6 +22,7 @@ class MostroInstance {
   final String lndNodeUri;
   final String fiatCurrenciesAccepted;
   final int maxOrdersPerResponse;
+  final int bondPayoutClaimWindowDays;
 
   MostroInstance(
     this.pubKey,
@@ -45,6 +46,7 @@ class MostroInstance {
     this.lndNodeUri,
     this.fiatCurrenciesAccepted,
     this.maxOrdersPerResponse,
+    this.bondPayoutClaimWindowDays,
   );
 
   factory MostroInstance.fromEvent(NostrEvent event) {
@@ -70,6 +72,7 @@ class MostroInstance {
       event.lndNodeUri,
       event.fiatCurrenciesAccepted,
       event.maxOrdersPerResponse,
+      event.bondPayoutClaimWindowDays,
     );
   }
 }
@@ -78,6 +81,12 @@ extension MostroInstanceExtensions on NostrEvent {
   String _getTagValue(String key) {
     final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
     return (tag != null && tag.length > 1) ? tag[1] : 'Tag: $key not found';
+  }
+
+  String? _getOptionalTagValue(String key) {
+    final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
+    if (tag == null || tag.length < 2) return null;
+    return tag[1];
   }
 
   String get pubKey => _getTagValue('d');
@@ -104,4 +113,11 @@ extension MostroInstanceExtensions on NostrEvent {
   String get lndNodeUri => _getTagValue('lnd_uris');
   String get fiatCurrenciesAccepted => _getTagValue('fiat_currencies_accepted');
   int get maxOrdersPerResponse => int.parse(_getTagValue('max_orders_per_response'));
+
+  /// Days from `slashed_at` to claim a slashed-bond share before forfeit.
+  int get bondPayoutClaimWindowDays {
+    final raw = _getOptionalTagValue('bond_payout_claim_window_days');
+    if (raw == null) return 15;
+    return int.tryParse(raw) ?? 15;
+  }
 }

--- a/lib/features/mostro/mostro_instance.dart
+++ b/lib/features/mostro/mostro_instance.dart
@@ -79,12 +79,18 @@ class MostroInstance {
 
 extension MostroInstanceExtensions on NostrEvent {
   String _getTagValue(String key) {
-    final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
+    final tag = tags?.firstWhere(
+      (t) => t.isNotEmpty && t[0] == key,
+      orElse: () => const [],
+    );
     return (tag != null && tag.length > 1) ? tag[1] : 'Tag: $key not found';
   }
 
   String? _getOptionalTagValue(String key) {
-    final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
+    final tag = tags?.firstWhere(
+      (t) => t.isNotEmpty && t[0] == key,
+      orElse: () => const [],
+    );
     if (tag == null || tag.length < 2) return null;
     return tag[1];
   }
@@ -118,6 +124,8 @@ extension MostroInstanceExtensions on NostrEvent {
   int get bondPayoutClaimWindowDays {
     final raw = _getOptionalTagValue('bond_payout_claim_window_days');
     if (raw == null) return 15;
-    return int.tryParse(raw) ?? 15;
+    final parsed = int.tryParse(raw);
+    if (parsed == null || parsed <= 0) return 15;
+    return parsed;
   }
 }

--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -207,6 +207,9 @@ class NotificationDataExtractor {
         // This action doesn't generate notifications
         return null;
 
+      case Action.addBondInvoice:
+        return null;
+
       default:
         // Unknown actions generate temporary notifications
         isTemporary = true;

--- a/lib/features/notifications/utils/notification_message_mapper.dart
+++ b/lib/features/notifications/utils/notification_message_mapper.dart
@@ -94,6 +94,7 @@ class NotificationMessageMapper {
       case mostro.Action.restore:
       case mostro.Action.orders:
       case mostro.Action.lastTradeIndex:
+      case mostro.Action.addBondInvoice:
         return 'TODO: implement  title key if needed';
     }
   }
@@ -197,8 +198,9 @@ class NotificationMessageMapper {
       case mostro.Action.restore:
       case mostro.Action.orders:
       case mostro.Action.lastTradeIndex:
+      case mostro.Action.addBondInvoice:
         return 'TODO: implement message key if needed';
-      
+
     }
   }
 

--- a/lib/features/notifications/widgets/notification_item.dart
+++ b/lib/features/notifications/widgets/notification_item.dart
@@ -132,6 +132,7 @@ class NotificationItem extends ConsumerWidget {
         case mostro_action.Action.restore:
         case mostro_action.Action.orders:
         case mostro_action.Action.lastTradeIndex:
+        case mostro_action.Action.addBondInvoice:
           break;
       }
     }

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -362,6 +362,7 @@ class OrderState {
       case Action.sendDm:
       case Action.tradePubkey:
       case Action.adminAddSolver:
+      case Action.addBondInvoice:
         return payloadStatus ?? status;
 
       // For actions that include Order payload, use the payload status

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models.dart';
+import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/features/restore/restore_mode_provider.dart';
 import 'package:mostro_mobile/shared/providers.dart';
@@ -12,6 +13,7 @@ import 'package:mostro_mobile/features/notifications/providers/notifications_pro
 import 'package:mostro_mobile/features/notifications/utils/notification_data_extractor.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
+import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
 
 class AbstractMostroNotifier extends StateNotifier<OrderState> {
   final String orderId;
@@ -263,6 +265,16 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
         sessionNotifier.saveSession(session);
         await _handleAddInvoiceWithAutoLightningAddress(event);
+        break;
+
+      case Action.addBondInvoice:
+        final request = event.getPayload<BondPayoutRequest>();
+        if (request == null) break;
+        final instance = ref.read(orderRepositoryProvider).mostroInstance;
+        final claimWindowDays = instance?.bondPayoutClaimWindowDays ?? 15;
+        if (isBondClaimExpired(request.slashedAt, claimWindowDays)) break;
+        ref.read(sessionNotifierProvider.notifier).saveSession(session);
+        navProvider.go('/bond_payout/$orderId');
         break;
 
       case Action.holdInvoicePaymentAccepted:

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -126,9 +126,18 @@ class OrderNotifier extends AbstractMostroNotifier {
       payload: PaymentRequest(lnInvoice: invoice),
       timestamp: timestamp,
     );
-    await ref
-        .read(mostroStorageProvider)
-        .addMessage('outbound_addBondInvoice_${orderId}_$timestamp', outbound);
+    try {
+      await ref.read(mostroStorageProvider).addMessage(
+            'outbound_addBondInvoice_${orderId}_$timestamp',
+            outbound,
+          );
+    } catch (e, stack) {
+      logger.e(
+        'Failed to persist outbound add-bond-invoice for $orderId',
+        error: e,
+        stackTrace: stack,
+      );
+    }
   }
 
   Future<void> cancelOrder() async {

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -119,6 +119,16 @@ class OrderNotifier extends AbstractMostroNotifier {
 
   Future<void> sendBondPayoutInvoice(String invoice) async {
     await mostroService.sendBondPayoutInvoice(orderId, invoice);
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final outbound = MostroMessage(
+      action: Action.addBondInvoice,
+      id: orderId,
+      payload: PaymentRequest(lnInvoice: invoice),
+      timestamp: timestamp,
+    );
+    await ref
+        .read(mostroStorageProvider)
+        .addMessage('outbound_addBondInvoice_${orderId}_$timestamp', outbound);
   }
 
   Future<void> cancelOrder() async {

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -117,6 +117,10 @@ class OrderNotifier extends AbstractMostroNotifier {
     );
   }
 
+  Future<void> sendBondPayoutInvoice(String invoice) async {
+    await mostroService.sendBondPayoutInvoice(orderId, invoice);
+  }
+
   Future<void> cancelOrder() async {
     await mostroService.cancelOrder(orderId);
   }

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -126,18 +126,10 @@ class OrderNotifier extends AbstractMostroNotifier {
       payload: PaymentRequest(lnInvoice: invoice),
       timestamp: timestamp,
     );
-    try {
-      await ref.read(mostroStorageProvider).addMessage(
-            'outbound_addBondInvoice_${orderId}_$timestamp',
-            outbound,
-          );
-    } catch (e, stack) {
-      logger.e(
-        'Failed to persist outbound add-bond-invoice for $orderId',
-        error: e,
-        stackTrace: stack,
-      );
-    }
+    await ref.read(mostroStorageProvider).addMessage(
+          'outbound_addBondInvoice_${orderId}_$timestamp',
+          outbound,
+        );
   }
 
   Future<void> cancelOrder() async {

--- a/lib/features/order/screens/bond_payout_invoice_screen.dart
+++ b/lib/features/order/screens/bond_payout_invoice_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
-import 'package:mostro_mobile/data/models/bond_payout_request.dart';
+import 'package:mostro_mobile/data/models.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';

--- a/lib/features/order/screens/bond_payout_invoice_screen.dart
+++ b/lib/features/order/screens/bond_payout_invoice_screen.dart
@@ -9,6 +9,7 @@ import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
@@ -81,12 +82,19 @@ class _BondPayoutInvoiceScreenState
           );
         },
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
-          child: Text(
-            e.toString(),
-            style: const TextStyle(color: AppTheme.textPrimary),
-          ),
-        ),
+        error: (e, stack) {
+          logger.e(
+            'Failed to load bond payout history for ${widget.orderId}',
+            error: e,
+            stackTrace: stack,
+          );
+          return Center(
+            child: Text(
+              s.errorLoadingBondPayout,
+              style: const TextStyle(color: AppTheme.textPrimary),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/features/order/screens/bond_payout_invoice_screen.dart
+++ b/lib/features/order/screens/bond_payout_invoice_screen.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/data/models/bond_payout_request.dart';
-import 'package:mostro_mobile/data/models/enums/action.dart' as mostro_action;
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
@@ -46,7 +45,7 @@ class _BondPayoutInvoiceScreenState
       appBar: OrderAppBar(title: s.addBondInvoiceTitle),
       body: historyAsync.when(
         data: (messages) {
-          final request = _latestBondPayoutRequest(messages);
+          final request = latestBondPayoutRequest(messages);
           if (request == null) {
             return Center(
               child: Padding(
@@ -97,15 +96,6 @@ class _BondPayoutInvoiceScreenState
         },
       ),
     );
-  }
-
-  BondPayoutRequest? _latestBondPayoutRequest(List<dynamic> messages) {
-    for (final msg in messages) {
-      if (msg.action != mostro_action.Action.addBondInvoice) continue;
-      final payload = msg.payload;
-      if (payload is BondPayoutRequest) return payload;
-    }
-    return null;
   }
 
   Widget _buildBody({
@@ -219,7 +209,12 @@ class _BondPayoutInvoiceScreenState
     try {
       await notifier.sendBondPayoutInvoice(invoice);
       if (mounted) context.go('/');
-    } catch (e) {
+    } catch (e, stack) {
+      logger.e(
+        'Failed to submit bond payout invoice for ${widget.orderId}',
+        error: e,
+        stackTrace: stack,
+      );
       if (!mounted) return;
       setState(() => _submitting = false);
       final s = S.of(context)!;
@@ -227,7 +222,7 @@ class _BondPayoutInvoiceScreenState
         if (mounted) {
           SnackBarHelper.showTopSnackBar(
             context,
-            s.addBondInvoiceFailedToSubmit(e.toString()),
+            s.addBondInvoiceFailedToSubmit,
           );
         }
       });

--- a/lib/features/order/screens/bond_payout_invoice_screen.dart
+++ b/lib/features/order/screens/bond_payout_invoice_screen.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/data/models/bond_payout_request.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart' as mostro_action;
+import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/providers.dart';
+import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
+import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
+
+class BondPayoutInvoiceScreen extends ConsumerStatefulWidget {
+  final String orderId;
+
+  const BondPayoutInvoiceScreen({super.key, required this.orderId});
+
+  @override
+  ConsumerState<BondPayoutInvoiceScreen> createState() =>
+      _BondPayoutInvoiceScreenState();
+}
+
+class _BondPayoutInvoiceScreenState
+    extends ConsumerState<BondPayoutInvoiceScreen> {
+  final TextEditingController _invoiceController = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _invoiceController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final historyAsync =
+        ref.watch(mostroMessageHistoryProvider(widget.orderId));
+
+    return Scaffold(
+      backgroundColor: AppTheme.dark1,
+      appBar: OrderAppBar(title: s.addBondInvoiceTitle),
+      body: historyAsync.when(
+        data: (messages) {
+          final request = _latestBondPayoutRequest(messages);
+          if (request == null) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  s.addBondInvoiceMessage,
+                  style: const TextStyle(color: AppTheme.textPrimary),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
+          final instance =
+              ref.watch(orderRepositoryProvider).mostroInstance;
+          final claimWindowDays = instance?.bondPayoutClaimWindowDays ?? 15;
+          if (isBondClaimExpired(request.slashedAt, claimWindowDays)) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) context.go('/');
+            });
+            return const SizedBox.shrink();
+          }
+
+          final deadline =
+              bondClaimDeadline(request.slashedAt, claimWindowDays);
+          final formattedDeadline =
+              DateFormat.yMMMd().add_jm().format(deadline);
+
+          return _buildBody(
+            s: s,
+            request: request,
+            formattedDeadline: formattedDeadline,
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Text(
+            e.toString(),
+            style: const TextStyle(color: AppTheme.textPrimary),
+          ),
+        ),
+      ),
+    );
+  }
+
+  BondPayoutRequest? _latestBondPayoutRequest(List<dynamic> messages) {
+    for (final msg in messages) {
+      if (msg.action != mostro_action.Action.addBondInvoice) continue;
+      final payload = msg.payload;
+      if (payload is BondPayoutRequest) return payload;
+    }
+    return null;
+  }
+
+  Widget _buildBody({
+    required S s,
+    required BondPayoutRequest request,
+    required String formattedDeadline,
+  }) {
+    return SingleChildScrollView(
+      padding: EdgeInsets.fromLTRB(
+        16,
+        16,
+        16,
+        16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            s.addBondInvoiceMessage,
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            s.addBondInvoiceWonLine(request.order.id ?? widget.orderId),
+            style: const TextStyle(
+              color: AppTheme.textSecondary,
+              fontSize: 14,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            s.addBondInvoiceDeadline(formattedDeadline),
+            style: const TextStyle(
+              color: AppTheme.textSecondary,
+              fontSize: 14,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: AppTheme.backgroundInput,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+            ),
+            child: TextFormField(
+              key: const Key('bondPayoutInvoiceTextField'),
+              controller: _invoiceController,
+              style: const TextStyle(color: AppTheme.textPrimary),
+              decoration: InputDecoration(
+                labelText: s.addBondInvoiceInputLabel,
+                labelStyle: const TextStyle(color: AppTheme.textSecondary),
+                hintText: s.addBondInvoiceInputHint,
+                hintStyle: const TextStyle(color: AppTheme.textSecondary),
+                border: InputBorder.none,
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                alignLabelWithHint: true,
+              ),
+              maxLines: 6,
+            ),
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              key: const Key('bondPayoutSubmitButton'),
+              onPressed: _submitting ? null : _onSubmit,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.activeColor,
+                foregroundColor: Colors.black,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              child: _submitting
+                  ? const SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.black,
+                      ),
+                    )
+                  : Text(
+                      s.addBondInvoiceSubmitButton,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onSubmit() async {
+    final invoice = _invoiceController.text.trim();
+    if (invoice.isEmpty) return;
+
+    setState(() => _submitting = true);
+    final notifier =
+        ref.read(orderNotifierProvider(widget.orderId).notifier);
+    try {
+      await notifier.sendBondPayoutInvoice(invoice);
+      if (mounted) context.go('/');
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      final s = S.of(context)!;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          SnackBarHelper.showTopSnackBar(
+            context,
+            s.addBondInvoiceFailedToSubmit(e.toString()),
+          );
+        }
+      });
+    }
+  }
+}

--- a/lib/features/order/screens/bond_payout_invoice_screen.dart
+++ b/lib/features/order/screens/bond_payout_invoice_screen.dart
@@ -114,7 +114,7 @@ class _BondPayoutInvoiceScreenState
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            s.addBondInvoiceMessage,
+            s.addBondInvoiceSubmitLine(request.order.amount.toString()),
             style: const TextStyle(
               color: AppTheme.textPrimary,
               fontSize: 16,

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
-import 'package:mostro_mobile/data/models/bond_payout_request.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart' as actions;
 import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
@@ -75,7 +74,6 @@ class TradeDetailScreen extends ConsumerWidget {
                 const SizedBox(height: 16),
                 _buildOrderId(context),
                 const SizedBox(height: 16),
-                _buildBondPayoutBanner(context, ref),
                 // For pending orders created by the user, show creator's reputation
                 if (isPending && isCreator) ...[
                   // TODO: Change this to use `orderPayload` after Order model is updated
@@ -269,91 +267,25 @@ class TradeDetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildBondPayoutBanner(BuildContext context, WidgetRef ref) {
-    final historyAsync = ref.watch(mostroMessageHistoryProvider(orderId));
+  bool _hasPendingBondClaim(WidgetRef ref) {
+    final history = ref.watch(mostroMessageHistoryProvider(orderId));
     final instance = ref.watch(orderRepositoryProvider).mostroInstance;
     final claimWindowDays = instance?.bondPayoutClaimWindowDays ?? 15;
-
-    final request = historyAsync.maybeWhen(
-      data: (msgs) => _latestPendingBondPayoutRequest(msgs, claimWindowDays),
-      orElse: () => null,
-    );
-    if (request == null) return const SizedBox.shrink();
-
-    final s = S.of(context)!;
-    final deadline =
-        bondClaimDeadline(request.slashedAt, claimWindowDays);
-    final formattedDeadline =
-        DateFormat.yMMMd().add_jm().format(deadline);
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: AppTheme.statusPendingBackground.withValues(alpha: 0.3),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: AppTheme.statusPendingText.withValues(alpha: 0.4),
-          ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              s.addBondInvoiceSubmitLine(request.order.amount.toString()),
-              style: const TextStyle(
-                color: AppTheme.textPrimary,
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              s.addBondInvoiceDeadline(formattedDeadline),
-              style: const TextStyle(
-                color: AppTheme.statusPendingText,
-                fontSize: 13,
-              ),
-            ),
-            const SizedBox(height: 12),
-            ElevatedButton(
-              key: const Key('bondPayoutClaimButton'),
-              onPressed: () =>
-                  context.push('/bond_payout/$orderId'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppTheme.activeColor,
-                foregroundColor: Colors.black,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                padding: const EdgeInsets.symmetric(vertical: 12),
-              ),
-              child: Text(
-                s.addBondInvoiceButton,
-                style: const TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
+    return history.maybeWhen(
+      data: (msgs) => hasPendingBondClaim(msgs, claimWindowDays),
+      orElse: () => false,
     );
   }
 
-  BondPayoutRequest? _latestPendingBondPayoutRequest(
-    List<MostroMessage> messages,
-    int claimWindowDays,
-  ) {
-    if (!hasPendingBondClaim(messages, claimWindowDays)) return null;
-    for (final msg in messages) {
-      if (msg.action != actions.Action.addBondInvoice) continue;
-      final payload = msg.payload;
-      if (payload is BondPayoutRequest) return payload;
-    }
-    return null;
+  Widget _buildBondPayoutClaimButton(BuildContext context) {
+    return ElevatedButton(
+      key: const Key('bondPayoutClaimButton'),
+      onPressed: () => context.push('/bond_payout/$orderId'),
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppTheme.mostroGreen,
+      ),
+      child: Text(S.of(context)!.addBondInvoiceButton),
+    );
   }
 
   /// Main action button area, switching on `orderPayload.status`.
@@ -910,6 +842,10 @@ class TradeDetailScreen extends ConsumerWidget {
         tradeState.dispute?.disputeId != null) {
       extraButtons
           .add(_buildViewDisputeButton(context, tradeState.dispute!.disputeId));
+    }
+
+    if (_hasPendingBondClaim(ref)) {
+      extraButtons.add(_buildBondPayoutClaimButton(context));
     }
 
     final allButtons = [

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/data/models/bond_payout_request.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart' as actions;
 import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
@@ -27,6 +28,7 @@ import 'package:mostro_mobile/shared/providers/time_provider.dart';
 import 'package:mostro_mobile/shared/widgets/dynamic_countdown_widget.dart';
 import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
 
 class TradeDetailScreen extends ConsumerWidget {
@@ -73,6 +75,7 @@ class TradeDetailScreen extends ConsumerWidget {
                 const SizedBox(height: 16),
                 _buildOrderId(context),
                 const SizedBox(height: 16),
+                _buildBondPayoutBanner(context, ref),
                 // For pending orders created by the user, show creator's reputation
                 if (isPending && isCreator) ...[
                   // TODO: Change this to use `orderPayload` after Order model is updated
@@ -264,6 +267,93 @@ class TradeDetailScreen extends ConsumerWidget {
     return OrderIdCard(
       orderId: orderId,
     );
+  }
+
+  Widget _buildBondPayoutBanner(BuildContext context, WidgetRef ref) {
+    final historyAsync = ref.watch(mostroMessageHistoryProvider(orderId));
+    final instance = ref.watch(orderRepositoryProvider).mostroInstance;
+    final claimWindowDays = instance?.bondPayoutClaimWindowDays ?? 15;
+
+    final request = historyAsync.maybeWhen(
+      data: (msgs) => _latestPendingBondPayoutRequest(msgs, claimWindowDays),
+      orElse: () => null,
+    );
+    if (request == null) return const SizedBox.shrink();
+
+    final s = S.of(context)!;
+    final deadline =
+        bondClaimDeadline(request.slashedAt, claimWindowDays);
+    final formattedDeadline =
+        DateFormat.yMMMd().add_jm().format(deadline);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: AppTheme.statusPendingBackground.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: AppTheme.statusPendingText.withValues(alpha: 0.4),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              s.addBondInvoiceSubmitLine(request.order.amount.toString()),
+              style: const TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              s.addBondInvoiceDeadline(formattedDeadline),
+              style: const TextStyle(
+                color: AppTheme.statusPendingText,
+                fontSize: 13,
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              key: const Key('bondPayoutClaimButton'),
+              onPressed: () =>
+                  context.push('/bond_payout/$orderId'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.activeColor,
+                foregroundColor: Colors.black,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+              child: Text(
+                s.addBondInvoiceButton,
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  BondPayoutRequest? _latestPendingBondPayoutRequest(
+    List<MostroMessage> messages,
+    int claimWindowDays,
+  ) {
+    if (!hasPendingBondClaim(messages, claimWindowDays)) return null;
+    for (final msg in messages) {
+      if (msg.action != actions.Action.addBondInvoice) continue;
+      final payload = msg.payload;
+      if (payload is BondPayoutRequest) return payload;
+    }
+    return null;
   }
 
   /// Main action button area, switching on `orderPayload.status`.

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -261,9 +261,10 @@ class MostroMessageDetail extends ConsumerWidget {
       data: (msgs) => latestBondPayoutRequest(msgs)?.order.amount,
       orElse: () => null,
     );
-    return S
-        .of(context)!
-        .addBondInvoiceSubmitLine((amount ?? 0).toString());
+    if (amount == null) {
+      return S.of(context)!.addBondInvoiceMessage;
+    }
+    return S.of(context)!.addBondInvoiceSubmitLine(amount.toString());
   }
 
   String _getCantDoMessage(BuildContext context, WidgetRef ref) {

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/enums.dart';
+import 'package:mostro_mobile/data/models/bond_payout_request.dart';
 import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
@@ -247,9 +248,29 @@ class MostroMessageDetail extends ConsumerWidget {
         return S.of(context)!.holdInvoicePaymentCanceled;
       case actions.Action.cantDo:
         return _getCantDoMessage(context, ref);
+      case actions.Action.addBondInvoice:
+        return _getBondPayoutMessage(context, ref);
       default:
         return 'No message found for action ${tradeState.action}'; // This is a fallback message for developers
     }
+  }
+
+  String _getBondPayoutMessage(BuildContext context, WidgetRef ref) {
+    final historyAsync = ref.watch(mostroMessageHistoryProvider(orderId));
+    final amount = historyAsync.maybeWhen(
+      data: (msgs) {
+        for (final msg in msgs) {
+          if (msg.action != actions.Action.addBondInvoice) continue;
+          final payload = msg.payload;
+          if (payload is BondPayoutRequest) return payload.order.amount;
+        }
+        return null;
+      },
+      orElse: () => null,
+    );
+    return S
+        .of(context)!
+        .addBondInvoiceSubmitLine((amount ?? 0).toString());
   }
 
   String _getCantDoMessage(BuildContext context, WidgetRef ref) {

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -9,6 +9,7 @@ import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/shared/providers/legible_handle_provider.dart';
+import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
 import 'package:mostro_mobile/shared/widgets/custom_card.dart';
 import 'package:mostro_mobile/shared/utils/text_formatting.dart';
 
@@ -257,14 +258,7 @@ class MostroMessageDetail extends ConsumerWidget {
   String _getBondPayoutMessage(BuildContext context, WidgetRef ref) {
     final historyAsync = ref.watch(mostroMessageHistoryProvider(orderId));
     final amount = historyAsync.maybeWhen(
-      data: (msgs) {
-        for (final msg in msgs) {
-          if (msg.action != actions.Action.addBondInvoice) continue;
-          final payload = msg.payload;
-          if (payload is BondPayoutRequest) return payload.order.amount;
-        }
-        return null;
-      },
+      data: (msgs) => latestBondPayoutRequest(msgs)?.order.amount,
       orElse: () => null,
     );
     return S

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/enums.dart';
-import 'package:mostro_mobile/data/models/bond_payout_request.dart';
-import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/data/models.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart' as actions;

--- a/lib/features/trades/widgets/trades_list_item.dart
+++ b/lib/features/trades/widgets/trades_list_item.dart
@@ -7,10 +7,14 @@ import 'package:mostro_mobile/data/models/enums/role.dart';
 import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
+import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/shared/providers/time_provider.dart';
 import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
+import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
@@ -27,6 +31,14 @@ class TradesListItem extends ConsumerWidget {
     final role = session?.role;
     final isBuying = role == Role.buyer;
     final orderState = ref.watch(orderNotifierProvider(trade.orderId!));
+    final messageHistory =
+        ref.watch(mostroMessageHistoryProvider(trade.orderId!));
+    final instance = ref.watch(orderRepositoryProvider).mostroInstance;
+    final claimWindowDays = instance?.bondPayoutClaimWindowDays ?? 15;
+    final showBondPayoutBadge = messageHistory.maybeWhen(
+      data: (msgs) => hasPendingBondClaim(msgs, claimWindowDays),
+      orElse: () => false,
+    );
 
     // Determine if the user is the creator of the order based on role and order type
     final isCreator = isBuying
@@ -70,7 +82,11 @@ class TradesListItem extends ConsumerWidget {
                     // Second row: Status and role chips + Premium/Discount
                     Row(
                       children: [
-                        _buildStatusChip(context, orderState.status),
+                        _buildStatusChip(
+                          context,
+                          orderState.status,
+                          showBondPayoutBadge: showBondPayoutBadge,
+                        ),
                         const SizedBox(width: 8),
                         _buildRoleChip(context, isCreator),
                         const Spacer(),
@@ -180,10 +196,36 @@ class TradesListItem extends ConsumerWidget {
     );
   }
 
-  Widget _buildStatusChip(BuildContext context, Status status) {
+  Widget _buildStatusChip(
+    BuildContext context,
+    Status status, {
+    bool showBondPayoutBadge = false,
+  }) {
     Color backgroundColor;
     Color textColor;
     String label;
+
+    if (showBondPayoutBadge) {
+      backgroundColor =
+          AppTheme.statusPendingBackground.withValues(alpha: 0.6);
+      textColor = AppTheme.statusPendingText;
+      label = S.of(context)!.bondPayoutBadge;
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: textColor,
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      );
+    }
 
     switch (status) {
       case Status.active:

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1550,5 +1550,48 @@
     "threeMonths": "3 Monate",
     "sixMonths": "6 Monate",
     "oneYear": "1 Jahr",
-    "never": "Nie"
+    "never": "Nie",
+    "addBondInvoiceTitle": "Anteil einfordern",
+    "addBondInvoiceMessage": "Du hast den Streit gewonnen. Sende eine Lightning-Rechnung, um deinen Anteil der eingezogenen Anti-Missbrauchs-Kaution einzufordern.",
+    "addBondInvoiceWonLine": "Du hast den Streit für Order {order_id} gewonnen.",
+    "@addBondInvoiceWonLine": {
+        "placeholders": {
+            "order_id": {
+                "type": "String",
+                "description": "The order ID"
+            }
+        }
+    },
+    "addBondInvoiceSubmitLine": "Sende eine Lightning-Rechnung über {amount} Sats, um deinen Anteil an der Anti-Missbrauchs-Kaution einzufordern.",
+    "@addBondInvoiceSubmitLine": {
+        "placeholders": {
+            "amount": {
+                "type": "String",
+                "description": "The amount of satoshis"
+            }
+        }
+    },
+    "addBondInvoiceDeadline": "Du musst sie vor dem {date} einfordern.",
+    "@addBondInvoiceDeadline": {
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "description": "The claim deadline"
+            }
+        }
+    },
+    "addBondInvoiceInputLabel": "Lightning-Rechnung",
+    "addBondInvoiceInputHint": "Füge hier deine bolt11-Rechnung ein",
+    "addBondInvoiceButton": "EINFORDERN",
+    "addBondInvoiceSubmitButton": "RECHNUNG SENDEN",
+    "addBondInvoiceFailedToSubmit": "Rechnung konnte nicht gesendet werden: {error}",
+    "@addBondInvoiceFailedToSubmit": {
+        "placeholders": {
+            "error": {
+                "type": "String",
+                "description": "The error message"
+            }
+        }
+    },
+    "bondPayoutBadge": "AUSZAHLUNG OFFEN"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1593,5 +1593,6 @@
             }
         }
     },
-    "bondPayoutBadge": "AUSZAHLUNG OFFEN"
+    "bondPayoutBadge": "AUSZAHLUNG OFFEN",
+    "errorLoadingBondPayout": "Fehler beim Laden der Auszahlungsdaten"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1584,15 +1584,7 @@
     "addBondInvoiceInputHint": "Füge hier deine bolt11-Rechnung ein",
     "addBondInvoiceButton": "EINFORDERN",
     "addBondInvoiceSubmitButton": "RECHNUNG SENDEN",
-    "addBondInvoiceFailedToSubmit": "Rechnung konnte nicht gesendet werden: {error}",
-    "@addBondInvoiceFailedToSubmit": {
-        "placeholders": {
-            "error": {
-                "type": "String",
-                "description": "The error message"
-            }
-        }
-    },
+    "addBondInvoiceFailedToSubmit": "Rechnung konnte nicht gesendet werden. Bitte erneut versuchen.",
     "bondPayoutBadge": "AUSZAHLUNG OFFEN",
     "errorLoadingBondPayout": "Fehler beim Laden der Auszahlungsdaten"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1584,15 +1584,7 @@
     "addBondInvoiceInputHint": "Paste your bolt11 invoice here",
     "addBondInvoiceButton": "CLAIM",
     "addBondInvoiceSubmitButton": "SUBMIT INVOICE",
-    "addBondInvoiceFailedToSubmit": "Failed to submit invoice: {error}",
-    "@addBondInvoiceFailedToSubmit": {
-        "placeholders": {
-            "error": {
-                "type": "String",
-                "description": "The error message"
-            }
-        }
-    },
+    "addBondInvoiceFailedToSubmit": "Failed to submit invoice. Please try again.",
     "bondPayoutBadge": "PAYOUT PENDING",
     "errorLoadingBondPayout": "Error loading payout data"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1550,5 +1550,48 @@
     "threeMonths": "3 months",
     "sixMonths": "6 months",
     "oneYear": "1 year",
-    "never": "Never"
+    "never": "Never",
+    "addBondInvoiceTitle": "Claim your share",
+    "addBondInvoiceMessage": "You won the dispute. Submit a Lightning invoice to claim your share of the slashed anti-abuse bond.",
+    "addBondInvoiceWonLine": "You won the dispute for order {order_id}.",
+    "@addBondInvoiceWonLine": {
+        "placeholders": {
+            "order_id": {
+                "type": "String",
+                "description": "The order ID"
+            }
+        }
+    },
+    "addBondInvoiceSubmitLine": "Submit a Lightning invoice for {amount} sats to claim your share of the anti-abuse bond.",
+    "@addBondInvoiceSubmitLine": {
+        "placeholders": {
+            "amount": {
+                "type": "String",
+                "description": "The amount of satoshis"
+            }
+        }
+    },
+    "addBondInvoiceDeadline": "You must claim it before {date}.",
+    "@addBondInvoiceDeadline": {
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "description": "The claim deadline"
+            }
+        }
+    },
+    "addBondInvoiceInputLabel": "Lightning invoice",
+    "addBondInvoiceInputHint": "Paste your bolt11 invoice here",
+    "addBondInvoiceButton": "CLAIM",
+    "addBondInvoiceSubmitButton": "SUBMIT INVOICE",
+    "addBondInvoiceFailedToSubmit": "Failed to submit invoice: {error}",
+    "@addBondInvoiceFailedToSubmit": {
+        "placeholders": {
+            "error": {
+                "type": "String",
+                "description": "The error message"
+            }
+        }
+    },
+    "bondPayoutBadge": "PAYOUT PENDING"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1593,5 +1593,6 @@
             }
         }
     },
-    "bondPayoutBadge": "PAYOUT PENDING"
+    "bondPayoutBadge": "PAYOUT PENDING",
+    "errorLoadingBondPayout": "Error loading payout data"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1525,5 +1525,48 @@
     "threeMonths": "3 meses",
     "sixMonths": "6 meses",
     "oneYear": "1 año",
-    "never": "Nunca"
+    "never": "Nunca",
+    "addBondInvoiceTitle": "Cobra tu parte",
+    "addBondInvoiceMessage": "Ganaste la disputa. Envía una factura Lightning para cobrar tu parte del depósito anti-abuso confiscado.",
+    "addBondInvoiceWonLine": "Ganaste la disputa por la orden {order_id}.",
+    "@addBondInvoiceWonLine": {
+        "placeholders": {
+            "order_id": {
+                "type": "String",
+                "description": "The order ID"
+            }
+        }
+    },
+    "addBondInvoiceSubmitLine": "Envía una factura Lightning por {amount} sats para cobrar la parte que te corresponde del depósito anti-abuso.",
+    "@addBondInvoiceSubmitLine": {
+        "placeholders": {
+            "amount": {
+                "type": "String",
+                "description": "The amount of satoshis"
+            }
+        }
+    },
+    "addBondInvoiceDeadline": "Debes reclamarlo antes del {date}.",
+    "@addBondInvoiceDeadline": {
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "description": "The claim deadline"
+            }
+        }
+    },
+    "addBondInvoiceInputLabel": "Factura Lightning",
+    "addBondInvoiceInputHint": "Pega aquí tu factura bolt11",
+    "addBondInvoiceButton": "COBRAR",
+    "addBondInvoiceSubmitButton": "ENVIAR FACTURA",
+    "addBondInvoiceFailedToSubmit": "Error al enviar la factura: {error}",
+    "@addBondInvoiceFailedToSubmit": {
+        "placeholders": {
+            "error": {
+                "type": "String",
+                "description": "The error message"
+            }
+        }
+    },
+    "bondPayoutBadge": "COBRO PENDIENTE"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1559,15 +1559,7 @@
     "addBondInvoiceInputHint": "Pega aquí tu factura bolt11",
     "addBondInvoiceButton": "COBRAR",
     "addBondInvoiceSubmitButton": "ENVIAR FACTURA",
-    "addBondInvoiceFailedToSubmit": "Error al enviar la factura: {error}",
-    "@addBondInvoiceFailedToSubmit": {
-        "placeholders": {
-            "error": {
-                "type": "String",
-                "description": "The error message"
-            }
-        }
-    },
+    "addBondInvoiceFailedToSubmit": "Error al enviar la factura. Intenta de nuevo.",
     "bondPayoutBadge": "COBRO PENDIENTE",
     "errorLoadingBondPayout": "Error al cargar los datos del cobro"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1568,5 +1568,6 @@
             }
         }
     },
-    "bondPayoutBadge": "COBRO PENDIENTE"
+    "bondPayoutBadge": "COBRO PENDIENTE",
+    "errorLoadingBondPayout": "Error al cargar los datos del cobro"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1593,5 +1593,6 @@
             }
         }
     },
-    "bondPayoutBadge": "PAIEMENT EN ATTENTE"
+    "bondPayoutBadge": "PAIEMENT EN ATTENTE",
+    "errorLoadingBondPayout": "Erreur lors du chargement des données de paiement"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1584,15 +1584,7 @@
     "addBondInvoiceInputHint": "Collez votre facture bolt11 ici",
     "addBondInvoiceButton": "RÉCLAMER",
     "addBondInvoiceSubmitButton": "ENVOYER LA FACTURE",
-    "addBondInvoiceFailedToSubmit": "Échec de l'envoi de la facture : {error}",
-    "@addBondInvoiceFailedToSubmit": {
-        "placeholders": {
-            "error": {
-                "type": "String",
-                "description": "The error message"
-            }
-        }
-    },
+    "addBondInvoiceFailedToSubmit": "Échec de l'envoi de la facture. Veuillez réessayer.",
     "bondPayoutBadge": "PAIEMENT EN ATTENTE",
     "errorLoadingBondPayout": "Erreur lors du chargement des données de paiement"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1550,5 +1550,48 @@
     "threeMonths": "3 mois",
     "sixMonths": "6 mois",
     "oneYear": "1 an",
-    "never": "Jamais"
+    "never": "Jamais",
+    "addBondInvoiceTitle": "Réclamer votre part",
+    "addBondInvoiceMessage": "Vous avez gagné le litige. Envoyez une facture Lightning pour réclamer votre part du dépôt anti-abus confisqué.",
+    "addBondInvoiceWonLine": "Vous avez gagné le litige pour la commande {order_id}.",
+    "@addBondInvoiceWonLine": {
+        "placeholders": {
+            "order_id": {
+                "type": "String",
+                "description": "The order ID"
+            }
+        }
+    },
+    "addBondInvoiceSubmitLine": "Envoyez une facture Lightning de {amount} sats pour réclamer votre part du dépôt anti-abus.",
+    "@addBondInvoiceSubmitLine": {
+        "placeholders": {
+            "amount": {
+                "type": "String",
+                "description": "The amount of satoshis"
+            }
+        }
+    },
+    "addBondInvoiceDeadline": "Vous devez la réclamer avant le {date}.",
+    "@addBondInvoiceDeadline": {
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "description": "The claim deadline"
+            }
+        }
+    },
+    "addBondInvoiceInputLabel": "Facture Lightning",
+    "addBondInvoiceInputHint": "Collez votre facture bolt11 ici",
+    "addBondInvoiceButton": "RÉCLAMER",
+    "addBondInvoiceSubmitButton": "ENVOYER LA FACTURE",
+    "addBondInvoiceFailedToSubmit": "Échec de l'envoi de la facture : {error}",
+    "@addBondInvoiceFailedToSubmit": {
+        "placeholders": {
+            "error": {
+                "type": "String",
+                "description": "The error message"
+            }
+        }
+    },
+    "bondPayoutBadge": "PAIEMENT EN ATTENTE"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1634,5 +1634,6 @@
             }
         }
     },
-    "bondPayoutBadge": "RISCATTO IN ATTESA"
+    "bondPayoutBadge": "RISCATTO IN ATTESA",
+    "errorLoadingBondPayout": "Errore nel caricamento dei dati del riscatto"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1625,15 +1625,7 @@
     "addBondInvoiceInputHint": "Incolla qui la tua fattura bolt11",
     "addBondInvoiceButton": "RISCATTA",
     "addBondInvoiceSubmitButton": "INVIA FATTURA",
-    "addBondInvoiceFailedToSubmit": "Errore nell'invio della fattura: {error}",
-    "@addBondInvoiceFailedToSubmit": {
-        "placeholders": {
-            "error": {
-                "type": "String",
-                "description": "The error message"
-            }
-        }
-    },
+    "addBondInvoiceFailedToSubmit": "Errore nell'invio della fattura. Riprova.",
     "bondPayoutBadge": "RISCATTO IN ATTESA",
     "errorLoadingBondPayout": "Errore nel caricamento dei dati del riscatto"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1591,5 +1591,48 @@
     "threeMonths": "3 mesi",
     "sixMonths": "6 mesi",
     "oneYear": "1 anno",
-    "never": "Mai"
+    "never": "Mai",
+    "addBondInvoiceTitle": "Riscatta la tua parte",
+    "addBondInvoiceMessage": "Hai vinto la disputa. Invia una fattura Lightning per riscattare la tua parte del deposito anti-abuso confiscato.",
+    "addBondInvoiceWonLine": "Hai vinto la disputa per l'ordine {order_id}.",
+    "@addBondInvoiceWonLine": {
+        "placeholders": {
+            "order_id": {
+                "type": "String",
+                "description": "The order ID"
+            }
+        }
+    },
+    "addBondInvoiceSubmitLine": "Invia una fattura Lightning di {amount} sat per riscattare la parte del deposito anti-abuso che ti spetta.",
+    "@addBondInvoiceSubmitLine": {
+        "placeholders": {
+            "amount": {
+                "type": "String",
+                "description": "The amount of satoshis"
+            }
+        }
+    },
+    "addBondInvoiceDeadline": "Devi riscattarla entro il {date}.",
+    "@addBondInvoiceDeadline": {
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "description": "The claim deadline"
+            }
+        }
+    },
+    "addBondInvoiceInputLabel": "Fattura Lightning",
+    "addBondInvoiceInputHint": "Incolla qui la tua fattura bolt11",
+    "addBondInvoiceButton": "RISCATTA",
+    "addBondInvoiceSubmitButton": "INVIA FATTURA",
+    "addBondInvoiceFailedToSubmit": "Errore nell'invio della fattura: {error}",
+    "@addBondInvoiceFailedToSubmit": {
+        "placeholders": {
+            "error": {
+                "type": "String",
+                "description": "The error message"
+            }
+        }
+    },
+    "bondPayoutBadge": "RISCATTO IN ATTESA"
 }

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -236,6 +236,17 @@ class MostroService {
     );
   }
 
+  Future<void> sendBondPayoutInvoice(String orderId, String invoice) async {
+    final payload = PaymentRequest(order: null, lnInvoice: invoice);
+    await publishOrder(
+      MostroMessage(
+        action: Action.addBondInvoice,
+        id: orderId,
+        payload: payload,
+      ),
+    );
+  }
+
   Future<void> cancelOrder(String orderId) async {
     await publishOrder(MostroMessage(action: Action.cancel, id: orderId));
   }

--- a/lib/shared/utils/bond_payout_helpers.dart
+++ b/lib/shared/utils/bond_payout_helpers.dart
@@ -1,3 +1,8 @@
+import 'package:mostro_mobile/data/models/bond_payout_request.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/payment_request.dart';
+
 DateTime bondClaimDeadline(int slashedAt, int claimWindowDays) {
   return DateTime.fromMillisecondsSinceEpoch(
     (slashedAt + claimWindowDays * 86400) * 1000,
@@ -7,4 +12,22 @@ DateTime bondClaimDeadline(int slashedAt, int claimWindowDays) {
 
 bool isBondClaimExpired(int slashedAt, int claimWindowDays) {
   return DateTime.now().isAfter(bondClaimDeadline(slashedAt, claimWindowDays));
+}
+
+/// True when the latest stored `add-bond-invoice` for the order is an
+/// inbound `BondPayoutRequest` whose claim window has not expired and to
+/// which the user has not yet replied with a `PaymentRequest`.
+bool hasPendingBondClaim(
+  List<MostroMessage> messages,
+  int claimWindowDays,
+) {
+  for (final msg in messages) {
+    if (msg.action != Action.addBondInvoice) continue;
+    final payload = msg.payload;
+    if (payload is BondPayoutRequest) {
+      return !isBondClaimExpired(payload.slashedAt, claimWindowDays);
+    }
+    if (payload is PaymentRequest) return false;
+  }
+  return false;
 }

--- a/lib/shared/utils/bond_payout_helpers.dart
+++ b/lib/shared/utils/bond_payout_helpers.dart
@@ -1,7 +1,5 @@
-import 'package:mostro_mobile/data/models/bond_payout_request.dart';
-import 'package:mostro_mobile/data/models/enums/action.dart';
-import 'package:mostro_mobile/data/models/mostro_message.dart';
-import 'package:mostro_mobile/data/models/payment_request.dart';
+import 'package:mostro_mobile/data/enums.dart';
+import 'package:mostro_mobile/data/models.dart';
 
 DateTime bondClaimDeadline(int slashedAt, int claimWindowDays) {
   return DateTime.fromMillisecondsSinceEpoch(

--- a/lib/shared/utils/bond_payout_helpers.dart
+++ b/lib/shared/utils/bond_payout_helpers.dart
@@ -1,0 +1,10 @@
+DateTime bondClaimDeadline(int slashedAt, int claimWindowDays) {
+  return DateTime.fromMillisecondsSinceEpoch(
+    (slashedAt + claimWindowDays * 86400) * 1000,
+    isUtc: true,
+  ).toLocal();
+}
+
+bool isBondClaimExpired(int slashedAt, int claimWindowDays) {
+  return DateTime.now().isAfter(bondClaimDeadline(slashedAt, claimWindowDays));
+}

--- a/lib/shared/utils/bond_payout_helpers.dart
+++ b/lib/shared/utils/bond_payout_helpers.dart
@@ -14,6 +14,22 @@ bool isBondClaimExpired(int slashedAt, int claimWindowDays) {
   return DateTime.now().isAfter(bondClaimDeadline(slashedAt, claimWindowDays));
 }
 
+/// Latest inbound `BondPayoutRequest` for the order, picked by timestamp
+/// regardless of input ordering. `null` when the most recent
+/// `add-bond-invoice` is an outbound `PaymentRequest` reply or absent.
+BondPayoutRequest? latestBondPayoutRequest(List<MostroMessage> messages) {
+  final sorted = [...messages]..sort(
+      (a, b) => (b.timestamp ?? 0).compareTo(a.timestamp ?? 0),
+    );
+  for (final msg in sorted) {
+    if (msg.action != Action.addBondInvoice) continue;
+    final payload = msg.payload;
+    if (payload is BondPayoutRequest) return payload;
+    if (payload is PaymentRequest) return null;
+  }
+  return null;
+}
+
 /// True when the latest stored `add-bond-invoice` for the order is an
 /// inbound `BondPayoutRequest` whose claim window has not expired and to
 /// which the user has not yet replied with a `PaymentRequest`.
@@ -21,16 +37,7 @@ bool hasPendingBondClaim(
   List<MostroMessage> messages,
   int claimWindowDays,
 ) {
-  final sorted = [...messages]..sort(
-      (a, b) => (b.timestamp ?? 0).compareTo(a.timestamp ?? 0),
-    );
-  for (final msg in sorted) {
-    if (msg.action != Action.addBondInvoice) continue;
-    final payload = msg.payload;
-    if (payload is BondPayoutRequest) {
-      return !isBondClaimExpired(payload.slashedAt, claimWindowDays);
-    }
-    if (payload is PaymentRequest) return false;
-  }
-  return false;
+  final request = latestBondPayoutRequest(messages);
+  if (request == null) return false;
+  return !isBondClaimExpired(request.slashedAt, claimWindowDays);
 }

--- a/lib/shared/utils/bond_payout_helpers.dart
+++ b/lib/shared/utils/bond_payout_helpers.dart
@@ -21,7 +21,10 @@ bool hasPendingBondClaim(
   List<MostroMessage> messages,
   int claimWindowDays,
 ) {
-  for (final msg in messages) {
+  final sorted = [...messages]..sort(
+      (a, b) => (b.timestamp ?? 0).compareTo(a.timestamp ?? 0),
+    );
+  for (final msg in sorted) {
     if (msg.action != Action.addBondInvoice) continue;
     final payload = msg.payload;
     if (payload is BondPayoutRequest) {

--- a/test/shared/utils/bond_payout_helpers_test.dart
+++ b/test/shared/utils/bond_payout_helpers_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/bond_payout_request.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/payment_request.dart';
+import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
+
+const _claimWindowDays = 15;
+
+BondPayoutRequest _request({int slashedAt = 1700000000}) {
+  return BondPayoutRequest(
+    order: const BondPayoutOrder(
+      id: 'order-1',
+      kind: OrderType.buy,
+      amount: 0,
+      fiatCode: 'USD',
+      fiatAmount: 100,
+      paymentMethod: 'wire',
+    ),
+    slashedAt: slashedAt,
+  );
+}
+
+MostroMessage<BondPayoutRequest> _addBondInvoiceMsg({
+  required int timestamp,
+  int slashedAt = 1700000000,
+}) {
+  return MostroMessage<BondPayoutRequest>(
+    action: Action.addBondInvoice,
+    id: 'order-1',
+    payload: _request(slashedAt: slashedAt),
+    timestamp: timestamp,
+  );
+}
+
+MostroMessage<PaymentRequest> _paymentReplyMsg({required int timestamp}) {
+  return MostroMessage<PaymentRequest>(
+    action: Action.addBondInvoice,
+    id: 'order-1',
+    payload: PaymentRequest(lnInvoice: 'lnbc1...'),
+    timestamp: timestamp,
+  );
+}
+
+void main() {
+  group('latestBondPayoutRequest', () {
+    test('returns null on empty message list', () {
+      expect(latestBondPayoutRequest([]), isNull);
+    });
+
+    test('returns null when latest add-bond-invoice is a PaymentRequest reply',
+        () {
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100),
+        _paymentReplyMsg(timestamp: 200),
+      ];
+      expect(latestBondPayoutRequest(messages), isNull);
+    });
+
+    test('picks the most recent BondPayoutRequest regardless of input order',
+        () {
+      final older = _addBondInvoiceMsg(timestamp: 100, slashedAt: 1);
+      final newer = _addBondInvoiceMsg(timestamp: 500, slashedAt: 2);
+      final result = latestBondPayoutRequest([newer, older]);
+      expect(result, isNotNull);
+      expect(result!.slashedAt, 2);
+
+      final resultReversed = latestBondPayoutRequest([older, newer]);
+      expect(resultReversed!.slashedAt, 2);
+    });
+
+    test('ignores messages whose action is not addBondInvoice', () {
+      final unrelated = MostroMessage(
+        action: Action.fiatSent,
+        id: 'order-1',
+        timestamp: 999,
+      );
+      final claim = _addBondInvoiceMsg(timestamp: 100);
+      final result = latestBondPayoutRequest([unrelated, claim]);
+      expect(result, isNotNull);
+      expect(result!.slashedAt, 1700000000);
+    });
+
+    test('treats null timestamps as zero without throwing', () {
+      final nullTs = MostroMessage<BondPayoutRequest>(
+        action: Action.addBondInvoice,
+        id: 'order-1',
+        payload: _request(slashedAt: 7),
+      );
+      final newer = _addBondInvoiceMsg(timestamp: 10, slashedAt: 8);
+      final result = latestBondPayoutRequest([nullTs, newer]);
+      expect(result!.slashedAt, 8);
+    });
+  });
+
+  group('hasPendingBondClaim', () {
+    test('false when no add-bond-invoice is present', () {
+      expect(hasPendingBondClaim([], _claimWindowDays), isFalse);
+    });
+
+    test('false once the claim window has expired', () {
+      final slashedAtSecs =
+          DateTime.now().subtract(const Duration(days: 30)).millisecondsSinceEpoch ~/
+              1000;
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100, slashedAt: slashedAtSecs),
+      ];
+      expect(hasPendingBondClaim(messages, _claimWindowDays), isFalse);
+    });
+
+    test('true while a BondPayoutRequest is within the claim window', () {
+      final slashedAtSecs = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100, slashedAt: slashedAtSecs),
+      ];
+      expect(hasPendingBondClaim(messages, _claimWindowDays), isTrue);
+    });
+
+    test('false after the user replied with a PaymentRequest', () {
+      final slashedAtSecs = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100, slashedAt: slashedAtSecs),
+        _paymentReplyMsg(timestamp: 200),
+      ];
+      expect(hasPendingBondClaim(messages, _claimWindowDays), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Implements the mobile side of Phase 3 of the anti-abuse bond spec: the winning counterparty receives `Action::AddBondInvoice` with a `BondPayoutRequest` payload and can reply with a bolt11 to claim their share before the forfeit deadline.
  - Recognize `Action::AddBondInvoice` and the `BondPayoutRequest` payload (with its embedded SmallOrder).
  - Expose `bondPayoutClaimWindowDays` from the kind-38385 info event.
  - New `/bond_payout/:orderId` screen auto-opened on message receipt within the claim window.
  - Publish the reply as `Action::AddBondInvoice` carrying a `PaymentRequest`.
  - "PAYOUT PENDING" badge in My Trades and a "CLAIM" button in Trade Details next to Close while the claim is pending.

Out of scope (follow-up PR): push notifications, badge in the notifications list, anti-spam dedup of daemon retries, session lifecycle extensions for long disputes.
  
  How to test:
  1. Run a local Mostro daemon with `[anti_abuse_bond] enabled = true`, `apply_to = "take"`, `slash_node_share_pct = 0.5`, `payout_claim_window_days = 1`.
  2. From two app instances, create a sell order on instance A and take it from instance B. Pay the taker bond on B and go through the trade until both parties are in `WaitingPayment` / `WaitingBuyerInvoice`.
  3. Open a dispute from B and have the solver resolve it with `admin-cancel` and `BondResolution { slash_buyer: true }` (or `slash_seller` on a buy order — depends on roles).
  4. Within the claim window, the winning side's app should auto-open the bond payout screen. Submit a bolt11 invoice for the exact counterparty share shown by the daemon log.
  5. Verify the daemon's `send_payment` routes successfully and the bond row transitions to `Slashed`.
  6. Close the screen before submitting and verify the "COBRO PENDIENTE" badge appears in My Trades and the "COBRAR" button appears in Order Details. Tap it to return to the screen.
  7. Let the claim window expire without submitting and verify the screen no longer auto-opens, the badge disappears and the banner button is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bond payout claim flow: new screen/route to submit Lightning invoices, deadline/expiry checks, submit-with-feedback, and post-submit navigation; claim window is configurable (15-day default).
  * Trade UI: “Claim” action and payout-pending badge; notifications route to related order/detail.
  * Client: send bond payout invoices and persist outbound messages.

* **Localization**
  * Added English, German, Spanish, French, and Italian strings for the claim flow, badge, and error messages.

* **Tests**
  * Added unit tests for bond-payout helper logic (selection and expiry).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->