### PR TITLE
Revert version/changelog bump for v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.2.6] - 2026-05-21
-
-### Added
-- feat: P2P chat push wake-up + register mostro_pubkey whitelist field (#590) (a79ff882)
-- feat(restore): differentiate restore outcomes by cant-do reason (#588) (cc6fe3a6)
-
-### Changed
-- flatten pay-invoice and add-invoice screens (#593) (48d4bb5d)
--   feat(bond): support Phase 1.5 anti-abuse bond invoice flow (#592) (35a544ae)
-- Restore dispute chats (#561) (b8bbee92)
-
-
 ## [v1.2.5] - 2026-04-23
 
 ### Added

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.6+993
+version: 1.2.5+987
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
Reverts the version and changelog bump introduced by #597 as part of fully rolling back the v1.2.6 release.

Context:
- The GitHub Release `v1.2.6` and its tag (local + remote) have been deleted.
- This restores `pubspec.yaml` to `1.2.5+987` and removes the v1.2.6 entry from `CHANGELOG.md`.

After merging, `main` will be back at the v1.2.5 state, ready to cut a fresh release when appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Version downgraded from 1.2.6 to 1.2.5 with corresponding changelog removal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->