### PR TITLE
feat: add Venezuela community node

### DIFF
--- a/lib/core/config/communities.dart
+++ b/lib/core/config/communities.dart
@@ -64,6 +64,12 @@ const List<CommunityConfig> trustedCommunities = [
     ],
   ),
   CommunityConfig(
+    pubkey:
+        '000009ee1e4b1dc7add19ab30e4ef854d7b562e208b62686fd9002b50b24dabb',
+    region: '\u{1F1FB}\u{1F1EA} Venezuela',
+    social: [SocialLink(type: 'telegram', url: 'https://t.me/MostroVzla')],
+  ),
+  CommunityConfig(
     pubkey: defaultMostroPubkey,
     region: '\u{1F310} Default',
     social: [],


### PR DESCRIPTION
## Summary
- Add Venezuela (🇻🇪) Mostro community node to the trusted communities list in `lib/core/config/communities.dart`.
- Inserted before the `Default` node to keep it last.

## Details
- Pubkey provided as `npub1qqqqnms7fvwu0tw3n2esunhc2ntm2chzpzmzdphajqpt2zeym2asr7ata2`, decoded to hex (`000009ee1e4b1dc7add19ab30e4ef854d7b562e208b62686fd9002b50b24dabb`) to match the format used by the other entries.
- Telegram social link: https://t.me/MostroVzla

## Test plan
- `flutter analyze lib/core/config/communities.dart` → No issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Venezuela as a supported community with regional identification and integrated Telegram social link for community access and communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->