### PR TITLE
feat: parse anti-abuse bond tags from kind-38385 info event

### DIFF
--- a/lib/features/mostro/mostro_instance.dart
+++ b/lib/features/mostro/mostro_instance.dart
@@ -1,5 +1,20 @@
 import 'package:dart_nostr/nostr/model/event/event.dart';
 
+/// Anti-abuse bond policy advertised by a Mostro daemon via the kind-38385
+/// info event.
+///
+/// Three states must be distinguished:
+/// - [unsupported]: the daemon does not emit the `bond_enabled` tag at all
+///   (legacy daemon that predates the anti-abuse bond feature).
+/// - [disabled]: the daemon emits `bond_enabled="false"`; the operator has
+///   not enabled the feature.
+/// - [enabled]: the daemon emits `bond_enabled="true"`; the bond is active
+///   and the remaining six bond tags are present.
+enum BondPolicy { unsupported, disabled, enabled }
+
+/// Which side of a trade a bond applies to.
+enum BondApplyTo { take, make, both }
+
 class MostroInstance {
   final String pubKey;
   final String mostroVersion;
@@ -22,7 +37,19 @@ class MostroInstance {
   final String lndNodeUri;
   final String fiatCurrenciesAccepted;
   final int maxOrdersPerResponse;
-  final int bondPayoutClaimWindowDays;
+
+  /// Bond policy state. See [BondPolicy] for the three-state semantics.
+  final BondPolicy bondPolicy;
+
+  /// The following six fields carry the bond parameters and are only
+  /// meaningful when [bondPolicy] is [BondPolicy.enabled]. They are null
+  /// otherwise.
+  final BondApplyTo? bondApplyTo;
+  final bool? bondSlashOnWaitingTimeout;
+  final double? bondAmountPct;
+  final int? bondBaseAmountSats;
+  final double? bondSlashNodeSharePct;
+  final int? bondPayoutClaimWindowDays;
 
   MostroInstance(
     this.pubKey,
@@ -45,9 +72,15 @@ class MostroInstance {
     this.supportedNetworks,
     this.lndNodeUri,
     this.fiatCurrenciesAccepted,
-    this.maxOrdersPerResponse,
+    this.maxOrdersPerResponse, {
+    this.bondPolicy = BondPolicy.unsupported,
+    this.bondApplyTo,
+    this.bondSlashOnWaitingTimeout,
+    this.bondAmountPct,
+    this.bondBaseAmountSats,
+    this.bondSlashNodeSharePct,
     this.bondPayoutClaimWindowDays,
-  );
+  });
 
   factory MostroInstance.fromEvent(NostrEvent event) {
     return MostroInstance(
@@ -72,25 +105,29 @@ class MostroInstance {
       event.lndNodeUri,
       event.fiatCurrenciesAccepted,
       event.maxOrdersPerResponse,
-      event.bondPayoutClaimWindowDays,
+      bondPolicy: event.bondPolicy,
+      bondApplyTo: event.bondApplyTo,
+      bondSlashOnWaitingTimeout: event.bondSlashOnWaitingTimeout,
+      bondAmountPct: event.bondAmountPct,
+      bondBaseAmountSats: event.bondBaseAmountSats,
+      bondSlashNodeSharePct: event.bondSlashNodeSharePct,
+      bondPayoutClaimWindowDays: event.bondPayoutClaimWindowDays,
     );
   }
 }
 
 extension MostroInstanceExtensions on NostrEvent {
   String _getTagValue(String key) {
-    final tag = tags?.firstWhere(
-      (t) => t.isNotEmpty && t[0] == key,
-      orElse: () => const [],
-    );
+    final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
     return (tag != null && tag.length > 1) ? tag[1] : 'Tag: $key not found';
   }
 
+  /// Returns the tag value, or null when the tag is missing or empty.
+  ///
+  /// Use this for optional tags where absence is semantically meaningful
+  /// (e.g. anti-abuse bond tags, which only appear on modern daemons).
   String? _getOptionalTagValue(String key) {
-    final tag = tags?.firstWhere(
-      (t) => t.isNotEmpty && t[0] == key,
-      orElse: () => const [],
-    );
+    final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
     if (tag == null || tag.length < 2) return null;
     return tag[1];
   }
@@ -118,14 +155,59 @@ extension MostroInstanceExtensions on NostrEvent {
   String get supportedNetworks => _getTagValue('lnd_networks');
   String get lndNodeUri => _getTagValue('lnd_uris');
   String get fiatCurrenciesAccepted => _getTagValue('fiat_currencies_accepted');
-  int get maxOrdersPerResponse => int.parse(_getTagValue('max_orders_per_response'));
+  int get maxOrdersPerResponse =>
+      int.parse(_getTagValue('max_orders_per_response'));
 
-  /// Days from `slashed_at` to claim a slashed-bond share before forfeit.
-  int get bondPayoutClaimWindowDays {
+  /// Parses the anti-abuse bond policy from the `bond_enabled` tag.
+  ///
+  /// - Tag absent → [BondPolicy.unsupported] (legacy daemon).
+  /// - `"true"` → [BondPolicy.enabled].
+  /// - Any other value → [BondPolicy.disabled].
+  BondPolicy get bondPolicy {
+    final raw = _getOptionalTagValue('bond_enabled');
+    if (raw == null) return BondPolicy.unsupported;
+    return raw.toLowerCase() == 'true'
+        ? BondPolicy.enabled
+        : BondPolicy.disabled;
+  }
+
+  BondApplyTo? get bondApplyTo {
+    final raw = _getOptionalTagValue('bond_apply_to');
+    switch (raw) {
+      case 'take':
+        return BondApplyTo.take;
+      case 'make':
+        return BondApplyTo.make;
+      case 'both':
+        return BondApplyTo.both;
+      default:
+        return null;
+    }
+  }
+
+  bool? get bondSlashOnWaitingTimeout {
+    final raw = _getOptionalTagValue('bond_slash_on_waiting_timeout');
+    if (raw == null) return null;
+    return raw.toLowerCase() == 'true';
+  }
+
+  double? get bondAmountPct {
+    final raw = _getOptionalTagValue('bond_amount_pct');
+    return raw == null ? null : double.tryParse(raw);
+  }
+
+  int? get bondBaseAmountSats {
+    final raw = _getOptionalTagValue('bond_base_amount_sats');
+    return raw == null ? null : int.tryParse(raw);
+  }
+
+  double? get bondSlashNodeSharePct {
+    final raw = _getOptionalTagValue('bond_slash_node_share_pct');
+    return raw == null ? null : double.tryParse(raw);
+  }
+
+  int? get bondPayoutClaimWindowDays {
     final raw = _getOptionalTagValue('bond_payout_claim_window_days');
-    if (raw == null) return 15;
-    final parsed = int.tryParse(raw);
-    if (parsed == null || parsed <= 0) return 15;
-    return parsed;
+    return raw == null ? null : int.tryParse(raw);
   }
 }

--- a/lib/features/mostro/mostro_instance.dart
+++ b/lib/features/mostro/mostro_instance.dart
@@ -126,10 +126,19 @@ extension MostroInstanceExtensions on NostrEvent {
   ///
   /// Use this for optional tags where absence is semantically meaningful
   /// (e.g. anti-abuse bond tags, which only appear on modern daemons).
+  ///
+  /// Empty or whitespace-only values are treated as missing so they cannot
+  /// be misparsed as legitimate data downstream (e.g. an empty
+  /// `bond_enabled=""` would otherwise be classified as `disabled` instead
+  /// of `unsupported`, breaking the three-state semantics).
   String? _getOptionalTagValue(String key) {
-    final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
+    final tag = tags?.firstWhere(
+      (t) => t.isNotEmpty && t[0] == key,
+      orElse: () => const <String>[],
+    );
     if (tag == null || tag.length < 2) return null;
-    return tag[1];
+    final value = tag[1].trim();
+    return value.isEmpty ? null : value;
   }
 
   String get pubKey => _getTagValue('d');
@@ -185,29 +194,49 @@ extension MostroInstanceExtensions on NostrEvent {
     }
   }
 
+  /// Parses `bond_slash_on_waiting_timeout`. Returns `null` for any value
+  /// other than `"true"` or `"false"` (case-insensitive) so malformed data
+  /// is not silently collapsed into a valid policy state.
   bool? get bondSlashOnWaitingTimeout {
-    final raw = _getOptionalTagValue('bond_slash_on_waiting_timeout');
-    if (raw == null) return null;
-    return raw.toLowerCase() == 'true';
+    final raw = _getOptionalTagValue('bond_slash_on_waiting_timeout')
+        ?.toLowerCase();
+    if (raw == 'true') return true;
+    if (raw == 'false') return false;
+    return null;
   }
 
+  /// Bond fraction of the order amount. Must be a percentage in `[0.0, 1.0]`;
+  /// out-of-range values are treated as invalid and yield `null`.
   double? get bondAmountPct {
     final raw = _getOptionalTagValue('bond_amount_pct');
-    return raw == null ? null : double.tryParse(raw);
+    final value = raw == null ? null : double.tryParse(raw);
+    if (value == null) return null;
+    return (value >= 0.0 && value <= 1.0) ? value : null;
   }
 
+  /// Minimum bond floor in sats. Negative values are treated as invalid.
   int? get bondBaseAmountSats {
     final raw = _getOptionalTagValue('bond_base_amount_sats');
-    return raw == null ? null : int.tryParse(raw);
+    final value = raw == null ? null : int.tryParse(raw);
+    if (value == null) return null;
+    return value >= 0 ? value : null;
   }
 
+  /// Node share of a slashed bond. Spec constrains this to `[0.0, 1.0]`;
+  /// out-of-range values are treated as invalid and yield `null`.
   double? get bondSlashNodeSharePct {
     final raw = _getOptionalTagValue('bond_slash_node_share_pct');
-    return raw == null ? null : double.tryParse(raw);
+    final value = raw == null ? null : double.tryParse(raw);
+    if (value == null) return null;
+    return (value >= 0.0 && value <= 1.0) ? value : null;
   }
 
+  /// Payout claim window in days. Must be positive; non-positive or
+  /// unparseable values yield `null`.
   int? get bondPayoutClaimWindowDays {
     final raw = _getOptionalTagValue('bond_payout_claim_window_days');
-    return raw == null ? null : int.tryParse(raw);
+    final value = raw == null ? null : int.tryParse(raw);
+    if (value == null) return null;
+    return value > 0 ? value : null;
   }
 }

--- a/lib/features/mostro/mostro_instance.dart
+++ b/lib/features/mostro/mostro_instance.dart
@@ -118,7 +118,10 @@ class MostroInstance {
 
 extension MostroInstanceExtensions on NostrEvent {
   String _getTagValue(String key) {
-    final tag = tags?.firstWhere((t) => t[0] == key, orElse: () => []);
+    final tag = tags?.firstWhere(
+      (t) => t.isNotEmpty && t[0] == key,
+      orElse: () => const <String>[],
+    );
     return (tag != null && tag.length > 1) ? tag[1] : 'Tag: $key not found';
   }
 
@@ -171,13 +174,19 @@ extension MostroInstanceExtensions on NostrEvent {
   ///
   /// - Tag absent → [BondPolicy.unsupported] (legacy daemon).
   /// - `"true"` → [BondPolicy.enabled].
-  /// - Any other value → [BondPolicy.disabled].
+  /// - `"false"` → [BondPolicy.disabled].
+  /// - Any other value → [BondPolicy.unsupported] (defensive: malformed
+  ///   payloads must not masquerade as an intentional policy state).
   BondPolicy get bondPolicy {
-    final raw = _getOptionalTagValue('bond_enabled');
-    if (raw == null) return BondPolicy.unsupported;
-    return raw.toLowerCase() == 'true'
-        ? BondPolicy.enabled
-        : BondPolicy.disabled;
+    final raw = _getOptionalTagValue('bond_enabled')?.toLowerCase();
+    switch (raw) {
+      case 'true':
+        return BondPolicy.enabled;
+      case 'false':
+        return BondPolicy.disabled;
+      default:
+        return BondPolicy.unsupported;
+    }
   }
 
   BondApplyTo? get bondApplyTo {

--- a/test/features/mostro/mostro_instance_test.dart
+++ b/test/features/mostro/mostro_instance_test.dart
@@ -146,5 +146,113 @@ void main() {
       expect(instance.fee, 0.006);
       expect(instance.expirationSeconds, 900);
     });
+
+    test('bondSlashOnWaitingTimeout parses true and false case-insensitively', () {
+      for (final entry in {
+        'true': true,
+        'TRUE': true,
+        'false': false,
+        'FALSE': false,
+      }.entries) {
+        final event = buildEvent([
+          const ['bond_enabled', 'true'],
+          ['bond_slash_on_waiting_timeout', entry.key],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondSlashOnWaitingTimeout, entry.value,
+            reason: entry.key);
+      }
+    });
+
+    test('bondSlashOnWaitingTimeout returns null for malformed values', () {
+      for (final raw in ['foo', 'yes', 'no', '1', '0', '']) {
+        final event = buildEvent([
+          const ['bond_enabled', 'true'],
+          ['bond_slash_on_waiting_timeout', raw],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondSlashOnWaitingTimeout, isNull, reason: '"$raw"');
+      }
+    });
+
+    test('empty tag value is treated as missing (preserves three-state semantics)', () {
+      // bond_enabled with an empty value must not collapse to disabled —
+      // it has to behave as if the tag were absent (unsupported).
+      final event = buildEvent(const [
+        ['bond_enabled', ''],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+    });
+
+    test('whitespace-only tag value is treated as missing', () {
+      final event = buildEvent(const [
+        ['bond_enabled', '   '],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+    });
+
+    test('bondSlashNodeSharePct out of [0.0, 1.0] range → null', () {
+      for (final raw in ['-0.1', '1.5', '2', '-1']) {
+        final event = buildEvent([
+          const ['bond_enabled', 'true'],
+          ['bond_slash_node_share_pct', raw],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondSlashNodeSharePct, isNull, reason: raw);
+      }
+    });
+
+    test('bondSlashNodeSharePct accepts boundary values 0.0 and 1.0', () {
+      for (final raw in ['0.0', '1.0', '0.5']) {
+        final event = buildEvent([
+          const ['bond_enabled', 'true'],
+          ['bond_slash_node_share_pct', raw],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondSlashNodeSharePct, double.parse(raw), reason: raw);
+      }
+    });
+
+    test('bondAmountPct out of [0.0, 1.0] range → null', () {
+      for (final raw in ['-0.01', '1.5', '2']) {
+        final event = buildEvent([
+          const ['bond_enabled', 'true'],
+          ['bond_amount_pct', raw],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondAmountPct, isNull, reason: raw);
+      }
+    });
+
+    test('bondBaseAmountSats negative value → null', () {
+      final event = buildEvent(const [
+        ['bond_enabled', 'true'],
+        ['bond_base_amount_sats', '-100'],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+      expect(instance.bondBaseAmountSats, isNull);
+    });
+
+    test('bondBaseAmountSats accepts zero', () {
+      final event = buildEvent(const [
+        ['bond_enabled', 'true'],
+        ['bond_base_amount_sats', '0'],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+      expect(instance.bondBaseAmountSats, 0);
+    });
+
+    test('bondPayoutClaimWindowDays zero or negative → null', () {
+      for (final raw in ['0', '-1', '-15']) {
+        final event = buildEvent([
+          const ['bond_enabled', 'true'],
+          ['bond_payout_claim_window_days', raw],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondPayoutClaimWindowDays, isNull, reason: raw);
+      }
+    });
   });
 }

--- a/test/features/mostro/mostro_instance_test.dart
+++ b/test/features/mostro/mostro_instance_test.dart
@@ -193,6 +193,40 @@ void main() {
       expect(instance.bondPolicy, BondPolicy.unsupported);
     });
 
+    test('bond_enabled with malformed value → unsupported (strict parse)', () {
+      // Anything other than "true"/"false" must not masquerade as a
+      // deliberate disabled policy. Corrupt payloads collapse to unsupported
+      // so callers can fall back to legacy behaviour.
+      for (final raw in ['yes', 'no', '1', '0', 'enabled', 'maybe']) {
+        final event = buildEvent([
+          ['bond_enabled', raw],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondPolicy, BondPolicy.unsupported, reason: raw);
+      }
+    });
+
+    test('empty tag entry in event does not throw on required getters', () {
+      // Guards against a regression where `_getTagValue` indexed `t[0]`
+      // without first checking the tag was non-empty, throwing RangeError
+      // on malformed events that carry an empty tag list.
+      final event = NostrEvent(
+        id: 'a' * 64,
+        kind: 38385,
+        content: '',
+        sig: 'b' * 128,
+        pubkey: 'c' * 64,
+        createdAt: DateTime(2025),
+        tags: [
+          const <String>[],
+          ['d', 'c' * 64],
+          ['mostro_version', '0.13.0'],
+        ],
+      );
+      expect(() => event.mostroVersion, returnsNormally);
+      expect(event.mostroVersion, '0.13.0');
+    });
+
     test('bondSlashNodeSharePct out of [0.0, 1.0] range → null', () {
       for (final raw in ['-0.1', '1.5', '2', '-1']) {
         final event = buildEvent([

--- a/test/features/mostro/mostro_instance_test.dart
+++ b/test/features/mostro/mostro_instance_test.dart
@@ -1,0 +1,150 @@
+import 'package:dart_nostr/nostr/model/event/event.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
+
+void main() {
+  group('MostroInstance anti-abuse bond tags', () {
+    NostrEvent buildEvent(List<List<String>> extraTags) {
+      return NostrEvent(
+        id: 'a' * 64,
+        kind: 38385,
+        content: '',
+        sig: 'b' * 128,
+        pubkey: 'c' * 64,
+        createdAt: DateTime(2025),
+        tags: [
+          ['d', 'c' * 64],
+          ['mostro_version', '0.13.0'],
+          ['mostro_commit_hash', 'deadbeef'],
+          ['max_order_amount', '1000000'],
+          ['min_order_amount', '1'],
+          ['expiration_hours', '24'],
+          ['expiration_seconds', '900'],
+          ['fee', '0.006'],
+          ['pow', '0'],
+          ['hold_invoice_expiration_window', '300'],
+          ['hold_invoice_cltv_delta', '144'],
+          ['invoice_expiration_window', '300'],
+          ['lnd_version', '0.18.0'],
+          ['lnd_node_pubkey', 'd' * 66],
+          ['lnd_commit_hash', 'cafebabe'],
+          ['lnd_node_alias', 'mostro-lnd'],
+          ['lnd_chains', 'bitcoin'],
+          ['lnd_networks', 'mainnet'],
+          ['lnd_uris', 'lnd://example'],
+          ['fiat_currencies_accepted', 'USD,EUR'],
+          ['max_orders_per_response', '100'],
+          ...extraTags,
+        ],
+      );
+    }
+
+    test('legacy daemon: bond_enabled tag absent → BondPolicy.unsupported', () {
+      final event = buildEvent(const []);
+      final instance = MostroInstance.fromEvent(event);
+
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+      expect(instance.bondApplyTo, isNull);
+      expect(instance.bondSlashOnWaitingTimeout, isNull);
+      expect(instance.bondAmountPct, isNull);
+      expect(instance.bondBaseAmountSats, isNull);
+      expect(instance.bondSlashNodeSharePct, isNull);
+      expect(instance.bondPayoutClaimWindowDays, isNull);
+    });
+
+    test('modern daemon, feature off: bond_enabled="false" → BondPolicy.disabled', () {
+      final event = buildEvent(const [
+        ['bond_enabled', 'false'],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+
+      expect(instance.bondPolicy, BondPolicy.disabled);
+      expect(instance.bondApplyTo, isNull);
+      expect(instance.bondSlashOnWaitingTimeout, isNull);
+      expect(instance.bondAmountPct, isNull);
+      expect(instance.bondBaseAmountSats, isNull);
+      expect(instance.bondSlashNodeSharePct, isNull);
+      expect(instance.bondPayoutClaimWindowDays, isNull);
+    });
+
+    test('bond active: bond_enabled="true" with all six bond parameters', () {
+      final event = buildEvent(const [
+        ['bond_enabled', 'true'],
+        ['bond_apply_to', 'both'],
+        ['bond_slash_on_waiting_timeout', 'true'],
+        ['bond_amount_pct', '0.01'],
+        ['bond_base_amount_sats', '1000'],
+        ['bond_slash_node_share_pct', '0.5'],
+        ['bond_payout_claim_window_days', '15'],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+
+      expect(instance.bondPolicy, BondPolicy.enabled);
+      expect(instance.bondApplyTo, BondApplyTo.both);
+      expect(instance.bondSlashOnWaitingTimeout, isTrue);
+      expect(instance.bondAmountPct, 0.01);
+      expect(instance.bondBaseAmountSats, 1000);
+      expect(instance.bondSlashNodeSharePct, 0.5);
+      expect(instance.bondPayoutClaimWindowDays, 15);
+    });
+
+    test('bond_apply_to enum: all three values parse correctly', () {
+      for (final entry in {
+        'take': BondApplyTo.take,
+        'make': BondApplyTo.make,
+        'both': BondApplyTo.both,
+      }.entries) {
+        final event = buildEvent([
+          const ['bond_enabled', 'true'],
+          ['bond_apply_to', entry.key],
+        ]);
+        final instance = MostroInstance.fromEvent(event);
+        expect(instance.bondApplyTo, entry.value, reason: entry.key);
+      }
+    });
+
+    test('bond_apply_to with unknown value → null (defensive)', () {
+      final event = buildEvent(const [
+        ['bond_enabled', 'true'],
+        ['bond_apply_to', 'unexpected'],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+      expect(instance.bondApplyTo, isNull);
+    });
+
+    test('numeric bond tags with malformed values → null (defensive)', () {
+      final event = buildEvent(const [
+        ['bond_enabled', 'true'],
+        ['bond_amount_pct', 'not-a-number'],
+        ['bond_base_amount_sats', 'NaN'],
+        ['bond_slash_node_share_pct', ''],
+        ['bond_payout_claim_window_days', 'fifteen'],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+
+      expect(instance.bondPolicy, BondPolicy.enabled);
+      expect(instance.bondAmountPct, isNull);
+      expect(instance.bondBaseAmountSats, isNull);
+      expect(instance.bondSlashNodeSharePct, isNull);
+      expect(instance.bondPayoutClaimWindowDays, isNull);
+    });
+
+    test('existing info-event fields still parse correctly when bond tags present', () {
+      final event = buildEvent(const [
+        ['bond_enabled', 'true'],
+        ['bond_apply_to', 'take'],
+        ['bond_slash_on_waiting_timeout', 'false'],
+        ['bond_amount_pct', '0.02'],
+        ['bond_base_amount_sats', '500'],
+        ['bond_slash_node_share_pct', '0.25'],
+        ['bond_payout_claim_window_days', '7'],
+      ]);
+      final instance = MostroInstance.fromEvent(event);
+
+      expect(instance.mostroVersion, '0.13.0');
+      expect(instance.maxOrderAmount, 1000000);
+      expect(instance.fee, 0.006);
+      expect(instance.expirationSeconds, 900);
+    });
+  });
+}


### PR DESCRIPTION
Closes #594

## Summary

Adds the reader/cache layer for the seven new anti-abuse bond tags shipped on `mostrod`'s kind-38385 info event ([ad1f74a](https://github.com/MostroP2P/mostro/commit/ad1f74a)). Required by the upcoming Anti-Abuse Bond Support work in #591.

Scope is intentionally limited to parsing and caching. UI, trade-flow integration, and payout deadline computation land with #591.

## Three-state semantics

`bond_enabled` is the only bond tag emitted unconditionally on modern daemons. Modelled as a `BondPolicy` enum rather than `bool?` to prevent silently collapsing "tag absent" with `bond_enabled = "false"`:

- `unsupported` — tag absent (legacy daemon)
- `disabled` — `bond_enabled = "false"`
- `enabled` — `bond_enabled = "true"` (six other bond tags present)

## Changes

- `lib/features/mostro/mostro_instance.dart`: new `BondPolicy` and `BondApplyTo` enums, seven new fields on `MostroInstance`, matching getters on the `NostrEvent` extension with defensive parsing.
- `test/features/mostro/mostro_instance_test.dart`: unit tests covering the three policy states, enum parsing, and malformed values.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instances can now advertise anti-abuse bond support, scope (take/make/both) and configurable bond parameters; parsing trims whitespace, treats missing/invalid values as unspecified, and makes payout-claim-window optional when not provided.

* **Tests**
  * Expanded test coverage for bond flag parsing, scope mapping, boolean/numeric validation and bounds, and related edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->