### PR TITLE
feat(notifications): persist order cancellations in history with context

### DIFF
--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -10,7 +10,7 @@ import 'package:mostro_mobile/shared/providers.dart';
 class NotificationDataExtractor {
   /// Extract notification data from MostroMessage
   /// If ref is null, will use fallback methods for nickname resolution
-  static Future<NotificationData?> extractFromMostroMessage(MostroMessage event, Ref? ref, {Session? session, Status? previousStatus}) async {
+  static Future<NotificationData?> extractFromMostroMessage(MostroMessage event, Ref? ref, {Session? session, Status? previousStatus, bool wasUserInitiatedCancel = false}) async {
     Map<String, dynamic> values = {};
     bool isTemporary = false;
     
@@ -148,10 +148,12 @@ class NotificationDataExtractor {
         break;
         
       case Action.canceled:
-        // Persist cancellations in notification history with a variant message
-        // based on the order's previous status, so the user can review what
-        // happened to the order later from the notifications screen.
-        if (previousStatus != null) {
+        // Persist cancellations in notification history. Only attach
+        // previous_status (which drives the inactivity-specific message)
+        // when the cancel was NOT user-initiated; manual cancels in
+        // waiting-payment / waiting-buyer-invoice should fall back to the
+        // generic message instead of falsely blaming the counterparty.
+        if (!wasUserInitiatedCancel && previousStatus != null) {
           values['previous_status'] = previousStatus.value;
         }
         break;

--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -10,7 +10,7 @@ import 'package:mostro_mobile/shared/providers.dart';
 class NotificationDataExtractor {
   /// Extract notification data from MostroMessage
   /// If ref is null, will use fallback methods for nickname resolution
-  static Future<NotificationData?> extractFromMostroMessage(MostroMessage event, Ref? ref, {Session? session}) async {
+  static Future<NotificationData?> extractFromMostroMessage(MostroMessage event, Ref? ref, {Session? session, Status? previousStatus}) async {
     Map<String, dynamic> values = {};
     bool isTemporary = false;
     
@@ -148,8 +148,13 @@ class NotificationDataExtractor {
         break;
         
       case Action.canceled:
-        // Canceled orders don't generate persistent notifications
-        return null;
+        // Persist cancellations in notification history with a variant message
+        // based on the order's previous status, so the user can review what
+        // happened to the order later from the notifications screen.
+        if (previousStatus != null) {
+          values['previous_status'] = previousStatus.value;
+        }
+        break;
         
       case Action.cooperativeCancelInitiatedByYou:
       case Action.cooperativeCancelNoFiatByYou:

--- a/lib/features/notifications/utils/notification_message_mapper.dart
+++ b/lib/features/notifications/utils/notification_message_mapper.dart
@@ -111,6 +111,15 @@ class NotificationMessageMapper {
         return 'notification_add_invoice_after_failure_message';
       }
     }
+    if (values != null && action == mostro.Action.canceled) {
+      final previousStatus = values['previous_status'];
+      if (previousStatus == 'waiting-payment') {
+        return 'notification_order_canceled_by_seller_inactivity_message';
+      }
+      if (previousStatus == 'waiting-buyer-invoice') {
+        return 'notification_order_canceled_by_buyer_inactivity_message';
+      }
+    }
     // Fall back to normal message key
     return getMessageKey(action);
   }
@@ -338,6 +347,10 @@ class NotificationMessageMapper {
         return s.notification_order_canceled_title;
       case 'notification_order_canceled_message':
         return s.notification_order_canceled_message;
+      case 'notification_order_canceled_by_seller_inactivity_message':
+        return s.notification_order_canceled_by_seller_inactivity_message;
+      case 'notification_order_canceled_by_buyer_inactivity_message':
+        return s.notification_order_canceled_by_buyer_inactivity_message;
       case 'notification_cooperative_cancel_initiated_by_you_title':
         return s.notification_cooperative_cancel_initiated_by_you_title;
       case 'notification_cooperative_cancel_initiated_by_you_message':

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -32,13 +32,17 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
   // bond-slashed notice can still be received before the trade key is dropped.
   static final Map<String, Timer> _bondCancelDeletionTimers = {};
 
-  // Orders the user explicitly asked to cancel. A voluntary cancel returns the
-  // taker's bond (no slash, so no trailing bond-slashed), so its `canceled`
-  // response can delete the session immediately instead of deferring 60s.
+  // Orders the user explicitly asked to cancel. Serves two purposes: a
+  // voluntary cancel returns the taker's bond (no slash, so no trailing
+  // bond-slashed), letting its `canceled` response delete the session
+  // immediately instead of deferring 60s; and it lets the notification path
+  // distinguish a user cancel from a counterparty inactivity timeout, which
+  // uses the same Action.canceled. Consumed once per cancel in subscribe().
   static final Set<String> _userInitiatedCancels = <String>{};
 
   /// Marks an order as cancelled by the user, so the matching `canceled`
-  /// response is treated as a voluntary cancel (immediate session deletion).
+  /// response is treated as a voluntary cancel (immediate session deletion)
+  /// and notified as user-initiated rather than a counterparty timeout.
   @protected
   static void markUserInitiatedCancel(String orderId) {
     _userInitiatedCancels.add(orderId);
@@ -89,6 +93,12 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
               // counterparty-specific cancellation reason).
               final previousStatus = state.status;
 
+              // Consume the user-initiated cancel flag (set by cancelOrder)
+              // so Action.canceled responses can be distinguished from
+              // counterparty inactivity timeouts, which use the same action.
+              final wasUserInitiatedCancel = msg.action == Action.canceled &&
+                  _userInitiatedCancels.remove(orderId);
+
               if (mounted) {
                 state = state.updateWith(msg);
               }
@@ -99,7 +109,9 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
                           .millisecondsSinceEpoch) {
                 logger.i(
                     'Message timestamp check passed, calling handleEvent for ${msg.action}');
-                unawaited(handleEvent(msg, previousStatus: previousStatus));
+                unawaited(handleEvent(msg,
+                    previousStatus: previousStatus,
+                    wasUserInitiatedCancel: wasUserInitiatedCancel));
               } else {
                 logger.w(
                     'Message timestamp check failed for ${msg.action}. Timestamp: ${msg.timestamp}, Current: ${DateTime.now().millisecondsSinceEpoch}, Threshold: ${DateTime.now().subtract(const Duration(seconds: 60)).millisecondsSinceEpoch}');
@@ -112,7 +124,8 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
                       'Processing dispute action ${msg.action} despite old timestamp (state update only)');
                   unawaited(handleEvent(msg,
                       bypassTimestampGate: true,
-                      previousStatus: previousStatus));
+                      previousStatus: previousStatus,
+                      wasUserInitiatedCancel: wasUserInitiatedCancel));
                 }
               }
             }
@@ -145,7 +158,9 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
   }
 
   Future<void> handleEvent(MostroMessage event,
-      {bool bypassTimestampGate = false, Status? previousStatus}) async {
+      {bool bypassTimestampGate = false,
+      Status? previousStatus,
+      bool wasUserInitiatedCancel = false}) async {
     // Skip if we've already processed this exact event
     final eventKey = '${event.id}_${event.action}_${event.timestamp}';
     if (_processedEventIds.contains(eventKey)) {
@@ -166,7 +181,9 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
     // Extract notification data using the centralized extractor
     final notificationData =
         await NotificationDataExtractor.extractFromMostroMessage(event, ref,
-            session: session, previousStatus: previousStatus);
+            session: session,
+            previousStatus: previousStatus,
+            wasUserInitiatedCancel: wasUserInitiatedCancel);
 
     // Only notify for recent events; old disputes still update state below
     if (notificationData != null && (isRecent || !bypassTimestampGate)) {
@@ -216,9 +233,10 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
           // deletion only for a bonded order the user did NOT cancel itself;
           // otherwise delete immediately as before.
           final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
-          final userInitiated = _userInitiatedCancels.remove(orderId);
+          // The flag was already consumed in subscribe() and propagated here
+          // as wasUserInitiatedCancel; reuse it instead of removing again.
           if (shouldDeferBondCancelDeletion(
-            userInitiated: userInitiated,
+            userInitiated: wasUserInitiatedCancel,
             hadBond: await _orderHadBond(orderId),
           )) {
             _startBondCancelDeletion(orderId, ref);

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -84,6 +84,11 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
               // Cancel timer on ANY response from Mostro for this order
               cancelSessionTimeoutCleanup(orderId);
 
+              // Capture previous status before updating state, so downstream
+              // notification handlers can differentiate messages (e.g. show a
+              // counterparty-specific cancellation reason).
+              final previousStatus = state.status;
+
               if (mounted) {
                 state = state.updateWith(msg);
               }
@@ -94,7 +99,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
                           .millisecondsSinceEpoch) {
                 logger.i(
                     'Message timestamp check passed, calling handleEvent for ${msg.action}');
-                unawaited(handleEvent(msg));
+                unawaited(handleEvent(msg, previousStatus: previousStatus));
               } else {
                 logger.w(
                     'Message timestamp check failed for ${msg.action}. Timestamp: ${msg.timestamp}, Current: ${DateTime.now().millisecondsSinceEpoch}, Threshold: ${DateTime.now().subtract(const Duration(seconds: 60)).millisecondsSinceEpoch}');
@@ -105,7 +110,9 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
                     msg.action == Action.disputeInitiatedByYou) {
                   logger.i(
                       'Processing dispute action ${msg.action} despite old timestamp (state update only)');
-                  unawaited(handleEvent(msg, bypassTimestampGate: true));
+                  unawaited(handleEvent(msg,
+                      bypassTimestampGate: true,
+                      previousStatus: previousStatus));
                 }
               }
             }
@@ -138,7 +145,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
   }
 
   Future<void> handleEvent(MostroMessage event,
-      {bool bypassTimestampGate = false}) async {
+      {bool bypassTimestampGate = false, Status? previousStatus}) async {
     // Skip if we've already processed this exact event
     final eventKey = '${event.id}_${event.action}_${event.timestamp}';
     if (_processedEventIds.contains(eventKey)) {
@@ -159,7 +166,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
     // Extract notification data using the centralized extractor
     final notificationData =
         await NotificationDataExtractor.extractFromMostroMessage(event, ref,
-            session: session);
+            session: session, previousStatus: previousStatus);
 
     // Only notify for recent events; old disputes still update state below
     if (notificationData != null && (isRecent || !bypassTimestampGate)) {
@@ -221,12 +228,8 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
             logger.i('Session deleted for canceled order $orderId');
           }
 
-          // Show cancellation notification
-          if (isRecent || !bypassTimestampGate) {
-            final notifProvider =
-                ref.read(notificationActionsProvider.notifier);
-            notifProvider.showCustomMessage('orderCanceled');
-          }
+          // SnackBar + history entry are delivered via the centralized
+          // NotificationDataExtractor + notify() path above.
 
           // Navigate to main order book screen
           if (isRecent && !bypassTimestampGate) {

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -48,6 +48,13 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
     _userInitiatedCancels.add(orderId);
   }
 
+  /// Clears the user-initiated cancel flag for [orderId]. Used to roll back
+  /// the marker when the outbound cancel request fails so a later, unrelated
+  /// Action.canceled is not misclassified as user-initiated.
+  static void unmarkUserInitiatedCancel(String orderId) {
+    _userInitiatedCancels.remove(orderId);
+  }
+
   AbstractMostroNotifier(
     this.orderId,
     this.ref, {

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -22,11 +22,14 @@ class OrderNotifier extends AbstractMostroNotifier {
   }
 
   @override
-  Future<void> handleEvent(MostroMessage event, {bool bypassTimestampGate = false}) async {
+  Future<void> handleEvent(MostroMessage event,
+      {bool bypassTimestampGate = false, Status? previousStatus}) async {
     logger.i('OrderNotifier received event: ${event.action} for order $orderId');
 
     // Handle the event normally - timeout/cancellation logic is now in AbstractMostroNotifier
-    await super.handleEvent(event, bypassTimestampGate: bypassTimestampGate);
+    await super.handleEvent(event,
+        bypassTimestampGate: bypassTimestampGate,
+        previousStatus: previousStatus);
   }
 
   Future<void> sync() async {
@@ -225,10 +228,14 @@ class OrderNotifier extends AbstractMostroNotifier {
             final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
             await sessionNotifier.deleteSession(orderId);
             
-            // Show expiration notification
+            // Persist expiration in notification history (and show SnackBar)
             final notifProvider = ref.read(notificationActionsProvider.notifier);
-            notifProvider.showCustomMessage('orderCanceled');
-            
+            await notifProvider.notify(
+              Action.canceled,
+              values: {'previous_status': Status.pending.value},
+              orderId: orderId,
+            );
+
             ref.invalidateSelf();
           }
         } catch (e, stack) {

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -166,13 +166,16 @@ class OrderNotifier extends AbstractMostroNotifier {
     }
     // Flag this cancel as user-initiated so the upcoming Action.canceled
     // response is not misattributed to counterparty inactivity when the
-    // order is in waiting-payment / waiting-buyer-invoice.
+    // order is in waiting-payment / waiting-buyer-invoice. Roll back the
+    // flag if the outbound request fails, otherwise a future canceled event
+    // for the same orderId would be misclassified as user-initiated.
     AbstractMostroNotifier.markUserInitiatedCancel(orderId);
-    await mostroService.cancelOrder(orderId);
-    // The cancel was sent by the user: its `canceled` response means the
-    // bond is returned (no slash), so the session can be deleted immediately
-    // instead of waiting for a bond-slashed notice that will never arrive.
-    AbstractMostroNotifier.markUserInitiatedCancel(orderId);
+    try {
+      await mostroService.cancelOrder(orderId);
+    } catch (_) {
+      AbstractMostroNotifier.unmarkUserInitiatedCancel(orderId);
+      rethrow;
+    }
   }
 
   Future<void> sendFiatSent() async {

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -23,13 +23,16 @@ class OrderNotifier extends AbstractMostroNotifier {
 
   @override
   Future<void> handleEvent(MostroMessage event,
-      {bool bypassTimestampGate = false, Status? previousStatus}) async {
+      {bool bypassTimestampGate = false,
+      Status? previousStatus,
+      bool wasUserInitiatedCancel = false}) async {
     logger.i('OrderNotifier received event: ${event.action} for order $orderId');
 
     // Handle the event normally - timeout/cancellation logic is now in AbstractMostroNotifier
     await super.handleEvent(event,
         bypassTimestampGate: bypassTimestampGate,
-        previousStatus: previousStatus);
+        previousStatus: previousStatus,
+        wasUserInitiatedCancel: wasUserInitiatedCancel);
   }
 
   Future<void> sync() async {
@@ -161,6 +164,10 @@ class OrderNotifier extends AbstractMostroNotifier {
       await sessionNotifier.deleteSession(orderId);
       return;
     }
+    // Flag this cancel as user-initiated so the upcoming Action.canceled
+    // response is not misattributed to counterparty inactivity when the
+    // order is in waiting-payment / waiting-buyer-invoice.
+    AbstractMostroNotifier.markUserInitiatedCancel(orderId);
     await mostroService.cancelOrder(orderId);
     // The cancel was sent by the user: its `canceled` response means the
     // bond is returned (no slash), so the session can be deleted immediately
@@ -228,12 +235,15 @@ class OrderNotifier extends AbstractMostroNotifier {
             final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
             await sessionNotifier.deleteSession(orderId);
             
-            // Persist expiration in notification history (and show SnackBar)
+            // Persist expiration in notification history (and show SnackBar).
+            // Use a stable eventId so repeated public-event emissions for the
+            // same auto-expiration are deduplicated by the notifications store.
             final notifProvider = ref.read(notificationActionsProvider.notifier);
             await notifProvider.notify(
               Action.canceled,
               values: {'previous_status': Status.pending.value},
               orderId: orderId,
+              eventId: 'auto_expire:$orderId',
             );
 
             ref.invalidateSelf();

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1207,6 +1207,8 @@
     "notification_dispute_started_message": "Ein Streitfall wurde eingeleitet",
     "notification_order_canceled_title": "Order abgebrochen",
     "notification_order_canceled_message": "Die Order wurde abgebrochen",
+    "notification_order_canceled_by_seller_inactivity_message": "Der Verkäufer hat die Order nicht fortgesetzt. Die Order wurde abgebrochen.",
+    "notification_order_canceled_by_buyer_inactivity_message": "Der Käufer hat die Order nicht fortgesetzt. Die Order wurde abgebrochen.",
     "notification_cooperative_cancel_initiated_by_you_title": "Stornierung angefordert",
     "notification_cooperative_cancel_initiated_by_you_message": "Du hast die Stornierung der Order angefordert; warte auf Bestätigung des Partners",
     "notification_cooperative_cancel_initiated_by_peer_title": "Stornierungsanfrage",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1207,6 +1207,8 @@
     "notification_dispute_started_message": "A dispute has been initiated",
     "notification_order_canceled_title": "Order canceled",
     "notification_order_canceled_message": "The order has been canceled",
+    "notification_order_canceled_by_seller_inactivity_message": "The seller did not continue the order. The order has been cancelled.",
+    "notification_order_canceled_by_buyer_inactivity_message": "The buyer did not continue the order. The order has been cancelled.",
     "notification_cooperative_cancel_initiated_by_you_title": "Cancellation requested",
     "notification_cooperative_cancel_initiated_by_you_message": "You requested to cancel the order, waiting for peer confirmation",
     "notification_cooperative_cancel_initiated_by_peer_title": "Cancellation request",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1121,6 +1121,8 @@
     "notification_dispute_started_message": "Se ha iniciado una disputa",
     "notification_order_canceled_title": "Orden cancelada",
     "notification_order_canceled_message": "La orden ha sido cancelada",
+    "notification_order_canceled_by_seller_inactivity_message": "El vendedor no continuó la orden. La orden ha sido cancelada.",
+    "notification_order_canceled_by_buyer_inactivity_message": "El comprador no continuó la orden. La orden ha sido cancelada.",
     "notification_cooperative_cancel_initiated_by_you_title": "Cancelación solicitada",
     "notification_cooperative_cancel_initiated_by_you_message": "Solicitaste cancelar la orden, esperando confirmación del par",
     "notification_cooperative_cancel_initiated_by_peer_title": "Solicitud de cancelación",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1207,6 +1207,8 @@
     "notification_dispute_started_message": "Un différend a été initié",
     "notification_order_canceled_title": "Commande annulée",
     "notification_order_canceled_message": "La commande a été annulée",
+    "notification_order_canceled_by_seller_inactivity_message": "Le vendeur n'a pas poursuivi la commande. La commande a été annulée.",
+    "notification_order_canceled_by_buyer_inactivity_message": "L'acheteur n'a pas poursuivi la commande. La commande a été annulée.",
     "notification_cooperative_cancel_initiated_by_you_title": "Annulation demandée",
     "notification_cooperative_cancel_initiated_by_you_message": "Vous avez demandé d'annuler la commande, en attente de confirmation du pair",
     "notification_cooperative_cancel_initiated_by_peer_title": "Demande d'annulation",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1187,6 +1187,8 @@
     "notification_dispute_started_message": "È stata avviata una disputa",
     "notification_order_canceled_title": "Ordine annullato",
     "notification_order_canceled_message": "L'ordine è stato annullato",
+    "notification_order_canceled_by_seller_inactivity_message": "Il venditore non ha continuato l'ordine. L'ordine è stato annullato.",
+    "notification_order_canceled_by_buyer_inactivity_message": "L'acquirente non ha continuato l'ordine. L'ordine è stato annullato.",
     "notification_cooperative_cancel_initiated_by_you_title": "Cancellazione richiesta",
     "notification_cooperative_cancel_initiated_by_you_message": "Hai richiesto di annullare l'ordine, in attesa della conferma del peer",
     "notification_cooperative_cancel_initiated_by_peer_title": "Richiesta di cancellazione",


### PR DESCRIPTION
## Summary

Closes #535.

When an order is canceled due to counterparty inactivity in `waiting-payment` or `waiting-buyer-invoice`, the user previously only saw a transient SnackBar — the event never reached the notifications screen (bell icon), so they could not review what happened to the order afterwards.

This PR persists every `Action.canceled` event to the notification history with a context-aware message based on the order's previous status:

- `waiting-payment` → "The seller did not continue the order. The order has been cancelled."
- `waiting-buyer-invoice` → "The buyer did not continue the order. The order has been cancelled."
- Other (manual cancel, pending expiry, etc.) → generic "The order has been canceled."

## Changes

- **`NotificationDataExtractor`**: new `previousStatus` parameter; `Action.canceled` no longer returns `null` (which previously skipped persistence) and instead emits `NotificationData` with `previous_status` in `values`.
- **`NotificationMessageMapper.getMessageKeyWithContext`**: resolves the correct localization key for `Action.canceled` based on `previous_status`.
- **`AbstractMostroNotifier.subscribe()`**: captures `previousStatus = state.status` before `state.updateWith(msg)` and forwards it through `handleEvent` → extractor.
- **`AbstractMostroNotifier.handleEvent()`**: removed the now-redundant `showCustomMessage('orderCanceled')` call — the centralized `notify()` path already shows the SnackBar **and** persists to history.
- **`OrderNotifier`**: forwards `previousStatus` in its `handleEvent` override and converts the pending-order-expiry `showCustomMessage('orderCanceled')` to a `notify(Action.canceled, ...)` call so it also appears in the history.
- **Localizations**: added `notification_order_canceled_by_seller_inactivity_message` and `notification_order_canceled_by_buyer_inactivity_message` to `en`, `es`, `it`, `de`, `fr`.

## Test plan

- [ ] `fvm flutter analyze` → no issues (verified)
- [ ] `fvm flutter test` → all tests pass (verified, 369/369)
- [ ] Manual: take a sell order, let the seller (maker) not pay → after `Action.canceled`, open the notifications screen and verify the "seller did not continue" message appears
- [ ] Manual: take a buy order, let the buyer (maker) not provide an invoice → verify the "buyer did not continue" message appears
- [ ] Manual: create a pending order and let it expire → verify a generic cancellation entry appears in the notifications screen
- [ ] Manual: verify a single SnackBar is shown (no duplicate) on cancellation
- [ ] Manual: verify message is correctly localized in EN, ES, IT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancellation notifications are always produced and persisted; when available they include the previous order status and correctly distinguish user-initiated vs automatic cancels.
  * Notifications now use distinct messages for cancellations due to seller vs buyer inactivity.
  * Manual cancels are tracked/untracked so user-initiated and automatic expirations are handled distinctly; automatic expirations generate deterministic notification events.

* **Localization**
  * Added localized messages for inactivity-based cancellations in English, German, Spanish, French, and Italian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->