### PR TITLE
feat(bond): Phase 3.5 payout confirmation actions on mobile

### DIFF
--- a/lib/data/models/enums/action.dart
+++ b/lib/data/models/enums/action.dart
@@ -5,6 +5,8 @@ enum Action {
   payInvoice('pay-invoice'),
   payBondInvoice('pay-bond-invoice'),
   addBondInvoice('add-bond-invoice'),
+  bondInvoiceAccepted('bond-invoice-accepted'),
+  bondPayoutCompleted('bond-payout-completed'),
   fiatSent('fiat-sent'),
   fiatSentOk('fiat-sent-ok'),
   release('release'),

--- a/lib/data/models/order.dart
+++ b/lib/data/models/order.dart
@@ -84,8 +84,10 @@ class Order implements Payload {
         }
       }
 
-      // Validate required fields
-      ['kind', 'status', 'fiat_code', 'fiat_amount', 'payment_method']
+      // Validate required fields. `status` is intentionally not required:
+      // Phase 3.5 bond payout acks (`bond-invoice-accepted` /
+      // `bond-payout-completed`) carry a SmallOrder with `status: null`.
+      ['kind', 'fiat_code', 'fiat_amount', 'payment_method']
           .forEach(validateField);
 
       // Parse and validate integer fields with type safety
@@ -157,10 +159,13 @@ class Order implements Payload {
             'Min amount ($minAmount) cannot be greater than max amount ($maxAmount)');
       }
 
+      final statusRaw = parseOptionalStringField('status');
       return Order(
         id: parseOptionalStringField('id'),
         kind: OrderType.fromString(parseStringField('kind')),
-        status: Status.fromString(parseStringField('status')),
+        status: statusRaw != null
+            ? Status.fromString(statusRaw)
+            : Status.pending,
         amount: amount,
         fiatCode: parseStringField('fiat_code'),
         minAmount: minAmount,

--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -208,6 +208,8 @@ class NotificationDataExtractor {
         return null;
 
       case Action.addBondInvoice:
+      case Action.bondInvoiceAccepted:
+      case Action.bondPayoutCompleted:
         return null;
 
       default:

--- a/lib/features/notifications/utils/notification_message_mapper.dart
+++ b/lib/features/notifications/utils/notification_message_mapper.dart
@@ -95,6 +95,8 @@ class NotificationMessageMapper {
       case mostro.Action.orders:
       case mostro.Action.lastTradeIndex:
       case mostro.Action.addBondInvoice:
+      case mostro.Action.bondInvoiceAccepted:
+      case mostro.Action.bondPayoutCompleted:
         return 'TODO: implement  title key if needed';
     }
   }
@@ -199,6 +201,8 @@ class NotificationMessageMapper {
       case mostro.Action.orders:
       case mostro.Action.lastTradeIndex:
       case mostro.Action.addBondInvoice:
+      case mostro.Action.bondInvoiceAccepted:
+      case mostro.Action.bondPayoutCompleted:
         return 'TODO: implement message key if needed';
 
     }

--- a/lib/features/notifications/widgets/notification_item.dart
+++ b/lib/features/notifications/widgets/notification_item.dart
@@ -133,6 +133,8 @@ class NotificationItem extends ConsumerWidget {
         case mostro_action.Action.orders:
         case mostro_action.Action.lastTradeIndex:
         case mostro_action.Action.addBondInvoice:
+        case mostro_action.Action.bondInvoiceAccepted:
+        case mostro_action.Action.bondPayoutCompleted:
           break;
       }
     }

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -240,10 +240,17 @@ class OrderState {
       logger.i('Auto-closed dispute: cooperative cancellation');
     }
 
+    // Phase 3.5: bond payout acks carry a SmallOrder whose `amount` is the
+    // counterparty share and whose `status` is null. They must NOT overwrite
+    // the tracked trade order, which holds the real trade amount and status.
+    final bool isBondPayoutAck =
+        message.action == Action.bondInvoiceAccepted ||
+            message.action == Action.bondPayoutCompleted;
+
     final newState = copyWith(
       status: newStatus,
       action: effectiveAction,
-      order: message.payload is Order
+      order: (message.payload is Order && !isBondPayoutAck)
           ? message.getPayload<Order>()
           : message.payload is PaymentRequest
               ? message.getPayload<PaymentRequest>()!.order
@@ -364,6 +371,15 @@ class OrderState {
       case Action.adminAddSolver:
       case Action.addBondInvoice:
         return payloadStatus ?? status;
+
+      // Phase 3.5 bond payout acks: always preserve current status.
+      // Their payload is an `Order` (SmallOrder) whose `status` is null on
+      // the wire; `Order.fromJson` defaults that null to `Status.pending`,
+      // which would otherwise overwrite the real terminal status of the
+      // order (success / settledByAdmin / canceledByAdmin / etc.).
+      case Action.bondInvoiceAccepted:
+      case Action.bondPayoutCompleted:
+        return status;
 
       // For actions that include Order payload, use the payload status
       case Action.newOrder:

--- a/lib/features/order/screens/bond_payout_invoice_screen.dart
+++ b/lib/features/order/screens/bond_payout_invoice_screen.dart
@@ -45,6 +45,21 @@ class _BondPayoutInvoiceScreenState
       appBar: OrderAppBar(title: s.addBondInvoiceTitle),
       body: historyAsync.when(
         data: (messages) {
+          final phase = bondPayoutPhase(messages);
+
+          if (phase == BondPayoutPhase.acknowledged) {
+            return _buildInfoBody(
+              s: s,
+              message: s.bondInvoiceAcceptedMessage,
+            );
+          }
+          if (phase == BondPayoutPhase.completed) {
+            return _buildInfoBody(
+              s: s,
+              message: s.bondPayoutCompletedMessage,
+            );
+          }
+
           final request = latestBondPayoutRequest(messages);
           if (request == null) {
             return Center(
@@ -192,6 +207,53 @@ class _BondPayoutInvoiceScreenState
                         fontWeight: FontWeight.w600,
                       ),
                     ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoBody({required S s, required String message}) {
+    return SingleChildScrollView(
+      padding: EdgeInsets.fromLTRB(
+        16,
+        16,
+        16,
+        16 + MediaQuery.of(context).viewPadding.bottom,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            message,
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              key: const Key('bondPayoutCloseButton'),
+              onPressed: () => context.go('/'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.activeColor,
+                foregroundColor: Colors.black,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              child: Text(
+                s.bondPayoutCloseButton,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -62,7 +62,51 @@ class MostroMessageDetail extends ConsumerWidget {
     WidgetRef ref,
   ) {
     final tradeState = ref.watch(orderNotifierProvider(orderId));
-    final action = tradeState.action;
+    final historyAsync = ref.watch(mostroMessageHistoryProvider(orderId));
+    final messages = historyAsync.maybeWhen<List<MostroMessage>>(
+      data: (m) => m,
+      orElse: () => const <MostroMessage>[],
+    );
+    final bondPhase = bondPayoutPhase(messages);
+
+    if (bondPhase == BondPayoutPhase.acknowledged) {
+      return S.of(context)!.bondInvoiceAcceptedMessage;
+    }
+
+    if (bondPhase == BondPayoutPhase.completed) {
+      final prev = _previousNonBondAction(messages) ?? tradeState.action;
+      final base = _renderActionMessage(context, ref, tradeState, prev);
+      final canRate =
+          messages.any((m) => m.action == actions.Action.rate);
+      final extension = canRate
+          ? S.of(context)!.bondPayoutCompletedWithRating
+          : S.of(context)!.bondPayoutCompletedMessage;
+      return '$base\n\n$extension';
+    }
+
+    return _renderActionMessage(context, ref, tradeState, tradeState.action);
+  }
+
+  actions.Action? _previousNonBondAction(List<MostroMessage> messages) {
+    final sorted = [...messages]..sort(
+        (a, b) => (b.timestamp ?? 0).compareTo(a.timestamp ?? 0),
+      );
+    for (final msg in sorted) {
+      final a = msg.action;
+      if (a == actions.Action.addBondInvoice) continue;
+      if (a == actions.Action.bondInvoiceAccepted) continue;
+      if (a == actions.Action.bondPayoutCompleted) continue;
+      return a;
+    }
+    return null;
+  }
+
+  String _renderActionMessage(
+    BuildContext context,
+    WidgetRef ref,
+    OrderState tradeState,
+    actions.Action? action,
+  ) {
     final orderPayload = tradeState.order;
     switch (action) {
       case actions.Action.newOrder:

--- a/lib/features/trades/widgets/trades_list_item.dart
+++ b/lib/features/trades/widgets/trades_list_item.dart
@@ -35,9 +35,17 @@ class TradesListItem extends ConsumerWidget {
         ref.watch(mostroMessageHistoryProvider(trade.orderId!));
     final instance = ref.watch(orderRepositoryProvider).mostroInstance;
     final claimWindowDays = instance?.bondPayoutClaimWindowDays ?? 15;
-    final showBondPayoutBadge = messageHistory.maybeWhen(
-      data: (msgs) => hasPendingBondClaim(msgs, claimWindowDays),
-      orElse: () => false,
+    final bondBadgeLabel = messageHistory.maybeWhen<String?>(
+      data: (msgs) {
+        if (hasPendingBondClaim(msgs, claimWindowDays)) {
+          return S.of(context)!.bondPayoutBadge;
+        }
+        if (bondPayoutPhase(msgs) == BondPayoutPhase.acknowledged) {
+          return S.of(context)!.bondPayoutInProgressBadge;
+        }
+        return null;
+      },
+      orElse: () => null,
     );
 
     // Determine if the user is the creator of the order based on role and order type
@@ -85,7 +93,7 @@ class TradesListItem extends ConsumerWidget {
                         _buildStatusChip(
                           context,
                           orderState.status,
-                          showBondPayoutBadge: showBondPayoutBadge,
+                          bondBadgeLabel: bondBadgeLabel,
                         ),
                         const SizedBox(width: 8),
                         _buildRoleChip(context, isCreator),
@@ -199,17 +207,17 @@ class TradesListItem extends ConsumerWidget {
   Widget _buildStatusChip(
     BuildContext context,
     Status status, {
-    bool showBondPayoutBadge = false,
+    String? bondBadgeLabel,
   }) {
     Color backgroundColor;
     Color textColor;
     String label;
 
-    if (showBondPayoutBadge) {
+    if (bondBadgeLabel != null) {
       backgroundColor =
           AppTheme.statusPendingBackground.withValues(alpha: 0.6);
       textColor = AppTheme.statusPendingText;
-      label = S.of(context)!.bondPayoutBadge;
+      label = bondBadgeLabel;
       return Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         decoration: BoxDecoration(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1588,5 +1588,10 @@
     "addBondInvoiceSubmitButton": "RECHNUNG SENDEN",
     "addBondInvoiceFailedToSubmit": "Rechnung konnte nicht gesendet werden. Bitte erneut versuchen.",
     "bondPayoutBadge": "AUSZAHLUNG OFFEN",
+    "bondPayoutInProgressBadge": "AUSZAHLUNG LÄUFT",
+    "bondInvoiceAcceptedMessage": "Mostro hat die Lightning-Rechnung akzeptiert, die du zum Erhalt deines Anteils der Anti-Missbrauchs-Kaution bereitgestellt hast. Bitte warte, bis die Zahlung abgeschlossen ist.",
+    "bondPayoutCompletedMessage": "Du hast die Auszahlung deines Anteils der Anti-Missbrauchs-Kaution erhalten.",
+    "bondPayoutCompletedWithRating": "Du hast die Auszahlung deines Anteils der Anti-Missbrauchs-Kaution erhalten. Du kannst deinen Handelspartner bewerten.",
+    "bondPayoutCloseButton": "SCHLIESSEN",
     "errorLoadingBondPayout": "Fehler beim Laden der Auszahlungsdaten"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1588,5 +1588,10 @@
     "addBondInvoiceSubmitButton": "SUBMIT INVOICE",
     "addBondInvoiceFailedToSubmit": "Failed to submit invoice. Please try again.",
     "bondPayoutBadge": "PAYOUT PENDING",
+    "bondPayoutInProgressBadge": "PAYOUT IN PROGRESS",
+    "bondInvoiceAcceptedMessage": "Mostro has accepted the Lightning invoice you provided to receive your share of the anti-abuse bond. Please wait for the payment to complete.",
+    "bondPayoutCompletedMessage": "You have received the payment of your share of the anti-abuse bond.",
+    "bondPayoutCompletedWithRating": "You have received the payment of your share of the anti-abuse bond. You can rate your counterparty.",
+    "bondPayoutCloseButton": "CLOSE",
     "errorLoadingBondPayout": "Error loading payout data"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1563,5 +1563,10 @@
     "addBondInvoiceSubmitButton": "ENVIAR FACTURA",
     "addBondInvoiceFailedToSubmit": "Error al enviar la factura. Intenta de nuevo.",
     "bondPayoutBadge": "COBRO PENDIENTE",
+    "bondPayoutInProgressBadge": "COBRO EN CURSO",
+    "bondInvoiceAcceptedMessage": "Mostro ha aceptado la factura Lightning que proporcionaste para recibir tu parte del bono anti-abuso. Espera a que se complete el pago.",
+    "bondPayoutCompletedMessage": "Ya recibiste el pago de tu parte del bono anti-abuso.",
+    "bondPayoutCompletedWithRating": "Ya recibiste el pago de tu parte del bono anti-abuso. Puedes calificar a tu contraparte.",
+    "bondPayoutCloseButton": "CERRAR",
     "errorLoadingBondPayout": "Error al cargar los datos del cobro"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1588,5 +1588,10 @@
     "addBondInvoiceSubmitButton": "ENVOYER LA FACTURE",
     "addBondInvoiceFailedToSubmit": "Échec de l'envoi de la facture. Veuillez réessayer.",
     "bondPayoutBadge": "PAIEMENT EN ATTENTE",
+    "bondPayoutInProgressBadge": "PAIEMENT EN COURS",
+    "bondInvoiceAcceptedMessage": "Mostro a accepté la facture Lightning que vous avez fournie pour recevoir votre part du dépôt anti-abus. Veuillez patienter jusqu'à ce que le paiement soit terminé.",
+    "bondPayoutCompletedMessage": "Vous avez reçu le paiement de votre part du dépôt anti-abus.",
+    "bondPayoutCompletedWithRating": "Vous avez reçu le paiement de votre part du dépôt anti-abus. Vous pouvez évaluer votre contrepartie.",
+    "bondPayoutCloseButton": "FERMER",
     "errorLoadingBondPayout": "Erreur lors du chargement des données de paiement"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1629,5 +1629,10 @@
     "addBondInvoiceSubmitButton": "INVIA FATTURA",
     "addBondInvoiceFailedToSubmit": "Errore nell'invio della fattura. Riprova.",
     "bondPayoutBadge": "RISCATTO IN ATTESA",
+    "bondPayoutInProgressBadge": "RISCATTO IN CORSO",
+    "bondInvoiceAcceptedMessage": "Mostro ha accettato la fattura Lightning che hai fornito per ricevere la tua parte del deposito anti-abuso. Attendi il completamento del pagamento.",
+    "bondPayoutCompletedMessage": "Hai ricevuto il pagamento della tua parte del deposito anti-abuso.",
+    "bondPayoutCompletedWithRating": "Hai ricevuto il pagamento della tua parte del deposito anti-abuso. Puoi valutare la tua controparte.",
+    "bondPayoutCloseButton": "CHIUDI",
     "errorLoadingBondPayout": "Errore nel caricamento dei dati del riscatto"
 }

--- a/lib/shared/utils/bond_payout_helpers.dart
+++ b/lib/shared/utils/bond_payout_helpers.dart
@@ -1,6 +1,26 @@
 import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models.dart';
 
+enum BondPayoutPhase {
+  /// No bond payout flow for this order.
+  none,
+
+  /// Latest bond-related message is an inbound `BondPayoutRequest`
+  /// awaiting the user's `PaymentRequest` reply (or a retry after a
+  /// previous acknowledgement).
+  pending,
+
+  /// Mostro acknowledged receipt of the user's invoice via
+  /// `bond-invoice-accepted`. Payment is in progress; the user must not
+  /// resubmit until either a new `add-bond-invoice` arrives (Failed-state
+  /// resurrection) or `bond-payout-completed` confirms terminal success.
+  acknowledged,
+
+  /// Mostro confirmed `send_payment` succeeded via `bond-payout-completed`.
+  /// The bond claim is closed; no further submissions are expected.
+  completed,
+}
+
 DateTime bondClaimDeadline(int slashedAt, int claimWindowDays) {
   return DateTime.fromMillisecondsSinceEpoch(
     (slashedAt + claimWindowDays * 86400) * 1000,
@@ -28,13 +48,49 @@ BondPayoutRequest? latestBondPayoutRequest(List<MostroMessage> messages) {
   return null;
 }
 
-/// True when the latest stored `add-bond-invoice` for the order is an
-/// inbound `BondPayoutRequest` whose claim window has not expired and to
-/// which the user has not yet replied with a `PaymentRequest`.
+/// Determines the current phase of the bond payout flow based on the
+/// timestamp-ordered history. Only messages relevant to the bond flow
+/// (`addBondInvoice`, `bondInvoiceAccepted`, `bondPayoutCompleted`) are
+/// considered. The latest one decides the phase.
+BondPayoutPhase bondPayoutPhase(List<MostroMessage> messages) {
+  final relevant = messages.where((m) =>
+      m.action == Action.addBondInvoice ||
+      m.action == Action.bondInvoiceAccepted ||
+      m.action == Action.bondPayoutCompleted);
+  if (relevant.isEmpty) return BondPayoutPhase.none;
+
+  final sorted = [...relevant]..sort(
+      (a, b) => (b.timestamp ?? 0).compareTo(a.timestamp ?? 0),
+    );
+
+  for (final msg in sorted) {
+    switch (msg.action) {
+      case Action.bondPayoutCompleted:
+        return BondPayoutPhase.completed;
+      case Action.bondInvoiceAccepted:
+        return BondPayoutPhase.acknowledged;
+      case Action.addBondInvoice:
+        if (msg.payload is BondPayoutRequest) {
+          return BondPayoutPhase.pending;
+        }
+        // Outbound PaymentRequest reply: keep looking for the next
+        // bond-flow message that defines a real phase.
+        continue;
+      default:
+        continue;
+    }
+  }
+  return BondPayoutPhase.none;
+}
+
+/// True when the bond claim is in `pending` phase and the claim window has
+/// not expired. Used to gate the CLAIM button and the "PAYOUT PENDING"
+/// badge.
 bool hasPendingBondClaim(
   List<MostroMessage> messages,
   int claimWindowDays,
 ) {
+  if (bondPayoutPhase(messages) != BondPayoutPhase.pending) return false;
   final request = latestBondPayoutRequest(messages);
   if (request == null) return false;
   return !isBondClaimExpired(request.slashedAt, claimWindowDays);

--- a/test/models/order_test.dart
+++ b/test/models/order_test.dart
@@ -27,6 +27,32 @@ void main() {
       expect(order.amount, equals(0));
       expect(order.fiatAmount, equals(100));
     });
+
+    test(
+        'fromJson accepts a SmallOrder with null status (Phase 3.5 bond ack)',
+        () {
+      final smallOrder = {
+        'id': '6fec64ea-f2d1-453b-ba1d-929c3cb62244',
+        'kind': 'sell',
+        'status': null,
+        'amount': 250,
+        'fiat_code': 'CUP',
+        'min_amount': null,
+        'max_amount': null,
+        'fiat_amount': 222,
+        'payment_method': 'hhhh',
+        'premium': 0,
+        'created_at': null,
+        'expires_at': null,
+      };
+
+      final order = Order.fromJson(smallOrder);
+
+      expect(order.status, equals(Status.pending));
+      expect(order.amount, equals(250));
+      expect(order.fiatCode, equals('CUP'));
+      expect(order.kind, equals(OrderType.sell));
+    });
   });
 
   group('Order Tests with JSON', () {

--- a/test/shared/utils/bond_payout_helpers_test.dart
+++ b/test/shared/utils/bond_payout_helpers_test.dart
@@ -43,6 +43,22 @@ MostroMessage<PaymentRequest> _paymentReplyMsg({required int timestamp}) {
   );
 }
 
+MostroMessage _invoiceAcceptedMsg({required int timestamp}) {
+  return MostroMessage(
+    action: Action.bondInvoiceAccepted,
+    id: 'order-1',
+    timestamp: timestamp,
+  );
+}
+
+MostroMessage _payoutCompletedMsg({required int timestamp}) {
+  return MostroMessage(
+    action: Action.bondPayoutCompleted,
+    id: 'order-1',
+    timestamp: timestamp,
+  );
+}
+
 void main() {
   group('latestBondPayoutRequest', () {
     test('returns null on empty message list', () {
@@ -94,6 +110,63 @@ void main() {
     });
   });
 
+  group('bondPayoutPhase', () {
+    test('none when there is no bond-flow message', () {
+      expect(bondPayoutPhase([]), BondPayoutPhase.none);
+      final unrelated = MostroMessage(
+        action: Action.fiatSent,
+        id: 'order-1',
+        timestamp: 100,
+      );
+      expect(bondPayoutPhase([unrelated]), BondPayoutPhase.none);
+    });
+
+    test('pending when latest is an inbound BondPayoutRequest', () {
+      final messages = [_addBondInvoiceMsg(timestamp: 100)];
+      expect(bondPayoutPhase(messages), BondPayoutPhase.pending);
+    });
+
+    test('acknowledged when latest is bondInvoiceAccepted', () {
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100),
+        _paymentReplyMsg(timestamp: 200),
+        _invoiceAcceptedMsg(timestamp: 300),
+      ];
+      expect(bondPayoutPhase(messages), BondPayoutPhase.acknowledged);
+    });
+
+    test('completed when latest is bondPayoutCompleted', () {
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100),
+        _paymentReplyMsg(timestamp: 200),
+        _invoiceAcceptedMsg(timestamp: 300),
+        _payoutCompletedMsg(timestamp: 400),
+      ];
+      expect(bondPayoutPhase(messages), BondPayoutPhase.completed);
+    });
+
+    test('retry: new addBondInvoice after acknowledged returns to pending',
+        () {
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100),
+        _paymentReplyMsg(timestamp: 200),
+        _invoiceAcceptedMsg(timestamp: 300),
+        _addBondInvoiceMsg(timestamp: 400, slashedAt: 9999),
+      ];
+      expect(bondPayoutPhase(messages), BondPayoutPhase.pending);
+    });
+
+    test('phase is decided by timestamp ordering, not input order', () {
+      final messages = [
+        _payoutCompletedMsg(timestamp: 400),
+        _invoiceAcceptedMsg(timestamp: 300),
+        _addBondInvoiceMsg(timestamp: 100),
+        _paymentReplyMsg(timestamp: 200),
+      ];
+      expect(bondPayoutPhase(messages), BondPayoutPhase.completed);
+    });
+  });
+
   group('hasPendingBondClaim', () {
     test('false when no add-bond-invoice is present', () {
       expect(hasPendingBondClaim([], _claimWindowDays), isFalse);
@@ -124,6 +197,26 @@ void main() {
         _paymentReplyMsg(timestamp: 200),
       ];
       expect(hasPendingBondClaim(messages, _claimWindowDays), isFalse);
+    });
+
+    test('false after bondInvoiceAccepted (acknowledged phase)', () {
+      final slashedAtSecs = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100, slashedAt: slashedAtSecs),
+        _invoiceAcceptedMsg(timestamp: 200),
+      ];
+      expect(hasPendingBondClaim(messages, _claimWindowDays), isFalse);
+    });
+
+    test('true again when a retry addBondInvoice arrives after acknowledged',
+        () {
+      final slashedAtSecs = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final messages = [
+        _addBondInvoiceMsg(timestamp: 100, slashedAt: slashedAtSecs),
+        _invoiceAcceptedMsg(timestamp: 200),
+        _addBondInvoiceMsg(timestamp: 300, slashedAt: slashedAtSecs),
+      ];
+      expect(hasPendingBondClaim(messages, _claimWindowDays), isTrue);
     });
   });
 }


### PR DESCRIPTION
  - Add  and  to the Action enum
  - Add  helper (none/pending/acknowledged/completed) with retry support
  - Bond payout screen: hide form on acknowledged/completed, show info + single CLOSE button
  - My Trades badge: PAYOUT IN PROGRESS on acknowledged; order's real status on completed
  - Trade Details: extend the previous non-bond message with a bond-paid line; rate hint only if  is in history
  - : accept  default to
  - : keep tracked order untouched on bond acks; preserve current status (don't fall to default)
  - Notification extractor: return null for the two new actions (no SnackBar fires)
  - Exhaustive switches in notification mapper/item updated as no-ops (compiler requirement; functional wiring deferred)
  - l10n: new keys in en/es/it/de/fr
  - Tests: bond payout helpers 9→17 cases; regression test for

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bond invoice acceptance and payout completion support with dedicated UI flows and localized messaging across five languages.
  * Introduced bond payout phase tracking for improved order state management.

* **Bug Fixes**
  * Made order status field optional to handle edge case payloads.

* **Tests**
  * Added comprehensive test coverage for bond payout phase transitions and order parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->