### PR TITLE
feat(order): show amount limits in fiat in the create order screen

### DIFF
--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -325,6 +325,7 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
                           validateSatsRange: _validateSatsRange,
                           validationError: _validationError,
                           onRangeModeChanged: _onRangeModeChanged,
+                          fiatCode: selectedFiatCode,
                         ),
                         const SizedBox(height: 16),
                         PaymentMethodsSection(

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -23,6 +23,7 @@ import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:uuid/uuid.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/utils/order_amount_limits.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
 
 class AddOrderScreen extends ConsumerStatefulWidget {
@@ -182,25 +183,42 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     final minAllowed = mostroInstance.minOrderAmount;
     final maxAllowed = mostroInstance.maxOrderAmount;
 
-    // Debug logging
-    debugPrint(
-        'Validation: fiat=$fiatAmount, rate=$exchangeRate, sats=$satsAmount, min=$minAllowed, max=$maxAllowed');
-
-    // Check if sats amount is outside range
-    if (satsAmount < minAllowed) {
-      return S.of(context)!.fiatAmountTooLow(
-            minAllowed.toString(),
-            maxAllowed.toString(),
-          );
-    } else if (satsAmount > maxAllowed) {
-      return S.of(context)!.fiatAmountTooHigh(
-            minAllowed.toString(),
-            maxAllowed.toString(),
-          );
+    if (satsAmount >= minAllowed && satsAmount <= maxAllowed) {
+      return null; // Validation passed
     }
 
-    // Validation passed
-    return null;
+    // Express the limits in the fiat currency the user typed in, since the
+    // sats bounds mean nothing to most users. Fall back to sats when the range
+    // collapses below 1 fiat unit (no whole number would be enterable).
+    final fiatLimits = fiatAmountLimits(
+      minSats: minAllowed,
+      maxSats: maxAllowed,
+      exchangeRate: exchangeRate,
+    );
+
+    if (satsAmount < minAllowed) {
+      return fiatLimits.isDisplayable
+          ? S.of(context)!.fiatAmountTooLowRange(
+              fiatLimits.minFiat.toString(),
+              fiatLimits.maxFiat.toString(),
+              selectedFiatCode,
+            )
+          : S.of(context)!.fiatAmountTooLow(
+              minAllowed.toString(),
+              maxAllowed.toString(),
+            );
+    } else {
+      return fiatLimits.isDisplayable
+          ? S.of(context)!.fiatAmountTooHighRange(
+              fiatLimits.minFiat.toString(),
+              fiatLimits.maxFiat.toString(),
+              selectedFiatCode,
+            )
+          : S.of(context)!.fiatAmountTooHigh(
+              minAllowed.toString(),
+              maxAllowed.toString(),
+            );
+    }
   }
 
   /// Comprehensive validation for all fiat amount inputs

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -202,6 +202,8 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
               fiatLimits.minFiat.toString(),
               fiatLimits.maxFiat.toString(),
               selectedFiatCode,
+              minAllowed.toString(),
+              maxAllowed.toString(),
             )
           : S.of(context)!.fiatAmountTooLow(
               minAllowed.toString(),
@@ -213,6 +215,8 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
               fiatLimits.minFiat.toString(),
               fiatLimits.maxFiat.toString(),
               selectedFiatCode,
+              minAllowed.toString(),
+              maxAllowed.toString(),
             )
           : S.of(context)!.fiatAmountTooHigh(
               minAllowed.toString(),

--- a/lib/features/order/widgets/amount_section.dart
+++ b/lib/features/order/widgets/amount_section.dart
@@ -12,6 +12,11 @@ class AmountSection extends StatefulWidget {
   final String? validationError;
   final ValueChanged<bool>? onRangeModeChanged;
 
+  /// Currently selected fiat code, used to label the amount field
+  /// (e.g. "Enter the amount of USD you want to receive"). Null/empty falls
+  /// back to the generic word "fiat".
+  final String? fiatCode;
+
   const AmountSection({
     super.key,
     required this.orderType,
@@ -19,6 +24,7 @@ class AmountSection extends StatefulWidget {
     this.validateSatsRange,
     this.validationError,
     this.onRangeModeChanged,
+    this.fiatCode,
   });
 
   @override
@@ -107,9 +113,12 @@ class _AmountSectionState extends State<AmountSection> {
           ? S.of(context)!.creatingRangeOrderBuySend
           : S.of(context)!.creatingRangeOrder;
     }
+    final currency = (widget.fiatCode != null && widget.fiatCode!.isNotEmpty)
+        ? widget.fiatCode!
+        : 'fiat';
     return widget.orderType == OrderType.buy
-        ? S.of(context)!.enterAmountYouWantToSend
-        : S.of(context)!.enterAmountYouWantToReceive;
+        ? S.of(context)!.enterAmountYouWantToSendCurrency(currency)
+        : S.of(context)!.enterAmountYouWantToReceiveCurrency(currency);
   }
 
   Widget? _getTopRightWidget() {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -521,8 +521,24 @@
     },
     "exchangeRateNotAvailable": "Wechselkurs nicht verfügbar, bitte warten oder aktualisieren",
     "mostroInstanceNotAvailable": "Mostro-Instanzdaten nicht verfügbar, bitte warten",
-    "enterAmountYouWantToReceive": "Betrag eingeben, den du erhalten möchtest",
-    "enterAmountYouWantToSend": "Betrag eingeben, den du senden möchtest",
+    "enterAmountYouWantToReceiveCurrency": "Gib den Betrag in {currency} ein, den du erhalten möchtest",
+    "@enterAmountYouWantToReceiveCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
+    "enterAmountYouWantToSendCurrency": "Gib den Betrag in {currency} ein, den du senden möchtest",
+    "@enterAmountYouWantToSendCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
     "creatingRangeOrder": "Erstelle eine Range-Order (du kannst zwischen Minimum und Maximum wählen)",
     "creatingRangeOrderBuySend": "Erstelle eine Range-Order (du kannst zwischen Minimum und Maximum senden)",
     "rangeOrder": "Range-Order",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -469,7 +469,7 @@
             }
         }
     },
-    "fiatAmountTooLowRange": "Der Betrag ist zu niedrig. Dieser Mostro-Node erlaubt zwischen {minAmount} und {maxAmount} {fiatCode}.",
+    "fiatAmountTooLowRange": "Der Betrag ist zu niedrig. Dieser Mostro-Node erlaubt zwischen {minAmount} und {maxAmount} {fiatCode} ({minSats} - {maxSats} Sats).",
     "@fiatAmountTooLowRange": {
         "placeholders": {
             "minAmount": {
@@ -483,10 +483,18 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },
-    "fiatAmountTooHighRange": "Der Betrag ist zu hoch. Dieser Mostro-Node erlaubt zwischen {minAmount} und {maxAmount} {fiatCode}.",
+    "fiatAmountTooHighRange": "Der Betrag ist zu hoch. Dieser Mostro-Node erlaubt zwischen {minAmount} und {maxAmount} {fiatCode} ({minSats} - {maxSats} Sats).",
     "@fiatAmountTooHighRange": {
         "placeholders": {
             "minAmount": {
@@ -500,6 +508,14 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -469,6 +469,40 @@
             }
         }
     },
+    "fiatAmountTooLowRange": "Der Betrag ist zu niedrig. Dieser Mostro-Node erlaubt zwischen {minAmount} und {maxAmount} {fiatCode}.",
+    "@fiatAmountTooLowRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
+    "fiatAmountTooHighRange": "Der Betrag ist zu hoch. Dieser Mostro-Node erlaubt zwischen {minAmount} und {maxAmount} {fiatCode}.",
+    "@fiatAmountTooHighRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
     "exchangeRateNotAvailable": "Wechselkurs nicht verfügbar, bitte warten oder aktualisieren",
     "mostroInstanceNotAvailable": "Mostro-Instanzdaten nicht verfügbar, bitte warten",
     "enterAmountYouWantToReceive": "Betrag eingeben, den du erhalten möchtest",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -469,7 +469,7 @@
             }
         }
     },
-    "fiatAmountTooLowRange": "The amount is too low. This Mostro node allows between {minAmount} and {maxAmount} {fiatCode}.",
+    "fiatAmountTooLowRange": "The amount is too low. This Mostro node allows between {minAmount} and {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooLowRange": {
         "placeholders": {
             "minAmount": {
@@ -483,10 +483,18 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },
-    "fiatAmountTooHighRange": "The amount is too high. This Mostro node allows between {minAmount} and {maxAmount} {fiatCode}.",
+    "fiatAmountTooHighRange": "The amount is too high. This Mostro node allows between {minAmount} and {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooHighRange": {
         "placeholders": {
             "minAmount": {
@@ -500,6 +508,14 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -469,6 +469,40 @@
             }
         }
     },
+    "fiatAmountTooLowRange": "The amount is too low. This Mostro node allows between {minAmount} and {maxAmount} {fiatCode}.",
+    "@fiatAmountTooLowRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
+    "fiatAmountTooHighRange": "The amount is too high. This Mostro node allows between {minAmount} and {maxAmount} {fiatCode}.",
+    "@fiatAmountTooHighRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
     "exchangeRateNotAvailable": "Exchange rate not available, please wait or refresh",
     "mostroInstanceNotAvailable": "Mostro instance data not available, please wait",
     "enterAmountYouWantToReceive": "Enter amount you want to receive",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -521,8 +521,24 @@
     },
     "exchangeRateNotAvailable": "Exchange rate not available, please wait or refresh",
     "mostroInstanceNotAvailable": "Mostro instance data not available, please wait",
-    "enterAmountYouWantToReceive": "Enter amount you want to receive",
-    "enterAmountYouWantToSend": "Enter amount you want to send",
+    "enterAmountYouWantToReceiveCurrency": "Enter the amount of {currency} you want to receive",
+    "@enterAmountYouWantToReceiveCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
+    "enterAmountYouWantToSendCurrency": "Enter the amount of {currency} you want to send",
+    "@enterAmountYouWantToSendCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
     "creatingRangeOrder": "Creating a range order (you can receive between min and max amounts)",
     "creatingRangeOrderBuySend": "Creating a range order (you can send between min and max amounts)",
     "rangeOrder": "Range Order",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -433,8 +433,24 @@
     },
     "exchangeRateNotAvailable": "Tasa de cambio no disponible, por favor espera o actualiza",
     "mostroInstanceNotAvailable": "Datos de instancia Mostro no disponibles, por favor espera",
-    "enterAmountYouWantToReceive": "Ingresa la cantidad que quieres recibir",
-    "enterAmountYouWantToSend": "Ingresa la cantidad que quieres enviar",
+    "enterAmountYouWantToReceiveCurrency": "Ingresa la cantidad de {currency} que quieres recibir",
+    "@enterAmountYouWantToReceiveCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
+    "enterAmountYouWantToSendCurrency": "Ingresa la cantidad de {currency} que quieres enviar",
+    "@enterAmountYouWantToSendCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
     "creatingRangeOrder": "Creando orden de rango (puedes recibir entre cantidades mínima y máxima)",
     "creatingRangeOrderBuySend": "Creando orden de rango (puedes enviar entre cantidades mínima y máxima)",
     "rangeOrder": "Orden de Rango",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -381,7 +381,7 @@
             }
         }
     },
-    "fiatAmountTooLowRange": "La cantidad es demasiado baja. Este nodo de Mostro permite entre {minAmount} y {maxAmount} {fiatCode}.",
+    "fiatAmountTooLowRange": "La cantidad es demasiado baja. Este nodo de Mostro permite entre {minAmount} y {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooLowRange": {
         "placeholders": {
             "minAmount": {
@@ -395,10 +395,18 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },
-    "fiatAmountTooHighRange": "La cantidad es demasiado alta. Este nodo de Mostro permite entre {minAmount} y {maxAmount} {fiatCode}.",
+    "fiatAmountTooHighRange": "La cantidad es demasiado alta. Este nodo de Mostro permite entre {minAmount} y {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooHighRange": {
         "placeholders": {
             "minAmount": {
@@ -412,6 +420,14 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -381,6 +381,40 @@
             }
         }
     },
+    "fiatAmountTooLowRange": "La cantidad es demasiado baja. Este nodo de Mostro permite entre {minAmount} y {maxAmount} {fiatCode}.",
+    "@fiatAmountTooLowRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
+    "fiatAmountTooHighRange": "La cantidad es demasiado alta. Este nodo de Mostro permite entre {minAmount} y {maxAmount} {fiatCode}.",
+    "@fiatAmountTooHighRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
     "exchangeRateNotAvailable": "Tasa de cambio no disponible, por favor espera o actualiza",
     "mostroInstanceNotAvailable": "Datos de instancia Mostro no disponibles, por favor espera",
     "enterAmountYouWantToReceive": "Ingresa la cantidad que quieres recibir",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -469,6 +469,40 @@
             }
         }
     },
+    "fiatAmountTooLowRange": "Le montant est trop bas. Ce nœud Mostro permet entre {minAmount} et {maxAmount} {fiatCode}.",
+    "@fiatAmountTooLowRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
+    "fiatAmountTooHighRange": "Le montant est trop élevé. Ce nœud Mostro permet entre {minAmount} et {maxAmount} {fiatCode}.",
+    "@fiatAmountTooHighRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
     "exchangeRateNotAvailable": "Taux de change non disponible, veuillez attendre ou actualiser",
     "mostroInstanceNotAvailable": "Données de l'instance Mostro non disponibles, veuillez attendre",
     "enterAmountYouWantToReceive": "Entrez le montant que vous voulez recevoir",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -469,7 +469,7 @@
             }
         }
     },
-    "fiatAmountTooLowRange": "Le montant est trop bas. Ce nœud Mostro permet entre {minAmount} et {maxAmount} {fiatCode}.",
+    "fiatAmountTooLowRange": "Le montant est trop bas. Ce nœud Mostro permet entre {minAmount} et {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooLowRange": {
         "placeholders": {
             "minAmount": {
@@ -483,10 +483,18 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },
-    "fiatAmountTooHighRange": "Le montant est trop élevé. Ce nœud Mostro permet entre {minAmount} et {maxAmount} {fiatCode}.",
+    "fiatAmountTooHighRange": "Le montant est trop élevé. Ce nœud Mostro permet entre {minAmount} et {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooHighRange": {
         "placeholders": {
             "minAmount": {
@@ -500,6 +508,14 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -521,8 +521,24 @@
     },
     "exchangeRateNotAvailable": "Taux de change non disponible, veuillez attendre ou actualiser",
     "mostroInstanceNotAvailable": "Données de l'instance Mostro non disponibles, veuillez attendre",
-    "enterAmountYouWantToReceive": "Entrez le montant que vous voulez recevoir",
-    "enterAmountYouWantToSend": "Entrez le montant que vous voulez envoyer",
+    "enterAmountYouWantToReceiveCurrency": "Entrez le montant en {currency} que vous voulez recevoir",
+    "@enterAmountYouWantToReceiveCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
+    "enterAmountYouWantToSendCurrency": "Entrez le montant en {currency} que vous voulez envoyer",
+    "@enterAmountYouWantToSendCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
     "creatingRangeOrder": "Création d'une commande de plage (vous pouvez recevoir entre les montants min et max)",
     "creatingRangeOrderBuySend": "Création d'une commande de plage (vous pouvez envoyer entre les montants min et max)",
     "rangeOrder": "Commande de plage",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -463,8 +463,24 @@
     },
     "exchangeRateNotAvailable": "Tasso di cambio non disponibile, per favore attendi o aggiorna",
     "mostroInstanceNotAvailable": "Dati dell'istanza Mostro non disponibili, per favore attendi",
-    "enterAmountYouWantToReceive": "Inserisci l'importo che vuoi ricevere",
-    "enterAmountYouWantToSend": "Inserisci l'importo che vuoi inviare",
+    "enterAmountYouWantToReceiveCurrency": "Inserisci l'importo in {currency} che vuoi ricevere",
+    "@enterAmountYouWantToReceiveCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
+    "enterAmountYouWantToSendCurrency": "Inserisci l'importo in {currency} che vuoi inviare",
+    "@enterAmountYouWantToSendCurrency": {
+        "placeholders": {
+            "currency": {
+                "type": "String",
+                "description": "The selected fiat code, or \"fiat\" when none is selected"
+            }
+        }
+    },
     "creatingRangeOrder": "Creazione ordine intervallo (puoi ricevere tra importi minimo e massimo)",
     "creatingRangeOrderBuySend": "Creazione ordine intervallo (puoi inviare tra importi minimo e massimo)",
     "rangeOrder": "Ordine Intervallo",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -411,7 +411,7 @@
             }
         }
     },
-    "fiatAmountTooLowRange": "L'importo è troppo basso. Questo nodo Mostro consente tra {minAmount} e {maxAmount} {fiatCode}.",
+    "fiatAmountTooLowRange": "L'importo è troppo basso. Questo nodo Mostro consente tra {minAmount} e {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooLowRange": {
         "placeholders": {
             "minAmount": {
@@ -425,10 +425,18 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },
-    "fiatAmountTooHighRange": "L'importo è troppo alto. Questo nodo Mostro consente tra {minAmount} e {maxAmount} {fiatCode}.",
+    "fiatAmountTooHighRange": "L'importo è troppo alto. Questo nodo Mostro consente tra {minAmount} e {maxAmount} {fiatCode} ({minSats} - {maxSats} sats).",
     "@fiatAmountTooHighRange": {
         "placeholders": {
             "minAmount": {
@@ -442,6 +450,14 @@
             "fiatCode": {
                 "type": "String",
                 "description": "The selected fiat currency code"
+            },
+            "minSats": {
+                "type": "String",
+                "description": "The minimum allowed amount in sats"
+            },
+            "maxSats": {
+                "type": "String",
+                "description": "The maximum allowed amount in sats"
             }
         }
     },

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -411,6 +411,40 @@
             }
         }
     },
+    "fiatAmountTooLowRange": "L'importo è troppo basso. Questo nodo Mostro consente tra {minAmount} e {maxAmount} {fiatCode}.",
+    "@fiatAmountTooLowRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
+    "fiatAmountTooHighRange": "L'importo è troppo alto. Questo nodo Mostro consente tra {minAmount} e {maxAmount} {fiatCode}.",
+    "@fiatAmountTooHighRange": {
+        "placeholders": {
+            "minAmount": {
+                "type": "String",
+                "description": "The minimum allowed amount in fiat"
+            },
+            "maxAmount": {
+                "type": "String",
+                "description": "The maximum allowed amount in fiat"
+            },
+            "fiatCode": {
+                "type": "String",
+                "description": "The selected fiat currency code"
+            }
+        }
+    },
     "exchangeRateNotAvailable": "Tasso di cambio non disponibile, per favore attendi o aggiorna",
     "mostroInstanceNotAvailable": "Dati dell'istanza Mostro non disponibili, per favore attendi",
     "enterAmountYouWantToReceive": "Inserisci l'importo che vuoi ricevere",

--- a/lib/shared/utils/order_amount_limits.dart
+++ b/lib/shared/utils/order_amount_limits.dart
@@ -1,0 +1,39 @@
+import 'dart:math';
+
+/// Pure helpers to express a Mostro node's sats order limits in the fiat
+/// currency the user types in. The node enforces a hard min/max in sats, but
+/// the create-order field only accepts whole fiat numbers >= 1, so the sats
+/// bounds are converted back to fiat and rounded to the nearest *enterable and
+/// valid* integer.
+class FiatAmountLimits {
+  final int minFiat;
+  final int maxFiat;
+
+  const FiatAmountLimits({required this.minFiat, required this.maxFiat});
+
+  /// Whether the fiat range can be shown. False when the whole valid range
+  /// collapses below 1 unit of fiat (no whole number is enterable) or the rate
+  /// was unavailable; callers should then fall back to the raw sats limits.
+  bool get isDisplayable => minFiat >= 1 && maxFiat >= minFiat;
+}
+
+/// Sats per BTC.
+const int _satsPerBtc = 100000000;
+
+/// Converts the node's sats limits to displayable whole-fiat bounds using the
+/// current exchange rate (BTC price in the selected fiat). The minimum rounds
+/// up and the maximum rounds down, so every value in the shown range stays
+/// >= the real min and <= the real max. The minimum is floored at 1 because
+/// the field rejects 0 and decimals.
+FiatAmountLimits fiatAmountLimits({
+  required int minSats,
+  required int maxSats,
+  required double exchangeRate,
+}) {
+  if (exchangeRate <= 0) {
+    return const FiatAmountLimits(minFiat: 0, maxFiat: 0);
+  }
+  final minFiat = max(1, (minSats / _satsPerBtc * exchangeRate).ceil());
+  final maxFiat = (maxSats / _satsPerBtc * exchangeRate).floor();
+  return FiatAmountLimits(minFiat: minFiat, maxFiat: maxFiat);
+}

--- a/test/shared/utils/order_amount_limits_test.dart
+++ b/test/shared/utils/order_amount_limits_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/shared/utils/order_amount_limits.dart';
+
+void main() {
+  group('fiatAmountLimits', () {
+    test('rounds min up and max down to whole, valid fiat bounds', () {
+      // 1 BTC = 100,000 USD. min 100 sats -> 0.10 USD, max 1,000,000 sats -> 1000 USD.
+      final limits = fiatAmountLimits(
+        minSats: 100,
+        maxSats: 1000000,
+        exchangeRate: 100000,
+      );
+      // 0.10 ceils to 1 (floored at 1), 1000 stays 1000.
+      expect(limits.minFiat, 1);
+      expect(limits.maxFiat, 1000);
+      expect(limits.isDisplayable, isTrue);
+    });
+
+    test('floors the minimum at 1 when the converted value is below 1', () {
+      // min converts to 0.5 -> shown as 1 (field rejects decimals and < 1).
+      final limits = fiatAmountLimits(
+        minSats: 50,
+        maxSats: 1000000,
+        exchangeRate: 100000,
+      );
+      expect(limits.minFiat, 1);
+    });
+
+    test('rounds a fractional minimum up to the next whole number', () {
+      // 1 BTC = 30,000,000 CUP. min 100 sats -> 30 CUP, max 1,000,000 -> 300,000.
+      final limits = fiatAmountLimits(
+        minSats: 100,
+        maxSats: 1000000,
+        exchangeRate: 30000000,
+      );
+      expect(limits.minFiat, 30);
+      expect(limits.maxFiat, 300000);
+      expect(limits.isDisplayable, isTrue);
+    });
+
+    test('ceils a non-integer minimum so the shown value is still valid', () {
+      // min converts to 30.6 -> 31 (30 would be below the real limit).
+      final limits = fiatAmountLimits(
+        minSats: 102,
+        maxSats: 1000000,
+        exchangeRate: 30000000,
+      );
+      expect(limits.minFiat, 31);
+    });
+
+    test('is not displayable when the whole range collapses below 1 fiat', () {
+      // Extremely high BTC/fiat parity: max 1,000,000 sats -> 0.5 fiat -> floor 0.
+      final limits = fiatAmountLimits(
+        minSats: 100,
+        maxSats: 1000000,
+        exchangeRate: 50,
+      );
+      expect(limits.maxFiat, 0);
+      expect(limits.isDisplayable, isFalse);
+    });
+
+    test('returns zeros and is not displayable for a non-positive rate', () {
+      final limits = fiatAmountLimits(
+        minSats: 100,
+        maxSats: 1000000,
+        exchangeRate: 0,
+      );
+      expect(limits.minFiat, 0);
+      expect(limits.maxFiat, 0);
+      expect(limits.isDisplayable, isFalse);
+    });
+  });
+}

--- a/test/shared/utils/order_amount_limits_test.dart
+++ b/test/shared/utils/order_amount_limits_test.dart
@@ -17,7 +17,7 @@ void main() {
     });
 
     test('floors the minimum at 1 when the converted value is below 1', () {
-      // min converts to 0.5 -> shown as 1 (field rejects decimals and < 1).
+      // min converts to 0.05 -> shown as 1 (field rejects decimals and < 1).
       final limits = fiatAmountLimits(
         minSats: 50,
         maxSats: 1000000,


### PR DESCRIPTION
The range error now shows the limits in the fiat currency the user typed, with the sats range in parentheses.

  Before: "...allows between 100 and 1000000 sats."
  After: "...allows between 1 and 734 USD (100 - 1000000 sats)."

  - Pure `fiatAmountLimits` helper reuses the already-loaded rate (no extra calls)
  - Min rounds up, max rounds down, floored at 1 (field is integer-only)
  - Falls back to the sats message when the range collapses below 1 fiat
  - Localized in en/es/it/de/fr + helper unit tests
<img width="561" height="732" alt="image" src="https://github.com/user-attachments/assets/98db66a9-8861-4fd0-9e56-31f85e92ce15" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order amount validation now shows range-aware error messages including both fiat and satoshi limits.
  * Amount input now displays the selected fiat currency in prompts and labels.
* **Localization**
  * Added range-based fiat validation messages and updated currency-specific prompt strings for EN/DE/ES/FR/IT.
* **Tests**
  * Added tests verifying fiat conversion, rounding, clamping and displayability logic for order amount limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mobile/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->