### PR TITLE
feat: add mostro-p2p.tech as fallback default relay

### DIFF
--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -5,6 +5,7 @@ class Config {
   // Nostr configuration
   static const List<String> nostrRelays = [
     'wss://relay.mostro.network',
+    'wss://mostro-p2p.tech',
     //'ws://127.0.0.1:7000',
     //'ws://192.168.1.103:7000',
     //'ws://10.0.2.2:7000', // mobile emulator

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -62,8 +62,10 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     }
 
     // Load Mostro relays from settings.relays (excluding defaults to avoid duplicates)
+    final normalizedDefaults =
+        Config.nostrRelays.map(_normalizeRelayUrl).toSet();
     final relaysFromSettings = saved.relays
-        .where((url) => !Config.nostrRelays.contains(_normalizeRelayUrl(url)))
+        .where((url) => !normalizedDefaults.contains(_normalizeRelayUrl(url)))
         .map((url) => Relay.fromMostro(url))
         .toList();
     loadedRelays.addAll(relaysFromSettings);

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:dart_nostr/nostr/model/ease.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/core/models/relay_list_event.dart';
 import 'package:mostro_mobile/features/settings/settings_notifier.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
@@ -55,13 +56,14 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     
     final loadedRelays = <Relay>[];
     
-    // Always ensure default relay exists for initial connection
-    final defaultRelay = Relay.fromDefault('wss://relay.mostro.network');
-    loadedRelays.add(defaultRelay);
-    
-    // Load Mostro relays from settings.relays (excluding default to avoid duplicates)
+    // Always ensure default relays exist for initial connection
+    for (final url in Config.nostrRelays) {
+      loadedRelays.add(Relay.fromDefault(url));
+    }
+
+    // Load Mostro relays from settings.relays (excluding defaults to avoid duplicates)
     final relaysFromSettings = saved.relays
-        .where((url) => url != 'wss://relay.mostro.network') // Avoid duplicates
+        .where((url) => !Config.nostrRelays.contains(_normalizeRelayUrl(url)))
         .map((url) => Relay.fromMostro(url))
         .toList();
     loadedRelays.addAll(relaysFromSettings);
@@ -692,12 +694,11 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     try {
       logger.i('Cleaning all relays and performing fresh sync...');
       
-      // CLEAR ALL relays (only keep default)
-      final defaultRelay = Relay.fromDefault('wss://relay.mostro.network');
-      state = [defaultRelay];
+      // CLEAR ALL relays (only keep defaults)
+      state = Config.nostrRelays.map(Relay.fromDefault).toList();
       await _saveRelays();
-      
-      logger.i('Reset to default relay only, starting fresh sync');
+
+      logger.i('Reset to default relays only, starting fresh sync');
       
       // Reset hash and timestamp for completely fresh sync with new Mostro
       _lastRelayListHash = null;


### PR DESCRIPTION
When relay.mostro.network is unreachable, clients have no fallback and all communication with any Mostro instance breaks. Adding mostro-p2p.tech as a second default relay ensures connectivity is maintained when the primary relay has an outage.

Also refactors RelaysNotifier to derive default relay seeds from Config.nostrRelays instead of a hardcoded single URL, so future additions only require updating Config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional Nostr relay endpoint to the app's default configuration.
  * Relay reset now restores the full set of configured default relays instead of a single relay.
  * Relay loading and syncing improved to pre-populate from configured defaults and avoid creating duplicate relay entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->