### PR TITLE
feat(relays): bootstrap relay discovery instead of pinned default relays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ When implementing or debugging protocol-related features (order flows, actions, 
 - **Source Tracking**: Relays tagged by source (user, mostro, default) for appropriate handling and storage strategy
 - **Smart Re-enablement**: Manual relay addition automatically removes from blacklist, Mostro relay re-activation removes from blacklist during sync
 - **URL Normalization**: All relay URLs normalized by removing trailing slashes to ensure consistent matching
+- **Bootstrap Discovery Layer**: Hardcoded relays are NOT seeded into the visible list; `Config.bootstrapRelays` are defensive connections used only to discover a Mostro's kind 10002 (cold start via `NostrService.init` fail-safe, all-down via `RelayHealthMonitor` watchdog, instance switch via `ensureBootstrapConnectivity()`). Engaged additively (never `disconnectFromRelays()`); retirement is logical only since dart_nostr has no per-relay disconnect. See `docs/architecture/RELAY_SYNC_IMPLEMENTATION.md` ("Bootstrap Relay Discovery Layer")
 - **Implementation**: Located in `features/relays/` with core logic in `RelaysNotifier`
 
 #### Manual Relay Addition

--- a/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
+++ b/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
@@ -45,6 +45,37 @@ The system handles NIP-65 relay list events (kind 10002), implements dual storag
 
 ---
 
+## Bootstrap Relay Discovery Layer
+
+The app does not seed hardcoded "default" relays into the user-visible relay list. Instead, a small set of **defensive bootstrap relays** (`Config.bootstrapRelays`) is used only to discover a Mostro instance's kind 10002 relay list. Once discovered, the app operates exclusively over the discovered relays; the bootstrap relays are never persisted nor shown.
+
+### Design
+
+- **Bootstrap relays live only at the NostrService connection level**, never in `RelaysNotifier` state or `settings.relays`. The visible list and `settings.relays` always contain only discovered (Mostro) relays plus user relays. This keeps the user-facing relay list equal to what the Mostro instance actually endorses, instead of pinning hardcoded relays the instance may not use.
+- **Engaged only when needed**, via additive init (never disconnect):
+  - **Cold start**: when `settings.relays` is empty, `NostrService.init()` falls back to `Config.bootstrapRelays` so the kind 10002 can be fetched.
+  - **All-down**: `RelayHealthMonitor` (a periodic watchdog, `Config.relayDiscoveryTimeout` interval) detects `liveRelayCount == 0` and calls `ensureBootstrapConnectivity()` + `subscribeAll()` + re-subscribes the kind 10002.
+  - **Instance switch**: `_cleanAllRelaysAndResync()` clears the list and calls `ensureBootstrapConnectivity()` so the new instance's kind 10002 can be fetched (the previous instance's relays may not carry it).
+- **Logical retirement**: once discovered relays are connected and `settings.relays` points only to them, bootstrap relays are no longer targeted. dart_nostr has **no per-relay disconnect** (`disconnectFromRelays()` closes all), so bootstrap sockets stay idle until the app closes rather than being individually closed.
+
+### Safety invariants (no event loss)
+
+1. **Never `disconnectFromRelays()`** — only additive init. This makes it impossible to drop existing connections/subscriptions (the cause of the historical subscription-loss bug; see `SUBSCRIPTION_LOSS_BUG.md`).
+2. **Watchdog floor** — when no relay is alive, bootstrap is engaged and subscriptions re-issued via the proven `subscribeAll()` path.
+3. **Fail-safe toward connecting** — a false positive only costs an idle socket, never silence.
+
+### Liveness signal
+
+`NostrService` tracks alive relays in `_connectedRelays` from the relay connection callbacks: a relay is added on `onRelayListening` (data received proves it alive) and removed on `onRelayConnectionError`/`onRelayConnectionDone` (error or socket close). Exposed via `liveRelayCount` and `connectedRelays`. The dart_nostr registry is not used for this because it is not pruned on disconnect.
+
+### Restart behavior
+
+Discovered relays persist in `settings.relays` and reload immediately, so normal launches connect only to discovered relays and never touch bootstrap. The kind 10002 still re-syncs over the discovered relays each launch (staying current with operator changes). Bootstrap is engaged again only on cold start or when every discovered relay is unreachable.
+
+**Key files**: `Config.bootstrapRelays` / `Config.relayDiscoveryTimeout` (`lib/core/config.dart`), `NostrService.ensureBootstrapConnectivity()` + init fail-safe + liveness tracking (`lib/services/nostr_service.dart`), `RelayHealthMonitor` (`lib/features/relays/relay_health_monitor.dart`).
+
+---
+
 ## System Architecture Overview
 
 ### Core Architectural Principles

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -10,6 +10,16 @@ class Config {
     //'ws://10.0.2.2:7000', // mobile emulator
   ];
 
+  // Defensive bootstrap relays: connected only to discover a Mostro's kind
+  // 10002 relay list at cold start or when no discovered relay is reachable.
+  // Not persisted nor shown in the relay list; they idle once relays are found.
+  static const List<String> bootstrapRelays = [
+    'wss://relay.mostro.network',
+    'wss://mostro-p2p.tech',
+    'wss://nos.lol',
+    'wss://relay.damus.io',
+  ];
+
   // Derived from trustedCommunities to maintain single source of truth
   static final List<Map<String, String>> trustedMostroNodes =
       trustedCommunities
@@ -33,6 +43,9 @@ class Config {
 
   // Timeout for relay operations (EOSE responses, publish OK)
   static const Duration nostrOperationTimeout = Duration(seconds: 20);
+
+  // Grace period for discovered relays to connect before engaging bootstrap.
+  static const Duration relayDiscoveryTimeout = Duration(seconds: 6);
 
   static bool fullPrivacyMode = false;
 

--- a/lib/features/relays/relay_health_monitor.dart
+++ b/lib/features/relays/relay_health_monitor.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
@@ -26,6 +27,11 @@ class RelayHealthMonitor {
     _timer = Timer.periodic(Config.relayDiscoveryTimeout, (_) => _check());
     ref.onDispose(() => _timer?.cancel());
   }
+
+  /// Runs a single health check synchronously. Exposed for tests so the
+  /// periodic timer does not need to be awaited.
+  @visibleForTesting
+  Future<void> checkNow() => _check();
 
   Future<void> _check() async {
     if (_recovering) return;

--- a/lib/features/relays/relay_health_monitor.dart
+++ b/lib/features/relays/relay_health_monitor.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/core/config.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/services/logger_service.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+
+/// Safety net for relay connectivity.
+///
+/// Periodically checks whether any relay is alive. When none are (cold start
+/// where discovered relays never connect, or every discovered relay dropped at
+/// runtime), it engages the defensive bootstrap relays and re-establishes the
+/// subscriptions so the app keeps receiving events.
+///
+/// All recovery is additive (it never disconnects), reusing the proven
+/// `subscribeAll()` path. Engaging bootstrap on a false positive only costs an
+/// idle socket, so the check is intentionally biased toward acting.
+class RelayHealthMonitor {
+  final Ref ref;
+  Timer? _timer;
+  bool _recovering = false;
+
+  RelayHealthMonitor(this.ref) {
+    _timer = Timer.periodic(Config.relayDiscoveryTimeout, (_) => _check());
+    ref.onDispose(() => _timer?.cancel());
+  }
+
+  Future<void> _check() async {
+    if (_recovering) return;
+
+    final nostrService = ref.read(nostrServiceProvider);
+    if (!nostrService.isInitialized) return;
+    if (nostrService.liveRelayCount > 0) return;
+
+    _recovering = true;
+    try {
+      logger.w('No live relays detected; engaging bootstrap relays');
+      await nostrService.ensureBootstrapConnectivity();
+
+      // Re-issue subscriptions so they reach the newly connected relays
+      // (additive init does not replay REQs to relays added afterwards).
+      final subscriptionManager = ref.read(subscriptionManagerProvider);
+      subscriptionManager.subscribeAll();
+
+      // Re-establish relay-list discovery so the app can recover its relays.
+      final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
+      if (mostroPubkey.isNotEmpty) {
+        subscriptionManager.subscribeToMostroRelayList(mostroPubkey);
+      }
+    } catch (e, stackTrace) {
+      logger.e('Relay health recovery failed',
+          error: e, stackTrace: stackTrace);
+    } finally {
+      _recovering = false;
+    }
+  }
+}
+
+final relayHealthMonitorProvider = Provider<RelayHealthMonitor>(
+  (ref) => RelayHealthMonitor(ref),
+);

--- a/lib/features/relays/relay_health_monitor.dart
+++ b/lib/features/relays/relay_health_monitor.dart
@@ -38,11 +38,19 @@ class RelayHealthMonitor {
 
     final nostrService = ref.read(nostrServiceProvider);
     if (!nostrService.isInitialized) return;
-    if (nostrService.liveRelayCount > 0) return;
+
+    // Only relays from the operating set (discovered + user, which never
+    // includes bootstrap) count as healthy. A live bootstrap-only socket must
+    // not mask a dead discovered-relay layer, otherwise recovery would stop
+    // while the app is surviving on bootstrap connectivity alone.
+    final operatingRelays = ref.read(settingsProvider).relays.toSet();
+    final hasLiveOperatingRelay =
+        nostrService.connectedRelays.any(operatingRelays.contains);
+    if (hasLiveOperatingRelay) return;
 
     _recovering = true;
     try {
-      logger.w('No live relays detected; engaging bootstrap relays');
+      logger.w('No live operating relay; engaging bootstrap relays');
       await nostrService.ensureBootstrapConnectivity();
 
       // Re-issue subscriptions so they reach the newly connected relays

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:dart_nostr/nostr/model/ease.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/core/models/relay_list_event.dart';
 import 'package:mostro_mobile/features/settings/settings_notifier.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
@@ -552,7 +553,21 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
           .whereType<String>()  // Filter out any null results
           .toSet() // Remove duplicates
           .toList();
-      
+
+      // Discovery + logical-retirement logging: discovered relays now drive the
+      // app; bootstrap relays absent from the 10002 stay connected but idle
+      // (NostrService has no per-relay disconnect, so this is logical only).
+      logger.i('Discovered ${normalizedRelays.length} relays from Mostro 10002: '
+          '$normalizedRelays');
+      final normalizedBootstrap =
+          Config.bootstrapRelays.map(_normalizeRelayUrl).toSet();
+      final retiredBootstrap =
+          normalizedBootstrap.where((b) => !normalizedRelays.contains(b)).toList();
+      if (retiredBootstrap.isNotEmpty) {
+        logger.i('Bootstrap relays not in 10002 are now idle '
+            '(logical retirement, not disconnected): $retiredBootstrap');
+      }
+
       // Get blacklisted relays from settings and normalize them for consistent matching
       final blacklistedUrls = settings.state.blacklistedRelays
           .map((url) => _normalizeRelayUrl(url))

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -54,14 +54,11 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     logger.i('Loading user relays from settings: ${saved.userRelays}');
     
     final loadedRelays = <Relay>[];
-    
-    // Always ensure default relay exists for initial connection
-    final defaultRelay = Relay.fromDefault('wss://relay.mostro.network');
-    loadedRelays.add(defaultRelay);
-    
-    // Load Mostro relays from settings.relays (excluding default to avoid duplicates)
+
+    // Load discovered Mostro relays from settings.relays. Bootstrap relays are
+    // never seeded into the list; NostrService connects to them defensively
+    // (cold start / all discovered down) without exposing them here.
     final relaysFromSettings = saved.relays
-        .where((url) => url != 'wss://relay.mostro.network') // Avoid duplicates
         .map((url) => Relay.fromMostro(url))
         .toList();
     loadedRelays.addAll(relaysFromSettings);
@@ -687,25 +684,29 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     });
   }
 
-  /// Clean all relays (except default) and perform fresh sync with new Mostro
+  /// Clean all relays and perform fresh sync with new Mostro
   Future<void> _cleanAllRelaysAndResync() async {
     try {
       logger.i('Cleaning all relays and performing fresh sync...');
-      
-      // CLEAR ALL relays (only keep default)
-      final defaultRelay = Relay.fromDefault('wss://relay.mostro.network');
-      state = [defaultRelay];
+
+      // Clear the whole list. Bootstrap relays (NostrService level) keep
+      // connectivity while the new instance's relay list is discovered.
+      state = [];
       await _saveRelays();
-      
-      logger.i('Reset to default relay only, starting fresh sync');
-      
+
+      // Ensure bootstrap connectivity so the new instance's kind 10002 can be
+      // fetched: the previous instance's relays may not carry it.
+      await ref.read(nostrServiceProvider).ensureBootstrapConnectivity();
+
+      logger.i('Reset relays, starting fresh sync');
+
       // Reset hash and timestamp for completely fresh sync with new Mostro
       _lastRelayListHash = null;
       _lastProcessedEventTime = null;
-      
+
       // Start completely fresh sync with new Mostro
       await syncWithMostroInstance();
-      
+
     } catch (e, stackTrace) {
       logger.e('Error during relay cleanup and resync',
           error: e, stackTrace: stackTrace);

--- a/lib/features/relays/widgets/relay_selector.dart
+++ b/lib/features/relays/widgets/relay_selector.dart
@@ -247,10 +247,9 @@ class RelaySelector extends ConsumerWidget {
   /// Handle relay toggle with safety checks and confirmation dialogs
   Future<void> _handleRelayToggle(BuildContext context, WidgetRef ref, MostroRelayInfo relayInfo) async {
     final isCurrentlyBlacklisted = !relayInfo.isActive;
-    final isDefaultMostroRelay = relayInfo.url.startsWith('wss://relay.mostro.network');
     final relaysNotifier = ref.read(relaysProvider.notifier);
-    
-    // Detect relay type (user vs mostro/default)
+
+    // Detect relay type (user vs mostro)
     final currentRelays = ref.read(relaysProvider);
     final relay = currentRelays.firstWhere(
       (r) => r.url == relayInfo.url, 
@@ -298,47 +297,8 @@ class RelaySelector extends ConsumerWidget {
     if (isUserRelay) {
       // User relay: Delete completely (no blacklisting needed)
       await relaysNotifier.removeRelay(relayInfo.url);
-    } else if (isDefaultMostroRelay) {
-      // Default relay: Show confirmation dialog before blacklisting
-      final shouldProceed = await showDialog<bool>(
-        context: context,
-        builder: (BuildContext context) {
-          return AlertDialog(
-            backgroundColor: AppTheme.dark2,
-            title: Text(
-              S.of(context)!.blacklistDefaultRelayTitle,
-              style: const TextStyle(color: AppTheme.cream1),
-            ),
-            content: Text(
-              S.of(context)!.blacklistDefaultRelayMessage,
-              style: const TextStyle(color: AppTheme.textSecondary),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(false),
-                child: Text(
-                  S.of(context)!.blacklistDefaultRelayCancel,
-                  style: const TextStyle(color: AppTheme.textSecondary),
-                ),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(true),
-                child: Text(
-                  S.of(context)!.blacklistDefaultRelayConfirm,
-                  style: const TextStyle(color: Colors.red),
-                ),
-              ),
-            ],
-          );
-        },
-      );
-      
-      // Proceed only if user confirmed
-      if (shouldProceed == true) {
-        await relaysNotifier.toggleMostroRelayBlacklist(relayInfo.url);
-      }
     } else {
-      // Regular Mostro relay - proceed directly with blacklisting
+      // Mostro relay: blacklist it directly
       await relaysNotifier.toggleMostroRelayBlacklist(relayInfo.url);
     }
   }

--- a/lib/features/settings/settings_notifier.dart
+++ b/lib/features/settings/settings_notifier.dart
@@ -27,7 +27,10 @@ class SettingsNotifier extends StateNotifier<Settings> {
 
   static Settings _defaultSettings() {
     return Settings(
-      relays: Config.nostrRelays,
+      // No relays are seeded: the active list holds only relays discovered from
+      // the Mostro kind 10002 plus user relays. On a fresh install this is empty
+      // and NostrService connects to the bootstrap relays to discover them.
+      relays: const [],
       fullPrivacyMode: Config.fullPrivacyMode,
       mostroPublicKey: Config.mostroPubKey,
       selectedLanguage: null,

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -17,6 +17,10 @@ class NostrService {
 
   bool _isInitialized = false;
 
+  /// Relays from which we have received data (proven alive). Maintained from
+  /// the relay connection callbacks; used to detect "no live relay" situations.
+  final Set<String> _connectedRelays = {};
+
   NostrService();
 
   /// Safe getter for settings with fallback
@@ -24,23 +28,38 @@ class NostrService {
       _settings ??
       Settings(relays: [], fullPrivacyMode: false, mostroPublicKey: '');
 
+  /// Relays currently considered alive (have sent us data since connecting).
+  Set<String> get connectedRelays => Set.unmodifiable(_connectedRelays);
+
+  /// Number of relays currently considered alive.
+  int get liveRelayCount => _connectedRelays.length;
+
   Future<void> init(Settings settings) async {
-    // Validate settings before initialization
-    if (settings.relays.isEmpty) {
-      throw Exception('Cannot initialize NostrService: No relays provided');
+    // Fail-safe: with no relays configured (e.g. cold start before any kind
+    // 10002 discovery) connect to the defensive bootstrap relays instead of
+    // failing, so the app can still discover the Mostro's relay list.
+    var effectiveSettings = settings;
+    if (effectiveSettings.relays.isEmpty) {
+      logger.w(
+        'No relays configured; falling back to bootstrap relays for discovery',
+      );
+      effectiveSettings = settings.copyWith(relays: Config.bootstrapRelays);
     }
 
-    logger.i('Initializing NostrService with relays: ${settings.relays}');
-    _settings = settings;
+    logger.i(
+        'Initializing NostrService with relays: ${effectiveSettings.relays}');
+    _settings = effectiveSettings;
 
     try {
       await _nostr.services.relays.init(
-        relaysUrl: settings.relays,
+        relaysUrl: effectiveSettings.relays,
         connectionTimeout: Config.relayConnectionTimeout,
         shouldReconnectToRelayOnNotice: true,
         retryOnClose: true,
         retryOnError: true,
         onRelayListening: (relayUrl, receivedData, channel) {
+          // Any data from a relay proves it is alive.
+          _connectedRelays.add(relayUrl);
           if (receivedData is NostrEvent) {
             logger.d('Event from $relayUrl: ${receivedData.id}');
           } else if (receivedData is NostrNotice) {
@@ -58,16 +77,19 @@ class NostrService {
           }
         },
         onRelayConnectionError: (relay, error, channel) {
+          _connectedRelays.remove(relay);
           logger.w('Failed to connect to relay $relay: $error');
         },
         onRelayConnectionDone: (relay, socket) {
-          logger.i('Successfully connected to relay: $relay');
+          // Fired when the relay websocket is closed (disconnected).
+          _connectedRelays.remove(relay);
+          logger.i('Relay disconnected (socket closed): $relay');
         },
       );
 
       _isInitialized = true;
       logger.i(
-        'NostrService initialized successfully with ${settings.relays.length} relays',
+        'NostrService initialized successfully with ${effectiveSettings.relays.length} relays',
       );
     } catch (e) {
       _isInitialized = false;
@@ -188,6 +210,25 @@ class NostrService {
     await _nostr.services.relays.disconnectFromRelays();
     _isInitialized = false;
     logger.i('Disconnected from all relays');
+  }
+
+  /// Connects the defensive bootstrap relays without dropping any existing
+  /// connection (additive init). Idempotent: returns early when they are
+  /// already part of the active relay set. Used as a fallback to keep relay
+  /// discovery possible when no discovered relay is reachable.
+  Future<void> ensureBootstrapConnectivity() async {
+    final current = settings.relays;
+    final merged = {...current, ...Config.bootstrapRelays}.toList();
+
+    if (ListEquality().equals(current, merged)) {
+      logger.d('Bootstrap relays already part of the active relay set');
+      return;
+    }
+
+    logger.i(
+      'Bootstrap: connecting to defensive relays: ${Config.bootstrapRelays}',
+    );
+    await updateSettings(settings.copyWith(relays: merged));
   }
 
   bool get isInitialized => _isInitialized;

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter/foundation.dart';
 import 'package:dart_nostr/nostr/model/ease.dart';
 import 'package:dart_nostr/nostr/model/ok.dart';
 import 'package:dart_nostr/nostr/model/relay_informations.dart';
@@ -34,17 +35,21 @@ class NostrService {
   /// Number of relays currently considered alive.
   int get liveRelayCount => _connectedRelays.length;
 
+  /// Relays to connect to: the configured relays, or the defensive bootstrap
+  /// relays as a fail-safe when none are configured (cold start before any kind
+  /// 10002 discovery), so init never fails on an empty list.
+  @visibleForTesting
+  static List<String> effectiveRelays(List<String> configured) =>
+      configured.isEmpty ? Config.bootstrapRelays : configured;
+
   Future<void> init(Settings settings) async {
-    // Fail-safe: with no relays configured (e.g. cold start before any kind
-    // 10002 discovery) connect to the defensive bootstrap relays instead of
-    // failing, so the app can still discover the Mostro's relay list.
-    var effectiveSettings = settings;
-    if (effectiveSettings.relays.isEmpty) {
+    final relays = effectiveRelays(settings.relays);
+    if (settings.relays.isEmpty) {
       logger.w(
         'No relays configured; falling back to bootstrap relays for discovery',
       );
-      effectiveSettings = settings.copyWith(relays: Config.bootstrapRelays);
     }
+    final effectiveSettings = settings.copyWith(relays: relays);
 
     logger.i(
         'Initializing NostrService with relays: ${effectiveSettings.relays}');

--- a/lib/shared/providers/app_init_provider.dart
+++ b/lib/shared/providers/app_init_provider.dart
@@ -5,6 +5,7 @@ import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
 import 'package:mostro_mobile/features/mostro/mostro_nodes_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/relays/relay_health_monitor.dart';
 import 'package:mostro_mobile/features/restore/restore_manager.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
@@ -36,6 +37,10 @@ final appInitializerProvider = FutureProvider<void>((ref) async {
   await sessionManager.init();
   
   ref.read(subscriptionManagerProvider);
+
+  // Start the relay health watchdog: re-engages bootstrap relays and
+  // re-subscribes if no relay is alive (cold start or all discovered down).
+  ref.read(relayHealthMonitorProvider);
 
   ref.listen<Settings>(settingsProvider, (previous, next) {
     ref.read(backgroundServiceProvider).updateSettings(next);

--- a/test/features/relays/relay_health_monitor_test.dart
+++ b/test/features/relays/relay_health_monitor_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/features/relays/relay_health_monitor.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+
+import '../../mocks.mocks.dart';
+
+/// Settings notifier with a fixed Mostro pubkey for tests.
+class _FixedSettingsNotifier extends SettingsNotifier {
+  _FixedSettingsNotifier(String pubkey) : super(MockSharedPreferencesAsync()) {
+    state = Settings(
+      relays: const [],
+      fullPrivacyMode: false,
+      mostroPublicKey: pubkey,
+    );
+  }
+}
+
+void main() {
+  late MockNostrService nostrService;
+  late MockSubscriptionManagerSpy subscriptionManager;
+
+  setUp(() {
+    nostrService = MockNostrService();
+    subscriptionManager = MockSubscriptionManagerSpy();
+    when(nostrService.ensureBootstrapConnectivity())
+        .thenAnswer((_) async {});
+  });
+
+  ProviderContainer buildContainer({String pubkey = 'test'}) {
+    final container = ProviderContainer(overrides: [
+      nostrServiceProvider.overrideWithValue(nostrService),
+      subscriptionManagerProvider.overrideWithValue(subscriptionManager),
+      settingsProvider.overrideWith((ref) => _FixedSettingsNotifier(pubkey)),
+    ]);
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('RelayHealthMonitor', () {
+    test('engages bootstrap and re-subscribes when no relay is alive',
+        () async {
+      when(nostrService.isInitialized).thenReturn(true);
+      when(nostrService.liveRelayCount).thenReturn(0);
+
+      final monitor =
+          buildContainer().read(relayHealthMonitorProvider);
+      await monitor.checkNow();
+
+      verify(nostrService.ensureBootstrapConnectivity()).called(1);
+      verify(subscriptionManager.subscribeAll()).called(1);
+      verify(subscriptionManager.subscribeToMostroRelayList('test')).called(1);
+    });
+
+    test('does nothing while at least one relay is alive', () async {
+      when(nostrService.isInitialized).thenReturn(true);
+      when(nostrService.liveRelayCount).thenReturn(2);
+
+      final monitor =
+          buildContainer().read(relayHealthMonitorProvider);
+      await monitor.checkNow();
+
+      verifyNever(nostrService.ensureBootstrapConnectivity());
+      verifyNever(subscriptionManager.subscribeAll());
+    });
+
+    test('does nothing before NostrService is initialized', () async {
+      when(nostrService.isInitialized).thenReturn(false);
+      when(nostrService.liveRelayCount).thenReturn(0);
+
+      final monitor =
+          buildContainer().read(relayHealthMonitorProvider);
+      await monitor.checkNow();
+
+      verifyNever(nostrService.ensureBootstrapConnectivity());
+      verifyNever(subscriptionManager.subscribeAll());
+    });
+
+    test('skips relay-list re-subscription when no Mostro is configured',
+        () async {
+      when(nostrService.isInitialized).thenReturn(true);
+      when(nostrService.liveRelayCount).thenReturn(0);
+
+      final monitor =
+          buildContainer(pubkey: '').read(relayHealthMonitorProvider);
+      await monitor.checkNow();
+
+      verify(nostrService.ensureBootstrapConnectivity()).called(1);
+      verify(subscriptionManager.subscribeAll()).called(1);
+      verifyNever(subscriptionManager.subscribeToMostroRelayList(any));
+    });
+  });
+}

--- a/test/features/relays/relay_health_monitor_test.dart
+++ b/test/features/relays/relay_health_monitor_test.dart
@@ -10,11 +10,14 @@ import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 
 import '../../mocks.mocks.dart';
 
-/// Settings notifier with a fixed Mostro pubkey for tests.
+/// Settings notifier with a fixed Mostro pubkey and operating relay list.
 class _FixedSettingsNotifier extends SettingsNotifier {
-  _FixedSettingsNotifier(String pubkey) : super(MockSharedPreferencesAsync()) {
+  _FixedSettingsNotifier({
+    String pubkey = 'test',
+    List<String> relays = const [],
+  }) : super(MockSharedPreferencesAsync()) {
     state = Settings(
-      relays: const [],
+      relays: relays,
       fullPrivacyMode: false,
       mostroPublicKey: pubkey,
     );
@@ -28,28 +31,33 @@ void main() {
   setUp(() {
     nostrService = MockNostrService();
     subscriptionManager = MockSubscriptionManagerSpy();
-    when(nostrService.ensureBootstrapConnectivity())
-        .thenAnswer((_) async {});
+    when(nostrService.ensureBootstrapConnectivity()).thenAnswer((_) async {});
+    when(nostrService.isInitialized).thenReturn(true);
+    when(nostrService.connectedRelays).thenReturn(<String>{});
   });
 
-  ProviderContainer buildContainer({String pubkey = 'test'}) {
+  ProviderContainer buildContainer({
+    String pubkey = 'test',
+    List<String> relays = const [],
+  }) {
     final container = ProviderContainer(overrides: [
       nostrServiceProvider.overrideWithValue(nostrService),
       subscriptionManagerProvider.overrideWithValue(subscriptionManager),
-      settingsProvider.overrideWith((ref) => _FixedSettingsNotifier(pubkey)),
+      settingsProvider.overrideWith(
+          (ref) => _FixedSettingsNotifier(pubkey: pubkey, relays: relays)),
     ]);
     addTearDown(container.dispose);
     return container;
   }
 
   group('RelayHealthMonitor', () {
-    test('engages bootstrap and re-subscribes when no relay is alive',
+    test('engages bootstrap and re-subscribes when no operating relay is alive',
         () async {
-      when(nostrService.isInitialized).thenReturn(true);
-      when(nostrService.liveRelayCount).thenReturn(0);
+      // Operating relay configured but not connected.
+      when(nostrService.connectedRelays).thenReturn(<String>{});
 
-      final monitor =
-          buildContainer().read(relayHealthMonitorProvider);
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
       await monitor.checkNow();
 
       verify(nostrService.ensureBootstrapConnectivity()).called(1);
@@ -57,24 +65,38 @@ void main() {
       verify(subscriptionManager.subscribeToMostroRelayList('test')).called(1);
     });
 
-    test('does nothing while at least one relay is alive', () async {
-      when(nostrService.isInitialized).thenReturn(true);
-      when(nostrService.liveRelayCount).thenReturn(2);
+    test('stays idle while an operating relay is alive', () async {
+      when(nostrService.connectedRelays)
+          .thenReturn({'wss://discovered.example.com'});
 
-      final monitor =
-          buildContainer().read(relayHealthMonitorProvider);
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
       await monitor.checkNow();
 
       verifyNever(nostrService.ensureBootstrapConnectivity());
       verifyNever(subscriptionManager.subscribeAll());
     });
 
+    test(
+        'still recovers when only a bootstrap relay is alive '
+        '(does not mask a dead discovered layer)', () async {
+      // A bootstrap relay is connected, but the operating (discovered) relay is
+      // not. The watchdog must NOT treat this as healthy.
+      when(nostrService.connectedRelays).thenReturn({'wss://relay.damus.io'});
+
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
+      await monitor.checkNow();
+
+      verify(nostrService.ensureBootstrapConnectivity()).called(1);
+      verify(subscriptionManager.subscribeAll()).called(1);
+    });
+
     test('does nothing before NostrService is initialized', () async {
       when(nostrService.isInitialized).thenReturn(false);
-      when(nostrService.liveRelayCount).thenReturn(0);
 
-      final monitor =
-          buildContainer().read(relayHealthMonitorProvider);
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
       await monitor.checkNow();
 
       verifyNever(nostrService.ensureBootstrapConnectivity());
@@ -83,9 +105,6 @@ void main() {
 
     test('skips relay-list re-subscription when no Mostro is configured',
         () async {
-      when(nostrService.isInitialized).thenReturn(true);
-      when(nostrService.liveRelayCount).thenReturn(0);
-
       final monitor =
           buildContainer(pubkey: '').read(relayHealthMonitorProvider);
       await monitor.checkNow();

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -50,6 +50,10 @@ import 'mocks.mocks.dart';
   EncryptedImageUploadService,
   BlossomDownloadService,
   ChatRoomNotifier,
+], customMocks: [
+  // Spy mock used to verify SubscriptionManager calls (the hand-written
+  // MockSubscriptionManager below keeps its name; this one has a distinct name).
+  MockSpec<SubscriptionManager>(as: #MockSubscriptionManagerSpy),
 ])
 
 // Custom mock for SettingsNotifier that returns a specific Settings object

--- a/test/services/nostr_service_test.dart
+++ b/test/services/nostr_service_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/core/config.dart';
+import 'package:mostro_mobile/services/nostr_service.dart';
+
+void main() {
+  group('NostrService relay health surface', () {
+    test('a fresh service reports no live relays', () {
+      final service = NostrService();
+
+      expect(service.isInitialized, isFalse);
+      expect(service.liveRelayCount, 0);
+      expect(service.connectedRelays, isEmpty);
+    });
+
+    test('settings getter falls back to an empty relay list', () {
+      final service = NostrService();
+
+      expect(service.settings.relays, isEmpty);
+    });
+
+    test('connectedRelays is an unmodifiable view', () {
+      final service = NostrService();
+
+      expect(
+        () => service.connectedRelays.add('wss://relay.example.com'),
+        throwsUnsupportedError,
+      );
+    });
+  });
+
+  group('bootstrap relay configuration', () {
+    test('bootstrap relays are non-empty secure websocket urls', () {
+      expect(Config.bootstrapRelays, isNotEmpty);
+      for (final url in Config.bootstrapRelays) {
+        expect(url.startsWith('wss://'), isTrue, reason: '$url must be wss://');
+      }
+    });
+
+    test('relay discovery timeout is a positive grace period', () {
+      expect(Config.relayDiscoveryTimeout, greaterThan(Duration.zero));
+    });
+  });
+}

--- a/test/services/nostr_service_test.dart
+++ b/test/services/nostr_service_test.dart
@@ -28,6 +28,17 @@ void main() {
     });
   });
 
+  group('cold-start relay fail-safe', () {
+    test('falls back to bootstrap relays when none are configured', () {
+      expect(NostrService.effectiveRelays(const []), Config.bootstrapRelays);
+    });
+
+    test('keeps the configured relays when present', () {
+      const configured = ['wss://a.example.com', 'wss://b.example.com'];
+      expect(NostrService.effectiveRelays(configured), configured);
+    });
+  });
+
   group('bootstrap relay configuration', () {
     test('bootstrap relays are non-empty secure websocket urls', () {
       expect(Config.bootstrapRelays, isNotEmpty);


### PR DESCRIPTION
fix #609
 Replaces the hardcoded default relay that was always seeded into the user's relay list with a hidden bootstrap discovery layer. The visible relay list now contains only relays discovered from the Mostro's kind 10002 plus user-added relays. A small set of defensive bootstrap relays is used only to discover that list: at cold start, when every discovered relay is unreachable, or when switching Mostro instances.

  ## Why

  The default relay was persisted and always connected even when the active Mostro did not use it, leaving idle connections, diverging the visible list from what the Mostro endorses, and requiring UI special-casing.

  ## How

  - `Config.bootstrapRelays` (relay.mostro.network, mostro-p2p.tech, nos.lol, relay.damus.io) live only at the NostrService connection level: never persisted, never shown.
  - Cold start: when settings has no relays, NostrService.init falls back to the bootstrap relays to fetch the kind 10002.
  - All-down recovery: RelayHealthMonitor (6s watchdog) re-engages bootstrap and re-subscribes (subscribeAll + kind 10002) when no relay is alive.
  - Instance switch: clears the list and ensures bootstrap connectivity for the new instance's kind 10002.

  All engagement is additive (never disconnectFromRelays), so existing connections and subscriptions are never dropped. Retirement is logical only since dart_nostr has no per-relay disconnect.

  ## How to test manually

  Watch logs with `flutter logs` (or `adb logcat | grep -i relay`).

  1. Cold start: clear app data and launch. Logs show "falling back to bootstrap relays", then "Discovered N relays from Mostro 10002". Settings > Relays lists only the discovered relays (not nos.lol / relay.damus.io). The order book loads.
  2. Normal restart: close and reopen. The relay list appears immediately and logs do not show a bootstrap connection (discovered relays work).
  3. Instance switch: change the Mostro node. Logs show bootstrap connection then discovery of the new instance's relays; the list updates.
  4. Manual relay: add a valid wss relay. It persists and is not removed by a later kind 10002 sync.
  5. No event loss: create or take an order and exchange chat messages; events arrive normally. 
  6. All-down recovery (optional): toggle WiFi off and on. Logs show "No live relays detected; engaging bootstrap relays" and events keep flowing after the network returns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a relay health watchdog that auto-recovers connectivity and re-subscribes when relays are down.
  * Added defensive bootstrap discovery to find and activate relay lists when no user relays are available.

* **Improvements**
  * Relay initialization now tolerates empty configured relay lists and uses bootstrap discovery as needed.
  * Default settings start with no pre-seeded relays.

* **Bug Fixes**
  * Streamlined relay deactivation flow in the UI (removed special-case confirmation for default relays).

* **Documentation**
  * Added architecture docs describing the bootstrap discovery layer and safety invariants.

* **Tests**
  * New coverage for relay health recovery, bootstrap behavior, and relay connection invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->