### PR TITLE
feat(about): show anti-abuse bond policy from node info event

### DIFF
--- a/lib/features/settings/about_screen.dart
+++ b/lib/features/settings/about_screen.dart
@@ -548,21 +548,25 @@ class AboutScreen extends ConsumerWidget {
         _buildInfoRowWithDialog(
           context,
           s.bondSlashOnTimeoutLabel,
-          (instance.bondSlashOnWaitingTimeout ?? false) ? s.yes : s.no,
+          instance.bondSlashOnWaitingTimeout == null
+              ? s.notAvailableShort
+              : (instance.bondSlashOnWaitingTimeout! ? s.yes : s.no),
           s.bondSlashOnTimeoutExplanation,
         ),
         const SizedBox(height: 16),
         _buildInfoRowWithDialog(
           context,
           s.bondNodeShareLabel,
-          _formatBondPercent(instance.bondSlashNodeSharePct),
+          _formatBondPercent(s, instance.bondSlashNodeSharePct),
           s.bondNodeShareExplanation,
         ),
         const SizedBox(height: 16),
         _buildInfoRowWithDialog(
           context,
           s.bondClaimWindowLabel,
-          s.bondClaimWindowValue(instance.bondPayoutClaimWindowDays ?? 0),
+          instance.bondPayoutClaimWindowDays == null
+              ? s.notAvailableShort
+              : s.bondClaimWindowValue(instance.bondPayoutClaimWindowDays!),
           s.bondClaimWindowExplanation,
         ),
       ]);
@@ -614,28 +618,30 @@ class AboutScreen extends ConsumerWidget {
       case BondApplyTo.both:
         return s.bondAppliesToBoth;
       case null:
-        return '—';
+        return s.notAvailableShort;
     }
   }
 
   String _bondAmountValue(S s, MostroInstance instance) {
-    final percent = _formatPercentNumber(instance.bondAmountPct);
     final base = instance.bondBaseAmountSats;
-    final min =
-        base == null ? '—' : NumberFormat.decimalPattern().format(base);
+    if (instance.bondAmountPct == null || base == null) {
+      return s.notAvailableShort;
+    }
+    final percent = _formatPercentNumber(s, instance.bondAmountPct);
+    final min = NumberFormat.decimalPattern().format(base);
     return s.bondAmountValue(percent, min);
   }
 
   /// Formats a `[0,1]` fraction as a percent number without trailing zeros,
-  /// e.g. 0.5 -> "50", 0.015 -> "1.5". Returns "—" for null.
-  String _formatPercentNumber(double? fraction) {
-    if (fraction == null) return '—';
+  /// e.g. 0.5 -> "50", 0.015 -> "1.5". Returns the localized "N/A" for null.
+  String _formatPercentNumber(S s, double? fraction) {
+    if (fraction == null) return s.notAvailableShort;
     return NumberFormat('0.##').format(fraction * 100);
   }
 
-  String _formatBondPercent(double? fraction) {
-    if (fraction == null) return '—';
-    return '${_formatPercentNumber(fraction)}%';
+  String _formatBondPercent(S s, double? fraction) {
+    if (fraction == null) return s.notAvailableShort;
+    return '${_formatPercentNumber(s, fraction)}%';
   }
 
   Widget _buildInfoRow(String label, String value) {

--- a/lib/features/settings/about_screen.dart
+++ b/lib/features/settings/about_screen.dart
@@ -313,6 +313,9 @@ class AboutScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 20),
 
+            // Anti-abuse bond Section (hidden when the node doesn't advertise it)
+            _buildAntiAbuseBondSection(context, instance),
+
             // Technical Details Section
             Text(
               S.of(context)!.technicalDetails,
@@ -499,6 +502,140 @@ class AboutScreen extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  /// Anti-abuse bond section. Hidden entirely for legacy daemons that don't
+  /// advertise the policy ([BondPolicy.unsupported]); shows only a status row
+  /// when disabled, and the full parameter set when enabled.
+  Widget _buildAntiAbuseBondSection(
+      BuildContext context, MostroInstance instance) {
+    if (instance.bondPolicy == BondPolicy.unsupported) {
+      return const SizedBox.shrink();
+    }
+    final s = S.of(context)!;
+    final enabled = instance.bondPolicy == BondPolicy.enabled;
+    final children = <Widget>[
+      _buildSectionHeaderWithInfo(
+        context,
+        s.antiAbuseBond,
+        s.antiAbuseBondExplanation,
+      ),
+      const SizedBox(height: 12),
+      _buildInfoRowWithDialog(
+        context,
+        s.bondStatusLabel,
+        enabled ? s.bondEnabled : s.bondDisabled,
+        s.bondStatusExplanation,
+      ),
+    ];
+    if (enabled) {
+      children.addAll([
+        const SizedBox(height: 16),
+        _buildInfoRowWithDialog(
+          context,
+          s.bondAppliesToLabel,
+          _bondAppliesToValue(s, instance.bondApplyTo),
+          s.bondAppliesToExplanation,
+        ),
+        const SizedBox(height: 16),
+        _buildInfoRowWithDialog(
+          context,
+          s.bondAmountLabel,
+          _bondAmountValue(s, instance),
+          s.bondAmountExplanation,
+        ),
+        const SizedBox(height: 16),
+        _buildInfoRowWithDialog(
+          context,
+          s.bondSlashOnTimeoutLabel,
+          (instance.bondSlashOnWaitingTimeout ?? false) ? s.yes : s.no,
+          s.bondSlashOnTimeoutExplanation,
+        ),
+        const SizedBox(height: 16),
+        _buildInfoRowWithDialog(
+          context,
+          s.bondNodeShareLabel,
+          _formatBondPercent(instance.bondSlashNodeSharePct),
+          s.bondNodeShareExplanation,
+        ),
+        const SizedBox(height: 16),
+        _buildInfoRowWithDialog(
+          context,
+          s.bondClaimWindowLabel,
+          s.bondClaimWindowValue(instance.bondPayoutClaimWindowDays ?? 0),
+          s.bondClaimWindowExplanation,
+        ),
+      ]);
+    }
+    children.add(const SizedBox(height: 20));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+  }
+
+  /// Section header matching the plain headers but with a tappable info icon
+  /// that opens the concept explanation dialog.
+  Widget _buildSectionHeaderWithInfo(
+      BuildContext context, String title, String explanation) {
+    return Row(
+      children: [
+        Text(
+          title,
+          style: const TextStyle(
+            color: AppTheme.activeColor,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(width: 6),
+        InkWell(
+          onTap: () => _showInfoDialog(context, title, explanation),
+          borderRadius: BorderRadius.circular(12),
+          child: const Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Icon(
+              Icons.info_outline,
+              size: 16,
+              color: AppTheme.activeColor,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _bondAppliesToValue(S s, BondApplyTo? applyTo) {
+    switch (applyTo) {
+      case BondApplyTo.take:
+        return s.bondAppliesToTakers;
+      case BondApplyTo.make:
+        return s.bondAppliesToMakers;
+      case BondApplyTo.both:
+        return s.bondAppliesToBoth;
+      case null:
+        return '—';
+    }
+  }
+
+  String _bondAmountValue(S s, MostroInstance instance) {
+    final percent = _formatPercentNumber(instance.bondAmountPct);
+    final base = instance.bondBaseAmountSats;
+    final min =
+        base == null ? '—' : NumberFormat.decimalPattern().format(base);
+    return s.bondAmountValue(percent, min);
+  }
+
+  /// Formats a `[0,1]` fraction as a percent number without trailing zeros,
+  /// e.g. 0.5 -> "50", 0.015 -> "1.5". Returns "—" for null.
+  String _formatPercentNumber(double? fraction) {
+    if (fraction == null) return '—';
+    return NumberFormat('0.##').format(fraction * 100);
+  }
+
+  String _formatBondPercent(double? fraction) {
+    if (fraction == null) return '—';
+    return '${_formatPercentNumber(fraction)}%';
   }
 
   Widget _buildInfoRow(String label, String value) {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1665,5 +1665,43 @@
     "bondPayoutCompletedMessage": "Du hast die Auszahlung deines Anteils der Anti-Missbrauchs-Kaution erhalten.",
     "bondPayoutCompletedWithRating": "Du hast die Auszahlung deines Anteils der Anti-Missbrauchs-Kaution erhalten. Du kannst deinen Handelspartner bewerten.",
     "bondPayoutCloseButton": "SCHLIESSEN",
-    "errorLoadingBondPayout": "Fehler beim Laden der Auszahlungsdaten"
+    "errorLoadingBondPayout": "Fehler beim Laden der Auszahlungsdaten",
+    "antiAbuseBond": "Anti-Missbrauchs-Kaution",
+    "antiAbuseBondExplanation": "Die Anti-Missbrauchs-Kaution ist ein optionaler Mechanismus, den manche Mostro-Knoten nutzen, um Trades sicherer zu machen. Beim Einstieg in einen Trade hinterlegst du eine kleine Menge Sats als Sicherheit, die vollständig zurückerstattet wird, wenn du ehrlich handelst, aber verloren geht, wenn du versuchst, deine Gegenpartei zu betrügen. So riskiert der Betrüger sein eigenes Geld, was Missbrauch entgegenwirkt.",
+    "bondStatusLabel": "Status",
+    "bondStatusExplanation": "Ob dieser Knoten zum Handeln eine Anti-Missbrauchs-Kaution verlangt. 'Deaktiviert' bedeutet, dass keine nötig ist.",
+    "bondEnabled": "Aktiviert",
+    "bondDisabled": "Deaktiviert",
+    "bondAppliesToLabel": "Gilt für",
+    "bondAppliesToExplanation": "Welche Seite eine Kaution hinterlegen muss: Taker, Maker oder beide.",
+    "bondAppliesToTakers": "Taker",
+    "bondAppliesToMakers": "Maker",
+    "bondAppliesToBoth": "Maker und Taker",
+    "bondAmountLabel": "Kautionsbetrag",
+    "bondAmountExplanation": "Die Höhe der Kaution: ein Prozentsatz des Orderbetrags, mit einem Mindestbetrag in Sats. Es gilt der größere der beiden Werte.",
+    "bondAmountValue": "{percent}% des Betrags (min. {min} Sats)",
+    "@bondAmountValue": {
+        "placeholders": {
+            "percent": {
+                "type": "String"
+            },
+            "min": {
+                "type": "String"
+            }
+        }
+    },
+    "bondSlashOnTimeoutLabel": "Slash bei Timeout",
+    "bondSlashOnTimeoutExplanation": "Ob deine Kaution einbehalten werden kann, wenn du eine Frist verpasst (zum Beispiel nicht zahlst oder nicht rechtzeitig eine Rechnung lieferst). Bei 'Nein' wird sie nur durch die Entscheidung eines Streitschlichters einbehalten.",
+    "bondNodeShareLabel": "Knoten-Anteil",
+    "bondNodeShareExplanation": "Wenn eine Kaution einbehalten wird, der Anteil, den der Knoten behält. Der Rest wird an die ehrliche Gegenpartei gezahlt.",
+    "bondClaimWindowLabel": "Anspruchsfrist",
+    "bondClaimWindowExplanation": "Wenn du die ehrliche Partei bist, wenn eine Kaution einbehalten wird, wie viele Tage du hast, um deinen Anteil zu beanspruchen, bevor er verfällt.",
+    "bondClaimWindowValue": "{days, plural, =1{1 Tag} other{{days} Tage}}",
+    "@bondClaimWindowValue": {
+        "placeholders": {
+            "days": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1684,5 +1684,43 @@
     "bondPayoutCompletedMessage": "You have received the payment of your share of the anti-abuse bond.",
     "bondPayoutCompletedWithRating": "You have received the payment of your share of the anti-abuse bond. You can rate your counterparty.",
     "bondPayoutCloseButton": "CLOSE",
-    "errorLoadingBondPayout": "Error loading payout data"
+    "errorLoadingBondPayout": "Error loading payout data",
+    "antiAbuseBond": "Anti-abuse bond",
+    "antiAbuseBondExplanation": "The anti-abuse bond is an optional mechanism some Mostro nodes use to make trades safer. When you enter a trade you put up a small amount of sats as collateral — fully refunded if you act in good faith, but lost if you try to cheat your counterparty. This puts the cheater's own money at risk, discouraging abuse.",
+    "bondStatusLabel": "Status",
+    "bondStatusExplanation": "Whether this node requires an anti-abuse bond to trade. 'Disabled' means no bond is needed.",
+    "bondEnabled": "Enabled",
+    "bondDisabled": "Disabled",
+    "bondAppliesToLabel": "Applies to",
+    "bondAppliesToExplanation": "Which side must lock a bond: takers, makers, or both.",
+    "bondAppliesToTakers": "Takers",
+    "bondAppliesToMakers": "Makers",
+    "bondAppliesToBoth": "Makers and takers",
+    "bondAmountLabel": "Bond amount",
+    "bondAmountExplanation": "The bond size: a percentage of the order amount, with a minimum floor in sats. The larger of the two applies.",
+    "bondAmountValue": "{percent}% of the order amount (min. {min} sats)",
+    "@bondAmountValue": {
+        "placeholders": {
+            "percent": {
+                "type": "String"
+            },
+            "min": {
+                "type": "String"
+            }
+        }
+    },
+    "bondSlashOnTimeoutLabel": "Slash on timeout",
+    "bondSlashOnTimeoutExplanation": "Whether your bond can be kept if you miss a deadline (for example, not paying or not providing an invoice in time). If 'No', a bond is only kept by a dispute resolver's decision.",
+    "bondNodeShareLabel": "Node share",
+    "bondNodeShareExplanation": "If a bond is kept, the fraction the node retains. The rest is paid to the honest counterparty.",
+    "bondClaimWindowLabel": "Claim window",
+    "bondClaimWindowExplanation": "If you are the honest party when a bond is kept, how many days you have to claim your share before it is forfeited.",
+    "bondClaimWindowValue": "{days, plural, =1{1 day} other{{days} days}}",
+    "@bondClaimWindowValue": {
+        "placeholders": {
+            "days": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1640,5 +1640,43 @@
     "bondPayoutCompletedMessage": "Ya recibiste el pago de tu parte del bono anti-abuso.",
     "bondPayoutCompletedWithRating": "Ya recibiste el pago de tu parte del bono anti-abuso. Puedes calificar a tu contraparte.",
     "bondPayoutCloseButton": "CERRAR",
-    "errorLoadingBondPayout": "Error al cargar los datos del cobro"
+    "errorLoadingBondPayout": "Error al cargar los datos del cobro",
+    "antiAbuseBond": "Depósito anti-abuso",
+    "antiAbuseBondExplanation": "El depósito anti-abuso es un mecanismo opcional que algunos nodos de Mostro usan para hacer los intercambios más seguros. Al entrar en una operación pones en garantía una pequeña cantidad de sats que recuperas por completo si actúas de buena fe, pero que pierdes si intentas estafar a tu contraparte. Así el estafador arriesga su propio dinero, lo que desalienta el abuso.",
+    "bondStatusLabel": "Estado",
+    "bondStatusExplanation": "Si este nodo exige un depósito anti-abuso para operar. 'Deshabilitado' significa que no hace falta ninguno.",
+    "bondEnabled": "Habilitado",
+    "bondDisabled": "Deshabilitado",
+    "bondAppliesToLabel": "Aplica a",
+    "bondAppliesToExplanation": "Qué lado debe bloquear un depósito: takers, makers o ambos.",
+    "bondAppliesToTakers": "Takers",
+    "bondAppliesToMakers": "Makers",
+    "bondAppliesToBoth": "Makers y takers",
+    "bondAmountLabel": "Monto del depósito",
+    "bondAmountExplanation": "El tamaño del depósito: un porcentaje del monto de la orden, con un mínimo en sats. Se aplica el mayor de los dos.",
+    "bondAmountValue": "{percent}% del monto (mín. {min} sats)",
+    "@bondAmountValue": {
+        "placeholders": {
+            "percent": {
+                "type": "String"
+            },
+            "min": {
+                "type": "String"
+            }
+        }
+    },
+    "bondSlashOnTimeoutLabel": "Slash por timeout",
+    "bondSlashOnTimeoutExplanation": "Si tu depósito puede retenerse por no cumplir un plazo (por ejemplo, no pagar o no enviar una factura a tiempo). Si es 'No', solo se retiene por decisión de un resolutor de disputa.",
+    "bondNodeShareLabel": "Retención del nodo",
+    "bondNodeShareExplanation": "Si un depósito se retiene, la fracción que se queda el nodo. El resto se paga a la contraparte honesta.",
+    "bondClaimWindowLabel": "Ventana de reclamo",
+    "bondClaimWindowExplanation": "Si eres la parte honesta cuando un depósito se retiene, cuántos días tienes para reclamar tu parte antes de perderla.",
+    "bondClaimWindowValue": "{days, plural, =1{1 día} other{{days} días}}",
+    "@bondClaimWindowValue": {
+        "placeholders": {
+            "days": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1665,5 +1665,43 @@
     "bondPayoutCompletedMessage": "Vous avez reçu le paiement de votre part du dépôt anti-abus.",
     "bondPayoutCompletedWithRating": "Vous avez reçu le paiement de votre part du dépôt anti-abus. Vous pouvez évaluer votre contrepartie.",
     "bondPayoutCloseButton": "FERMER",
-    "errorLoadingBondPayout": "Erreur lors du chargement des données de paiement"
+    "errorLoadingBondPayout": "Erreur lors du chargement des données de paiement",
+    "antiAbuseBond": "Dépôt anti-abus",
+    "antiAbuseBondExplanation": "Le dépôt anti-abus est un mécanisme optionnel que certains nœuds Mostro utilisent pour rendre les échanges plus sûrs. En entrant dans un échange, vous déposez une petite quantité de sats en garantie, intégralement remboursée si vous agissez de bonne foi, mais perdue si vous tentez d'escroquer votre contrepartie. Ainsi, l'escroc risque son propre argent, ce qui décourage les abus.",
+    "bondStatusLabel": "Statut",
+    "bondStatusExplanation": "Si ce nœud exige un dépôt anti-abus pour échanger. 'Désactivé' signifie qu'aucun dépôt n'est requis.",
+    "bondEnabled": "Activé",
+    "bondDisabled": "Désactivé",
+    "bondAppliesToLabel": "S'applique à",
+    "bondAppliesToExplanation": "Quel côté doit bloquer un dépôt : preneurs, créateurs ou les deux.",
+    "bondAppliesToTakers": "Preneurs",
+    "bondAppliesToMakers": "Créateurs",
+    "bondAppliesToBoth": "Créateurs et preneurs",
+    "bondAmountLabel": "Montant du dépôt",
+    "bondAmountExplanation": "La taille du dépôt : un pourcentage du montant de l'ordre, avec un minimum en sats. Le plus élevé des deux s'applique.",
+    "bondAmountValue": "{percent}% du montant (min. {min} sats)",
+    "@bondAmountValue": {
+        "placeholders": {
+            "percent": {
+                "type": "String"
+            },
+            "min": {
+                "type": "String"
+            }
+        }
+    },
+    "bondSlashOnTimeoutLabel": "Slash en cas de délai",
+    "bondSlashOnTimeoutExplanation": "Si votre dépôt peut être conservé en cas de délai non respecté (par exemple, ne pas payer ou ne pas fournir une facture à temps). Si 'Non', il n'est conservé que sur décision d'un médiateur de litige.",
+    "bondNodeShareLabel": "Part du nœud",
+    "bondNodeShareExplanation": "Si un dépôt est conservé, la fraction que le nœud retient. Le reste est versé à la contrepartie honnête.",
+    "bondClaimWindowLabel": "Délai de réclamation",
+    "bondClaimWindowExplanation": "Si vous êtes la partie honnête lorsqu'un dépôt est conservé, combien de jours vous avez pour réclamer votre part avant de la perdre.",
+    "bondClaimWindowValue": "{days, plural, =1{1 jour} other{{days} jours}}",
+    "@bondClaimWindowValue": {
+        "placeholders": {
+            "days": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1706,5 +1706,43 @@
     "bondPayoutCompletedMessage": "Hai ricevuto il pagamento della tua parte del deposito anti-abuso.",
     "bondPayoutCompletedWithRating": "Hai ricevuto il pagamento della tua parte del deposito anti-abuso. Puoi valutare la tua controparte.",
     "bondPayoutCloseButton": "CHIUDI",
-    "errorLoadingBondPayout": "Errore nel caricamento dei dati del riscatto"
+    "errorLoadingBondPayout": "Errore nel caricamento dei dati del riscatto",
+    "antiAbuseBond": "Deposito anti-abuso",
+    "antiAbuseBondExplanation": "Il deposito anti-abuso è un meccanismo opzionale che alcuni nodi Mostro usano per rendere gli scambi più sicuri. Quando entri in uno scambio depositi una piccola quantità di sats come garanzia, che ti viene restituita per intero se agisci in buona fede, ma che perdi se cerchi di truffare la tua controparte. Così il truffatore mette a rischio il proprio denaro, scoraggiando gli abusi.",
+    "bondStatusLabel": "Stato",
+    "bondStatusExplanation": "Se questo nodo richiede un deposito anti-abuso per fare trading. 'Disabilitato' significa che non ne serve nessuno.",
+    "bondEnabled": "Abilitato",
+    "bondDisabled": "Disabilitato",
+    "bondAppliesToLabel": "Si applica a",
+    "bondAppliesToExplanation": "Quale lato deve bloccare un deposito: taker, maker o entrambi.",
+    "bondAppliesToTakers": "Taker",
+    "bondAppliesToMakers": "Maker",
+    "bondAppliesToBoth": "Maker e taker",
+    "bondAmountLabel": "Importo del deposito",
+    "bondAmountExplanation": "La dimensione del deposito: una percentuale dell'importo dell'ordine, con un minimo in sats. Si applica il maggiore dei due.",
+    "bondAmountValue": "{percent}% dell'importo (min. {min} sats)",
+    "@bondAmountValue": {
+        "placeholders": {
+            "percent": {
+                "type": "String"
+            },
+            "min": {
+                "type": "String"
+            }
+        }
+    },
+    "bondSlashOnTimeoutLabel": "Slash su timeout",
+    "bondSlashOnTimeoutExplanation": "Se il tuo deposito può essere trattenuto per il mancato rispetto di una scadenza (ad esempio non pagare o non fornire una fattura in tempo). Se 'No', viene trattenuto solo per decisione di un risolutore di dispute.",
+    "bondNodeShareLabel": "Quota del nodo",
+    "bondNodeShareExplanation": "Se un deposito viene trattenuto, la frazione che il nodo trattiene. Il resto è pagato alla controparte onesta.",
+    "bondClaimWindowLabel": "Finestra di reclamo",
+    "bondClaimWindowExplanation": "Se sei la parte onesta quando un deposito viene trattenuto, quanti giorni hai per reclamare la tua quota prima di perderla.",
+    "bondClaimWindowValue": "{days, plural, =1{1 giorno} other{{days} giorni}}",
+    "@bondClaimWindowValue": {
+        "placeholders": {
+            "days": {
+                "type": "int"
+            }
+        }
+    }
 }


### PR DESCRIPTION
  - Add an Anti-abuse bond section to the About screen, parsed from the kind-38385 info event
  - Hide it on legacy nodes, show status only when disabled, full parameters when enabled
  - Add localized labels, per-row help dialogs and a concept explanation in en/es/it/de/fr
 
<img width="495" height="775" alt="Captura desde 2026-06-15 16-42-04" src="https://github.com/user-attachments/assets/22f022c3-e97a-4fb4-b5db-a3807a38d243" />
<img width="495" height="775" alt="Captura desde 2026-06-15 16-40-49" src="https://github.com/user-attachments/assets/e7f0b925-a108-4265-8d97-d90b647cf54c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Anti-abuse bond” section to the Mostro node details card, showing current bond status and configuration (applicability, amount/percent, slash-on-timeout, node share, and claim window).
  * The section is shown only when supported, and the info icon opens a concept explanation dialog.
  * Missing values are displayed using localized “not available” placeholders.

* **Documentation**
  * Added/extended localization strings for German, English, Spanish, French, and Italian for the anti-abuse bond UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->