### PR TITLE
feat(bond): cause-aware bond-slashed handling (dispute vs timeout)

### DIFF
--- a/docs/architecture/ANTI_ABUSE_BOND.md
+++ b/docs/architecture/ANTI_ABUSE_BOND.md
@@ -45,6 +45,7 @@ on locking, releasing, slashing and paying out.
 | Payout request payload | `lib/data/models/bond_payout_request.dart` |
 | Pure payout-phase helpers | `lib/shared/utils/bond_payout_helpers.dart` |
 | Pure cancel-lifecycle helpers | `lib/shared/utils/bond_cancel_helpers.dart` |
+| Pure slash-cause helpers | `lib/shared/utils/bond_slash_helpers.dart` |
 | Message handling / session logic | `lib/features/order/notifiers/abstract_mostro_notifier.dart` |
 | Maker-bond create flow | `lib/features/order/notifiers/add_order_notifier.dart` |
 | Pay-bond screen | `lib/features/order/screens/pay_bond_invoice_screen.dart` |
@@ -307,39 +308,76 @@ catch keeps the user on the form rather than silently losing the submission
 
 ## 7. Forfeiture notice (`bond-slashed`)
 
-`bond-slashed` is a **best-effort** notice the daemon sends to a taker whose
-bond was slashed on a **waiting-state timeout** (it complements the
-`Action::Canceled` the user already gets for the order). It is *not* sent on a
-voluntary cancel — that returns the bond.
+`bond-slashed` is a **best-effort** notice the daemon sends to the slashed party
+when their bond is forfeited. It complements the resolution message the user
+already gets for the order, and is sent for **both** slash causes:
 
-- **Payload.** `Order` (a `SmallOrder`) whose `amount` is the **slashed bond
-  amount**, not the trade amount, and whose `status` is `null`.
-- **Ordering.** The daemon sends `canceled` first, then `bond-slashed` ~150 ms
-  later, both to the same trade pubkey. This ordering is why the client must
-  defer session deletion (§8).
+- **Timeout slash** — the user missed a waiting-state deadline. The daemon sends
+  `canceled` first, then `bond-slashed` ~150 ms later. (Not sent on a voluntary
+  cancel — that returns the bond.) This `canceled`-then-`bond-slashed` ordering
+  is why the client must defer session deletion (§8).
+- **Dispute-resolution slash** — a solver directed the slash while resolving a
+  dispute. The daemon sends `admin-settled` / `admin-canceled` first, then
+  `bond-slashed`.
+
+- **Payload (identical for both causes).** `Order` (a `SmallOrder`) whose
+  `amount` is the **slashed bond amount**, not the trade amount, and whose
+  `status` is `null`. There is **no `reason` field** — the wire message does not
+  say which cause triggered it.
 - **Why it was being dropped before.** Two bugs, both fixed: (1) the action was
   not in the enum, so `MostroMessage.fromJson` threw and discarded it; (2) the
   `canceled` handler deleted the session immediately, dropping the trade key
   from the subscription filter and the decryption key, so the trailing notice
   could never be received or decrypted.
 
+### Inferring the cause
+
+Because the payload is identical, the client infers the cause from the order's
+message history, in the pure helper `lib/shared/utils/bond_slash_helpers.dart`:
+
+- `bondSlashCause(messages)` → `dispute` when the history contains a
+  dispute/admin action (`dispute-initiated-by-you/peer`, `admin-settled`,
+  `admin-canceled`); `timeout` otherwise (and for an empty history).
+- The two causes are **mutually exclusive**: a timeout slash only happens in a
+  waiting state, before any dispute; once disputed, the only slash path is the
+  admin resolution. So a single dispute/admin action in the history
+  unambiguously marks a dispute slash.
+
+The cause is computed **once, at notification creation** — in the `bond-slashed`
+case of `notification_data_extractor.dart`, where storage is reachable via `ref`
+— and persisted into the notification's `data['slash_cause']`, so the
+notification stays self-contained (it does not depend on the order history still
+being present when later opened). When `ref` is unavailable (background) the
+inference defaults to `timeout`.
+
 ### Rendering
 
-- **Extraction** (`notification_data_extractor.dart:222-232`): pulls
-  `{amount, order_id, fiat_code, fiat_amount, payment_method}` from the payload
-  and persists a non-temporary notification. The other payout acks
-  (`add-bond-invoice`, `bond-invoice-accepted`, `bond-payout-completed`) return
-  `null` here — no notification (`:217-219`).
+- **Extraction** (`notification_data_extractor.dart`, `bond-slashed` case):
+  pulls `{amount, order_id, fiat_code, fiat_amount, payment_method}` from the
+  payload plus the inferred `slash_cause`, and persists a non-temporary
+  notification. The other payout acks (`add-bond-invoice`,
+  `bond-invoice-accepted`, `bond-payout-completed`) return `null` here — no
+  notification.
 - **Mapping** (`notification.dart:87`): `bond-slashed` →
-  `NotificationType.cancellation`. List preview uses the short
-  `notification_bond_slashed_title` / `_message` keys
-  (`notification_message_mapper.dart:102,219`).
-- **Tap → detail dialog** (`notification_item.dart:139-140`, `:171-215`):
-  `_showBondSlashedDialog` shows the forfeiture detail in **prose**
-  (`notification_bond_slashed_detail`, parameterized with
-  amount/orderId/fiatAmount/fiatCode/paymentMethod) with a **green** close
-  button (`AppTheme.activeColor`). The `bond-slashed` case is isolated from the
-  no-op action group in the switch to avoid fall-through (commit `b226af3c`).
+  `NotificationType.cancellation`. The **title** is the same for both causes;
+  the **message** key is chosen by cause in
+  `notification_message_mapper.dart::getMessageKeyWithContext`
+  (timeout → `notification_bond_slashed_message`, dispute →
+  `notification_bond_slashed_dispute_message`).
+- **Tap → detail dialog** (`notification_item.dart`, `_showBondSlashedDialog`):
+  picks the `notification_bond_slashed_detail` vs `_dispute_detail` variant from
+  `data['slash_cause']`; prose with a **green** close button
+  (`AppTheme.activeColor`). The `bond-slashed` case is isolated from the no-op
+  action group in the switch to avoid fall-through (commit `b226af3c`).
+
+### Order-details notice (dispute only)
+
+`trade_detail_screen.dart::_buildBondLostDisputeNotice` shows a durable line in
+the order detail **only** when `orderBondWasSlashed(messages) && bondSlashCause
+== dispute`. A timeout slash shows nothing there (the notification already
+covers it). The amount comes from the `bond-slashed` message via
+`slashedBondAmount(messages)`, rendered with the `bondLostByDisputeNotice`
+localized key.
 
 ---
 
@@ -461,6 +499,7 @@ when generated mocks are stale:
 |------|--------|
 | `test/shared/utils/bond_payout_helpers_test.dart` | phase model, deadline, expiry, `hasPendingBondClaim` |
 | `test/shared/utils/bond_cancel_helpers_test.dart` | defer/reconcile truth tables, window boundary |
+| `test/shared/utils/bond_slash_helpers_test.dart` | slash-cause inference (timeout vs dispute), slashed-amount extraction |
 | `test/features/order/models/order_state_bond_slashed_test.dart` | slash notice must not overwrite the tracked order |
 | `test/features/order/models/order_state_maker_bond_test.dart` | maker bond status handling |
 | `test/features/order/notifiers/maker_bond_timeout_test.dart` | maker-bond flow disarms the create timeout |
@@ -472,7 +511,8 @@ when generated mocks are stale:
 > `getSessionByOrderId` / `sessions` with fixed fields and bypasses the real
 > session map, which makes `deleteSession`-wiring assertions fragile. The
 > decision logic was extracted into `bond_payout_helpers.dart` /
-> `bond_cancel_helpers.dart` so the truth tables can be tested without mocks.
+> `bond_cancel_helpers.dart` / `bond_slash_helpers.dart` so the truth tables can
+> be tested without mocks.
 
 ---
 
@@ -485,10 +525,14 @@ when generated mocks are stale:
   open, not refreshed live.
 - **Offline correctness** of the 60 s deferral depends on relay retention of the
   trailing `bond-slashed` gift wrap.
+- **Slash-cause inference is a heuristic.** The daemon ships no `reason` on
+  `bond-slashed`, so the client infers timeout vs dispute from order history
+  (§7). It defaults to `timeout` when the history is unavailable. A daemon-side
+  `reason` field would make this unambiguous.
 
 ---
 
-**Last Updated**: 2026-06-15
+**Last Updated**: 2026-06-16
 **Related docs**: `MULTI_MOSTRO_SUPPORT.md` (info-event parsing),
 `ORDER_STATUS_HANDLING.md` (status model),
 `TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md` (session cleanup),

--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -6,6 +6,7 @@ import 'package:mostro_mobile/data/models.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/shared/providers/legible_handle_provider.dart';
 import 'package:mostro_mobile/shared/providers.dart';
+import 'package:mostro_mobile/shared/utils/bond_slash_helpers.dart';
 
 class NotificationDataExtractor {
   /// Extract notification data from MostroMessage
@@ -223,12 +224,28 @@ class NotificationDataExtractor {
         // SmallOrder carries the slashed bond amount and the order context.
         final order = event.getPayload<Order>();
         if (order == null) return null;
+        // The daemon sends the same bond-slashed notice for a timeout slash
+        // and a dispute-resolution slash; infer which from the order history
+        // (best-effort: defaults to timeout when history is unavailable).
+        var slashCause = BondSlashCause.timeout;
+        if (ref != null && event.id != null) {
+          try {
+            final messages = await ref
+                .read(mostroStorageProvider)
+                .getAllMessagesForOrderId(event.id!);
+            slashCause = bondSlashCause(messages);
+          } catch (e) {
+            logger.e('Failed to infer bond-slash cause for order ${event.id}',
+                error: e);
+          }
+        }
         values = {
           'amount': order.amount,
           'order_id': order.id,
           'fiat_code': order.fiatCode,
           'fiat_amount': order.fiatAmount,
           'payment_method': order.paymentMethod,
+          'slash_cause': slashCause.name,
         };
         break;
 

--- a/lib/features/notifications/utils/notification_message_mapper.dart
+++ b/lib/features/notifications/utils/notification_message_mapper.dart
@@ -120,6 +120,12 @@ class NotificationMessageMapper {
         return 'notification_order_canceled_by_buyer_inactivity_message';
       }
     }
+    // Same bond-slashed notice covers timeout and dispute slashes; pick the
+    // message variant from the cause inferred at notification creation.
+    if (action == mostro.Action.bondSlashed &&
+        values?['slash_cause'] == 'dispute') {
+      return 'notification_bond_slashed_dispute_message';
+    }
     // Fall back to normal message key
     return getMessageKey(action);
   }
@@ -381,6 +387,8 @@ class NotificationMessageMapper {
         return s.notification_bond_slashed_title;
       case 'notification_bond_slashed_message':
         return s.notification_bond_slashed_message;
+      case 'notification_bond_slashed_dispute_message':
+        return s.notification_bond_slashed_dispute_message;
       default:
         return key; // Fallback to key if not found
     }

--- a/lib/features/notifications/widgets/notification_item.dart
+++ b/lib/features/notifications/widgets/notification_item.dart
@@ -177,6 +177,14 @@ class NotificationItem extends ConsumerWidget {
     final fiatAmount = (data['fiat_amount'] ?? '').toString();
     final fiatCode = (data['fiat_code'] ?? '').toString();
     final paymentMethod = (data['payment_method'] ?? '').toString();
+    // Same bond-slashed notice covers both timeout and dispute slashes; the
+    // cause was inferred and persisted at notification creation.
+    final isDispute = data['slash_cause'] == 'dispute';
+    final detail = isDispute
+        ? s.notification_bond_slashed_dispute_detail(
+            amount, orderId, fiatAmount, fiatCode, paymentMethod)
+        : s.notification_bond_slashed_detail(
+            amount, orderId, fiatAmount, fiatCode, paymentMethod);
 
     showDialog(
       context: context,
@@ -187,8 +195,7 @@ class NotificationItem extends ConsumerWidget {
           style: const TextStyle(color: AppTheme.textPrimary),
         ),
         content: Text(
-          s.notification_bond_slashed_detail(
-              amount, orderId, fiatAmount, fiatCode, paymentMethod),
+          detail,
           style: const TextStyle(color: AppTheme.textSecondary),
         ),
         actions: [

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -267,13 +267,21 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         break;
 
       case Action.bondSlashed:
-        // Cancel any deferred deletion timer (only the timeout/canceled path sets one).
-        _bondCancelDeletionTimers.remove(orderId)?.cancel();
+        // Read history first; on failure leave the deferred timer intact as the
+        // fallback cleanup instead of stranding the session.
+        late final List<MostroMessage> bondSlashMessages;
+        try {
+          bondSlashMessages = await ref
+              .read(mostroStorageProvider)
+              .getAllMessagesForOrderId(orderId);
+        } catch (e) {
+          logger.e('Failed to read history for bond-slashed order $orderId',
+              error: e);
+          break;
+        }
         // Delete only on a timeout slash (order returned to the book). A dispute
         // slash is a terminal trade that stays in My Trades with its role intact.
-        final bondSlashMessages = await ref
-            .read(mostroStorageProvider)
-            .getAllMessagesForOrderId(orderId);
+        _bondCancelDeletionTimers.remove(orderId)?.cancel();
         if (bondSlashIsTimeout(bondSlashMessages)) {
           await ref
               .read(sessionNotifierProvider.notifier)

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -15,6 +15,7 @@ import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/shared/utils/bond_cancel_helpers.dart';
 import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
+import 'package:mostro_mobile/shared/utils/bond_slash_helpers.dart';
 
 class AbstractMostroNotifier extends StateNotifier<OrderState> {
   final String orderId;
@@ -266,12 +267,23 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         break;
 
       case Action.bondSlashed:
-        // The forfeiture notification was already persisted at the top of
-        // handleEvent. The notice arrived, so cancel the deferred deletion
-        // and release the session now.
+        // Cancel any deferred deletion timer (only the timeout/canceled path sets one).
         _bondCancelDeletionTimers.remove(orderId)?.cancel();
-        await ref.read(sessionNotifierProvider.notifier).deleteSession(orderId);
-        logger.i('Session deleted after bond-slashed for order $orderId');
+        // Delete only on a timeout slash (order returned to the book). A dispute
+        // slash is a terminal trade that stays in My Trades with its role intact.
+        final bondSlashMessages = await ref
+            .read(mostroStorageProvider)
+            .getAllMessagesForOrderId(orderId);
+        if (bondSlashIsTimeout(bondSlashMessages)) {
+          await ref
+              .read(sessionNotifierProvider.notifier)
+              .deleteSession(orderId);
+          logger.i(
+              'Session deleted after timeout bond-slashed for order $orderId');
+        } else {
+          logger
+              .i('Dispute bond-slashed: keeping session for order $orderId');
+        }
         break;
 
       case Action.buyerTookOrder:

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -28,7 +28,6 @@ import 'package:mostro_mobile/shared/widgets/dynamic_countdown_widget.dart';
 import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
-import 'package:mostro_mobile/shared/utils/bond_slash_helpers.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
 
 class TradeDetailScreen extends ConsumerWidget {
@@ -86,7 +85,6 @@ class TradeDetailScreen extends ConsumerWidget {
                   // Detailed info: includes the last Mostro message action text
                   MostroMessageDetail(orderId: orderId),
                 ],
-                _buildBondLostDisputeNotice(context, ref),
                 const SizedBox(height: 24),
                 // Show countdown timer only for specific statuses
                 _CountdownWidget(
@@ -266,34 +264,6 @@ class TradeDetailScreen extends ConsumerWidget {
   Widget _buildOrderId(BuildContext context) {
     return OrderIdCard(
       orderId: orderId,
-    );
-  }
-
-  /// Durable notice shown ONLY when this order's bond was slashed by a dispute
-  /// resolution. A timeout slash shows nothing here (the notification covers
-  /// it); the amount comes from the bond-slashed message itself.
-  Widget _buildBondLostDisputeNotice(BuildContext context, WidgetRef ref) {
-    final history = ref.watch(mostroMessageHistoryProvider(orderId));
-    return history.maybeWhen(
-      data: (msgs) {
-        if (!orderBondWasSlashed(msgs) ||
-            bondSlashCause(msgs) != BondSlashCause.dispute) {
-          return const SizedBox.shrink();
-        }
-        final amount = slashedBondAmount(msgs);
-        if (amount == null) return const SizedBox.shrink();
-        return Padding(
-          padding: const EdgeInsets.only(top: 16),
-          child: Text(
-            S.of(context)!.bondLostByDisputeNotice(amount.toString()),
-            style: const TextStyle(
-              color: AppTheme.textSecondary,
-              fontSize: 14,
-            ),
-          ),
-        );
-      },
-      orElse: () => const SizedBox.shrink(),
     );
   }
 

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -28,6 +28,7 @@ import 'package:mostro_mobile/shared/widgets/dynamic_countdown_widget.dart';
 import 'package:mostro_mobile/features/disputes/providers/dispute_providers.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
+import 'package:mostro_mobile/shared/utils/bond_slash_helpers.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
 
 class TradeDetailScreen extends ConsumerWidget {
@@ -85,6 +86,7 @@ class TradeDetailScreen extends ConsumerWidget {
                   // Detailed info: includes the last Mostro message action text
                   MostroMessageDetail(orderId: orderId),
                 ],
+                _buildBondLostDisputeNotice(context, ref),
                 const SizedBox(height: 24),
                 // Show countdown timer only for specific statuses
                 _CountdownWidget(
@@ -264,6 +266,34 @@ class TradeDetailScreen extends ConsumerWidget {
   Widget _buildOrderId(BuildContext context) {
     return OrderIdCard(
       orderId: orderId,
+    );
+  }
+
+  /// Durable notice shown ONLY when this order's bond was slashed by a dispute
+  /// resolution. A timeout slash shows nothing here (the notification covers
+  /// it); the amount comes from the bond-slashed message itself.
+  Widget _buildBondLostDisputeNotice(BuildContext context, WidgetRef ref) {
+    final history = ref.watch(mostroMessageHistoryProvider(orderId));
+    return history.maybeWhen(
+      data: (msgs) {
+        if (!orderBondWasSlashed(msgs) ||
+            bondSlashCause(msgs) != BondSlashCause.dispute) {
+          return const SizedBox.shrink();
+        }
+        final amount = slashedBondAmount(msgs);
+        if (amount == null) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.only(top: 16),
+          child: Text(
+            S.of(context)!.bondLostByDisputeNotice(amount.toString()),
+            style: const TextStyle(
+              color: AppTheme.textSecondary,
+              fontSize: 14,
+            ),
+          ),
+        );
+      },
+      orElse: () => const SizedBox.shrink(),
     );
   }
 

--- a/lib/features/trades/widgets/mostro_message_detail_widget.dart
+++ b/lib/features/trades/widgets/mostro_message_detail_widget.dart
@@ -10,6 +10,7 @@ import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/shared/providers/legible_handle_provider.dart';
 import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
+import 'package:mostro_mobile/shared/utils/bond_slash_helpers.dart';
 import 'package:mostro_mobile/shared/widgets/custom_card.dart';
 import 'package:mostro_mobile/shared/utils/text_formatting.dart';
 
@@ -294,6 +295,8 @@ class MostroMessageDetail extends ConsumerWidget {
         return _getCantDoMessage(context, ref);
       case actions.Action.addBondInvoice:
         return _getBondPayoutMessage(context, ref);
+      case actions.Action.bondSlashed:
+        return _getBondSlashedMessage(context, ref);
       default:
         return 'No message found for action ${tradeState.action}'; // This is a fallback message for developers
     }
@@ -309,6 +312,20 @@ class MostroMessageDetail extends ConsumerWidget {
       return S.of(context)!.addBondInvoiceMessage;
     }
     return S.of(context)!.addBondInvoiceSubmitLine(amount.toString());
+  }
+
+  String _getBondSlashedMessage(BuildContext context, WidgetRef ref) {
+    final historyAsync = ref.watch(mostroMessageHistoryProvider(orderId));
+    // The slashed amount is carried by the bond-slashed message itself; read it
+    // from history. Render nothing until the history loads to avoid flashing a
+    // stale amount. Only dispute slashes reach this screen — a timeout slash
+    // deletes the session.
+    final amount = historyAsync.maybeWhen(
+      data: (msgs) => slashedBondAmount(msgs),
+      orElse: () => null,
+    );
+    if (amount == null) return '';
+    return S.of(context)!.bondLostByDisputeNotice(amount.toString());
   }
 
   String _getCantDoMessage(BuildContext context, WidgetRef ref) {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1277,6 +1277,8 @@
     "notification_bond_slashed_title": "Anti-Missbrauchs-Kaution verloren",
     "notification_bond_slashed_message": "Du hast deine Anti-Missbrauchs-Kaution verloren, weil du nicht rechtzeitig geantwortet hast.",
     "notification_bond_slashed_detail": "Du hast deine Anti-Missbrauchs-Kaution von {amount} Sats für die Bestellung {orderId}, über {fiatAmount} {fiatCode} mit Zahlungsmethode {paymentMethod}, verloren, weil du nicht rechtzeitig geantwortet hast.",
+    "notification_bond_slashed_dispute_message": "Du hast deine Anti-Missbrauchs-Kaution durch die Schlichtung der Streitigkeit dieser Bestellung verloren.",
+    "notification_bond_slashed_dispute_detail": "Du hast deine Anti-Missbrauchs-Kaution von {amount} Sats für die Bestellung {orderId}, über {fiatAmount} {fiatCode} mit Zahlungsmethode {paymentMethod}, durch die Schlichtung der Streitigkeit verloren.",
     "notificationDelete": "Löschen",
     "confirmDeleteNotification": "Bist du sicher, dass du diese Benachrichtigung löschen möchtest?",
     "confirmClearAll": "Dies wird alle Benachrichtigungen dauerhaft löschen. Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1279,6 +1279,7 @@
     "notification_bond_slashed_detail": "Du hast deine Anti-Missbrauchs-Kaution von {amount} Sats für die Bestellung {orderId}, über {fiatAmount} {fiatCode} mit Zahlungsmethode {paymentMethod}, verloren, weil du nicht rechtzeitig geantwortet hast.",
     "notification_bond_slashed_dispute_message": "Du hast deine Anti-Missbrauchs-Kaution durch die Schlichtung der Streitigkeit dieser Bestellung verloren.",
     "notification_bond_slashed_dispute_detail": "Du hast deine Anti-Missbrauchs-Kaution von {amount} Sats für die Bestellung {orderId}, über {fiatAmount} {fiatCode} mit Zahlungsmethode {paymentMethod}, durch die Schlichtung der Streitigkeit verloren.",
+    "bondLostByDisputeNotice": "Du hast die Anti-Missbrauchs-Kaution von {amount} Sats für diese Bestellung durch die Schlichtung der Streitigkeit verloren.",
     "notificationDelete": "Löschen",
     "confirmDeleteNotification": "Bist du sicher, dass du diese Benachrichtigung löschen möchtest?",
     "confirmClearAll": "Dies wird alle Benachrichtigungen dauerhaft löschen. Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1296,6 +1296,27 @@
             }
         }
     },
+    "notification_bond_slashed_dispute_message": "You lost your anti-abuse bond due to the dispute resolution for this order.",
+    "notification_bond_slashed_dispute_detail": "You lost your anti-abuse bond of {amount} sats for order {orderId}, for {fiatAmount} {fiatCode} with payment method {paymentMethod}, due to the dispute resolution.",
+    "@notification_bond_slashed_dispute_detail": {
+        "placeholders": {
+            "amount": {
+                "type": "String"
+            },
+            "orderId": {
+                "type": "String"
+            },
+            "fiatAmount": {
+                "type": "String"
+            },
+            "fiatCode": {
+                "type": "String"
+            },
+            "paymentMethod": {
+                "type": "String"
+            }
+        }
+    },
     "notificationDelete": "Delete",
     "confirmDeleteNotification": "Are you sure you want to delete this notification?",
     "confirmClearAll": "This will permanently delete all notifications. This action cannot be undone.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1317,6 +1317,14 @@
             }
         }
     },
+    "bondLostByDisputeNotice": "You lost the anti-abuse bond of {amount} sats for this order due to the dispute resolution.",
+    "@bondLostByDisputeNotice": {
+        "placeholders": {
+            "amount": {
+                "type": "String"
+            }
+        }
+    },
     "notificationDelete": "Delete",
     "confirmDeleteNotification": "Are you sure you want to delete this notification?",
     "confirmClearAll": "This will permanently delete all notifications. This action cannot be undone.",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1193,6 +1193,7 @@
     "notification_bond_slashed_detail": "Has perdido tu bono anti-abuso de {amount} sats por la orden {orderId}, de {fiatAmount} {fiatCode} y método de pago {paymentMethod}, porque no respondiste dentro del tiempo establecido.",
     "notification_bond_slashed_dispute_message": "Has perdido tu bono anti-abuso por la resolución de la disputa de esta orden.",
     "notification_bond_slashed_dispute_detail": "Has perdido tu bono anti-abuso de {amount} sats por la orden {orderId}, de {fiatAmount} {fiatCode} y método de pago {paymentMethod}, por la resolución de la disputa.",
+    "bondLostByDisputeNotice": "Perdiste el bono anti-abuso de {amount} sats de esta orden por la resolución de la disputa.",
     "notificationDelete": "Eliminar",
     "confirmDeleteNotification": "¿Estás seguro de que quieres eliminar esta notificación?",
     "confirmClearAll": "Esto eliminará permanentemente todas las notificaciones. Esta acción no se puede deshacer.",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1191,6 +1191,8 @@
     "notification_bond_slashed_title": "Bono anti-abuso perdido",
     "notification_bond_slashed_message": "Has perdido tu bono anti-abuso porque no respondiste dentro del tiempo establecido.",
     "notification_bond_slashed_detail": "Has perdido tu bono anti-abuso de {amount} sats por la orden {orderId}, de {fiatAmount} {fiatCode} y método de pago {paymentMethod}, porque no respondiste dentro del tiempo establecido.",
+    "notification_bond_slashed_dispute_message": "Has perdido tu bono anti-abuso por la resolución de la disputa de esta orden.",
+    "notification_bond_slashed_dispute_detail": "Has perdido tu bono anti-abuso de {amount} sats por la orden {orderId}, de {fiatAmount} {fiatCode} y método de pago {paymentMethod}, por la resolución de la disputa.",
     "notificationDelete": "Eliminar",
     "confirmDeleteNotification": "¿Estás seguro de que quieres eliminar esta notificación?",
     "confirmClearAll": "Esto eliminará permanentemente todas las notificaciones. Esta acción no se puede deshacer.",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1277,6 +1277,8 @@
     "notification_bond_slashed_title": "Dépôt anti-abus perdu",
     "notification_bond_slashed_message": "Vous avez perdu votre dépôt anti-abus car vous n'avez pas répondu dans le délai imparti.",
     "notification_bond_slashed_detail": "Vous avez perdu votre dépôt anti-abus de {amount} sats pour la commande {orderId}, de {fiatAmount} {fiatCode} avec le mode de paiement {paymentMethod}, car vous n'avez pas répondu dans le délai imparti.",
+    "notification_bond_slashed_dispute_message": "Vous avez perdu votre dépôt anti-abus en raison de la résolution du litige de cette commande.",
+    "notification_bond_slashed_dispute_detail": "Vous avez perdu votre dépôt anti-abus de {amount} sats pour la commande {orderId}, de {fiatAmount} {fiatCode} avec le mode de paiement {paymentMethod}, en raison de la résolution du litige.",
     "notificationDelete": "Supprimer",
     "confirmDeleteNotification": "Êtes-vous sûr de vouloir supprimer cette notification ?",
     "confirmClearAll": "Ceci supprimera définitivement toutes les notifications. Cette action ne peut pas être annulée.",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1279,6 +1279,7 @@
     "notification_bond_slashed_detail": "Vous avez perdu votre dépôt anti-abus de {amount} sats pour la commande {orderId}, de {fiatAmount} {fiatCode} avec le mode de paiement {paymentMethod}, car vous n'avez pas répondu dans le délai imparti.",
     "notification_bond_slashed_dispute_message": "Vous avez perdu votre dépôt anti-abus en raison de la résolution du litige de cette commande.",
     "notification_bond_slashed_dispute_detail": "Vous avez perdu votre dépôt anti-abus de {amount} sats pour la commande {orderId}, de {fiatAmount} {fiatCode} avec le mode de paiement {paymentMethod}, en raison de la résolution du litige.",
+    "bondLostByDisputeNotice": "Vous avez perdu le dépôt anti-abus de {amount} sats de cette commande en raison de la résolution du litige.",
     "notificationDelete": "Supprimer",
     "confirmDeleteNotification": "Êtes-vous sûr de vouloir supprimer cette notification ?",
     "confirmClearAll": "Ceci supprimera définitivement toutes les notifications. Cette action ne peut pas être annulée.",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1257,6 +1257,8 @@
     "notification_bond_slashed_title": "Deposito anti-abuso perso",
     "notification_bond_slashed_message": "Hai perso il tuo deposito anti-abuso perché non hai risposto entro il tempo previsto.",
     "notification_bond_slashed_detail": "Hai perso il tuo deposito anti-abuso di {amount} sats per l'ordine {orderId}, di {fiatAmount} {fiatCode} con metodo di pagamento {paymentMethod}, perché non hai risposto entro il tempo previsto.",
+    "notification_bond_slashed_dispute_message": "Hai perso il tuo deposito anti-abuso a causa della risoluzione della disputa di questo ordine.",
+    "notification_bond_slashed_dispute_detail": "Hai perso il tuo deposito anti-abuso di {amount} sats per l'ordine {orderId}, di {fiatAmount} {fiatCode} con metodo di pagamento {paymentMethod}, a causa della risoluzione della disputa.",
     "notificationDelete": "Elimina",
     "confirmDeleteNotification": "Sei sicuro di voler eliminare questa notifica?",
     "confirmClearAll": "Questo eliminerà permanentemente tutte le notifiche. Questa azione non può essere annullata.",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1259,6 +1259,7 @@
     "notification_bond_slashed_detail": "Hai perso il tuo deposito anti-abuso di {amount} sats per l'ordine {orderId}, di {fiatAmount} {fiatCode} con metodo di pagamento {paymentMethod}, perché non hai risposto entro il tempo previsto.",
     "notification_bond_slashed_dispute_message": "Hai perso il tuo deposito anti-abuso a causa della risoluzione della disputa di questo ordine.",
     "notification_bond_slashed_dispute_detail": "Hai perso il tuo deposito anti-abuso di {amount} sats per l'ordine {orderId}, di {fiatAmount} {fiatCode} con metodo di pagamento {paymentMethod}, a causa della risoluzione della disputa.",
+    "bondLostByDisputeNotice": "Hai perso il deposito anti-abuso di {amount} sats di questo ordine a causa della risoluzione della disputa.",
     "notificationDelete": "Elimina",
     "confirmDeleteNotification": "Sei sicuro di voler eliminare questa notifica?",
     "confirmClearAll": "Questo eliminerà permanentemente tutte le notifiche. Questa azione non può essere annullata.",

--- a/lib/shared/utils/bond_slash_helpers.dart
+++ b/lib/shared/utils/bond_slash_helpers.dart
@@ -34,11 +34,12 @@ BondSlashCause bondSlashCause(List<MostroMessage> messages) {
 bool orderBondWasSlashed(List<MostroMessage> messages) =>
     messages.any((m) => m.action == Action.bondSlashed);
 
-/// Whether a bond slash is a timeout slash, identified positively by a plain
-/// `canceled` in the history. Dispute slashes carry admin-settled/canceled, so
-/// the false default keeps the session — the safe choice for an irreversible delete.
+/// Whether a bond slash is a timeout slash: a plain `canceled` is present AND no
+/// dispute/admin markers are. Anything else (incl. a conflicting history) returns
+/// false, keeping the session — the safe default for an irreversible delete.
 bool bondSlashIsTimeout(List<MostroMessage> messages) =>
-    messages.any((m) => m.action == Action.canceled);
+    messages.any((m) => m.action == Action.canceled) &&
+    bondSlashCause(messages) == BondSlashCause.timeout;
 
 /// The slashed bond amount carried by the order's `bond-slashed` notice, or
 /// null when there is no such message or its payload is missing.

--- a/lib/shared/utils/bond_slash_helpers.dart
+++ b/lib/shared/utils/bond_slash_helpers.dart
@@ -1,0 +1,35 @@
+import 'package:mostro_mobile/data/enums.dart';
+import 'package:mostro_mobile/data/models.dart';
+
+/// Pure helpers to classify why a bond was slashed, inferred from an order's
+/// message history.
+///
+/// The daemon sends the same `bond-slashed` notice (identical payload, no
+/// reason field) for both a waiting-state timeout slash and a solver-directed
+/// dispute slash, so the client infers the cause from context. The two causes
+/// are mutually exclusive: a timeout slash only happens in a waiting state,
+/// before any dispute; once an order is disputed, the only slash path is the
+/// admin resolution. So the presence of any dispute/admin action in the history
+/// unambiguously marks a dispute slash.
+enum BondSlashCause { timeout, dispute }
+
+/// Actions that prove the order went through a dispute / admin resolution.
+const _disputeActions = {
+  Action.disputeInitiatedByYou,
+  Action.disputeInitiatedByPeer,
+  Action.adminSettled,
+  Action.adminCanceled,
+};
+
+/// Infers the cause of a bond slash from the order's [messages]. Returns
+/// [BondSlashCause.dispute] when the history shows a dispute/admin resolution,
+/// otherwise [BondSlashCause.timeout] (also the default for an empty history).
+BondSlashCause bondSlashCause(List<MostroMessage> messages) {
+  final disputed = messages.any((m) => _disputeActions.contains(m.action));
+  return disputed ? BondSlashCause.dispute : BondSlashCause.timeout;
+}
+
+/// Whether the order's bond was slashed (a `bond-slashed` notice exists in the
+/// history). Drives the dispute-only notice shown in order details.
+bool orderBondWasSlashed(List<MostroMessage> messages) =>
+    messages.any((m) => m.action == Action.bondSlashed);

--- a/lib/shared/utils/bond_slash_helpers.dart
+++ b/lib/shared/utils/bond_slash_helpers.dart
@@ -33,3 +33,15 @@ BondSlashCause bondSlashCause(List<MostroMessage> messages) {
 /// history). Drives the dispute-only notice shown in order details.
 bool orderBondWasSlashed(List<MostroMessage> messages) =>
     messages.any((m) => m.action == Action.bondSlashed);
+
+/// The slashed bond amount carried by the order's `bond-slashed` notice, or
+/// null when there is no such message or its payload is missing.
+int? slashedBondAmount(List<MostroMessage> messages) {
+  for (final m in messages) {
+    if (m.action == Action.bondSlashed) {
+      final order = m.getPayload<Order>();
+      if (order != null) return order.amount;
+    }
+  }
+  return null;
+}

--- a/lib/shared/utils/bond_slash_helpers.dart
+++ b/lib/shared/utils/bond_slash_helpers.dart
@@ -34,6 +34,12 @@ BondSlashCause bondSlashCause(List<MostroMessage> messages) {
 bool orderBondWasSlashed(List<MostroMessage> messages) =>
     messages.any((m) => m.action == Action.bondSlashed);
 
+/// Whether a bond slash is a timeout slash, identified positively by a plain
+/// `canceled` in the history. Dispute slashes carry admin-settled/canceled, so
+/// the false default keeps the session — the safe choice for an irreversible delete.
+bool bondSlashIsTimeout(List<MostroMessage> messages) =>
+    messages.any((m) => m.action == Action.canceled);
+
 /// The slashed bond amount carried by the order's `bond-slashed` notice, or
 /// null when there is no such message or its payload is missing.
 int? slashedBondAmount(List<MostroMessage> messages) {

--- a/test/shared/utils/bond_slash_helpers_test.dart
+++ b/test/shared/utils/bond_slash_helpers_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/shared/utils/bond_slash_helpers.dart';
+
+MostroMessage _msg(Action action) =>
+    MostroMessage(action: action, id: 'order-1');
+
+void main() {
+  group('bondSlashCause', () {
+    test('timeout when no dispute or admin action is present', () {
+      expect(
+        bondSlashCause([
+          _msg(Action.payBondInvoice),
+          _msg(Action.waitingBuyerInvoice),
+          _msg(Action.canceled),
+          _msg(Action.bondSlashed),
+        ]),
+        BondSlashCause.timeout,
+      );
+    });
+
+    test('dispute when admin-settled is present', () {
+      expect(
+        bondSlashCause([
+          _msg(Action.payBondInvoice),
+          _msg(Action.disputeInitiatedByYou),
+          _msg(Action.adminSettled),
+          _msg(Action.bondSlashed),
+        ]),
+        BondSlashCause.dispute,
+      );
+    });
+
+    test('dispute when admin-canceled is present', () {
+      expect(
+        bondSlashCause([
+          _msg(Action.adminCanceled),
+          _msg(Action.bondSlashed),
+        ]),
+        BondSlashCause.dispute,
+      );
+    });
+
+    test('dispute when only a dispute-initiated action is present', () {
+      expect(
+        bondSlashCause([
+          _msg(Action.disputeInitiatedByPeer),
+          _msg(Action.bondSlashed),
+        ]),
+        BondSlashCause.dispute,
+      );
+      expect(
+        bondSlashCause([
+          _msg(Action.disputeInitiatedByYou),
+          _msg(Action.bondSlashed),
+        ]),
+        BondSlashCause.dispute,
+      );
+    });
+
+    test('timeout for an empty history (defensive default)', () {
+      expect(bondSlashCause([]), BondSlashCause.timeout);
+    });
+  });
+
+  group('orderBondWasSlashed', () {
+    test('true when a bond-slashed message exists', () {
+      expect(
+        orderBondWasSlashed([
+          _msg(Action.payBondInvoice),
+          _msg(Action.bondSlashed),
+        ]),
+        isTrue,
+      );
+    });
+
+    test('false when no bond-slashed message exists', () {
+      expect(
+        orderBondWasSlashed([
+          _msg(Action.payBondInvoice),
+          _msg(Action.canceled),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('false for an empty history', () {
+      expect(orderBondWasSlashed([]), isFalse);
+    });
+  });
+}

--- a/test/shared/utils/bond_slash_helpers_test.dart
+++ b/test/shared/utils/bond_slash_helpers_test.dart
@@ -1,10 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/shared/utils/bond_slash_helpers.dart';
 
 MostroMessage _msg(Action action) =>
     MostroMessage(action: action, id: 'order-1');
+
+MostroMessage<Order> _bondSlashedMsg(int amount) => MostroMessage<Order>(
+      action: Action.bondSlashed,
+      id: 'order-1',
+      payload: Order(
+        kind: OrderType.sell,
+        amount: amount,
+        fiatCode: 'CUP',
+        fiatAmount: 200,
+        paymentMethod: 'ggg',
+      ),
+    );
 
 void main() {
   group('bondSlashCause', () {
@@ -87,6 +101,32 @@ void main() {
 
     test('false for an empty history', () {
       expect(orderBondWasSlashed([]), isFalse);
+    });
+  });
+
+  group('slashedBondAmount', () {
+    test('returns the amount from the bond-slashed payload', () {
+      expect(
+        slashedBondAmount([
+          _msg(Action.payBondInvoice),
+          _bondSlashedMsg(300),
+        ]),
+        300,
+      );
+    });
+
+    test('returns null when there is no bond-slashed message', () {
+      expect(
+        slashedBondAmount([
+          _msg(Action.payBondInvoice),
+          _msg(Action.canceled),
+        ]),
+        isNull,
+      );
+    });
+
+    test('returns null for an empty history', () {
+      expect(slashedBondAmount([]), isNull);
     });
   });
 }

--- a/test/shared/utils/bond_slash_helpers_test.dart
+++ b/test/shared/utils/bond_slash_helpers_test.dart
@@ -142,6 +142,17 @@ void main() {
       expect(bondSlashIsTimeout([_bondSlashedMsg(300)]), isFalse);
       expect(bondSlashIsTimeout([]), isFalse);
     });
+
+    test('false when canceled and a dispute marker conflict (conflict-safe)', () {
+      expect(
+        bondSlashIsTimeout([
+          _msg(Action.canceled),
+          _msg(Action.adminSettled),
+          _bondSlashedMsg(300),
+        ]),
+        isFalse,
+      );
+    });
   });
 
   group('slashedBondAmount', () {

--- a/test/shared/utils/bond_slash_helpers_test.dart
+++ b/test/shared/utils/bond_slash_helpers_test.dart
@@ -104,6 +104,46 @@ void main() {
     });
   });
 
+  group('bondSlashIsTimeout', () {
+    test('true when a plain canceled message is present (timeout path)', () {
+      expect(
+        bondSlashIsTimeout([
+          _msg(Action.payBondInvoice),
+          _msg(Action.canceled),
+          _bondSlashedMsg(300),
+        ]),
+        isTrue,
+      );
+    });
+
+    test('false for a dispute resolution (admin-settled, no canceled)', () {
+      expect(
+        bondSlashIsTimeout([
+          _msg(Action.disputeInitiatedByYou),
+          _msg(Action.adminSettled),
+          _bondSlashedMsg(300),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('false for an admin-canceled dispute (no plain canceled)', () {
+      expect(
+        bondSlashIsTimeout([
+          _msg(Action.adminCanceled),
+          _bondSlashedMsg(300),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('false (safe default) when neither marker is present yet', () {
+      // Early-arrival race: bond-slashed before the preceding message lands.
+      expect(bondSlashIsTimeout([_bondSlashedMsg(300)]), isFalse);
+      expect(bondSlashIsTimeout([]), isFalse);
+    });
+  });
+
   group('slashedBondAmount', () {
     test('returns the amount from the bond-slashed payload', () {
       expect(


### PR DESCRIPTION
The daemon sends the same `bond-slashed` notice for timeout and dispute-resolution slashes (identical payload, no reason field). The client assumed timeout always, causing two issues, both fixed here:

  1. The forfeiture notification always said "you didn't respond in time", even on a dispute slash.
  2. On a dispute slash the loser's session was deleted, so the order vanished from My Trades and showed the wrong buy/sell direction when opened.

  ## Changes
  - Infer the slash cause from the order history (pure helpers in `bond_slash_helpers.dart`).
  - Notification picks the timeout/dispute message + detail variant (en/es/it/de/fr).
  - Order details shows a "bond lost due to dispute resolution" line (dispute only),
    with the amount from the message.
  - `bond-slashed` deletes the session only on timeout; a dispute slash keeps it
    (trade stays in My Trades with its role intact).
  - Docs updated.

  ## How to test manually
  1. Enable bonds on a regtest node (`apply_to = both`) and take/create a bonded order.
  2. **Dispute slash:** open a dispute, have the admin settle/cancel directing a slash against you. Expect: the notification says it was due to the dispute resolution; the order **stays** in My Trades showing the correct buy/sell direction; order details shows the "bond lost due to dispute resolution" line with the amount.
  3. **Timeout slash:** let a waiting-state deadline elapse on a bonded order (`slash_on_waiting_timeout = true`). Expect: notification says you didn't respond in time; the order is removed from My Trades; no line in order details.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bond loss notifications now distinguish between dispute resolutions and timeouts, displaying tailored messages for each scenario.
  * Improved order session handling based on the type of bond loss.

* **Documentation**
  * Updated anti-abuse bond specification with expanded helper coverage and clarified slash behavior distinctions.

* **Tests**
  * Added test coverage for bond slash classification logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->