### PR TITLE
feat(nwc): allow paying invoice from another wallet on insufficient balance

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1538,6 +1538,7 @@
     "nwcQuotaExceeded": "Ausgabenlimit der Wallet überschritten",
     "nwcRetryPayment": "Zahlung wiederholen",
     "nwcPayManually": "Stattdessen manuell zahlen",
+    "nwcShowInvoice": "Rechnung anzeigen",
     "nwcPreimageLabel": "Preimage",
     "nwcGenerateWithWallet": "Mit Wallet generieren",
     "nwcInvoiceGenerating": "Rechnung wird generiert...",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1557,6 +1557,7 @@
     "nwcQuotaExceeded": "Wallet spending quota exceeded",
     "nwcRetryPayment": "Retry Payment",
     "nwcPayManually": "Pay manually instead",
+    "nwcShowInvoice": "Show invoice",
     "nwcPreimageLabel": "Preimage",
     "nwcGenerateWithWallet": "Generate with Wallet",
     "nwcInvoiceGenerating": "Generating invoice...",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1513,6 +1513,7 @@
     "nwcQuotaExceeded": "Cuota de gastos de la billetera excedida",
     "nwcRetryPayment": "Reintentar Pago",
     "nwcPayManually": "Pagar manualmente",
+    "nwcShowInvoice": "Mostrar factura",
     "nwcPreimageLabel": "Preimagen",
     "nwcGenerateWithWallet": "Generar con Billetera",
     "nwcInvoiceGenerating": "Generando factura...",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1538,6 +1538,7 @@
     "nwcQuotaExceeded": "Quota de dépenses du portefeuille dépassé",
     "nwcRetryPayment": "Réessayer le paiement",
     "nwcPayManually": "Payer manuellement à la place",
+    "nwcShowInvoice": "Afficher la facture",
     "nwcPreimageLabel": "Preimage",
     "nwcGenerateWithWallet": "Générer avec le portefeuille",
     "nwcInvoiceGenerating": "Génération de facture...",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1579,6 +1579,7 @@
     "nwcQuotaExceeded": "Quota di spesa del portafoglio superata",
     "nwcRetryPayment": "Riprova Pagamento",
     "nwcPayManually": "Paga manualmente",
+    "nwcShowInvoice": "Mostra fattura",
     "nwcPreimageLabel": "Preimage",
     "nwcGenerateWithWallet": "Genera con Portafoglio",
     "nwcInvoiceGenerating": "Generazione fattura...",

--- a/lib/shared/widgets/nwc_payment_widget.dart
+++ b/lib/shared/widgets/nwc_payment_widget.dart
@@ -62,6 +62,7 @@ class _NwcPaymentWidgetState extends ConsumerState<NwcPaymentWidget> {
   String? _preimage;
   int? _feesPaidMsats;
   DateTime? _paymentTimestamp;
+  bool _refreshingBalance = false;
 
   Future<void> _payWithWallet() async {
     final nwcNotifier = ref.read(nwcProvider.notifier);
@@ -172,10 +173,16 @@ class _NwcPaymentWidgetState extends ConsumerState<NwcPaymentWidget> {
 
   @override
   Widget build(BuildContext context) {
+    // Show the "Show invoice" fallback whenever the user is not actively
+    // paying or already done, so they can always pay from another wallet
+    // (e.g. when the NWC wallet has insufficient balance).
+    final showFallback = _status == NwcPaymentStatus.idle ||
+        _status == NwcPaymentStatus.failed;
+
     return Column(
       children: [
         _buildPaymentArea(),
-        if (_status == NwcPaymentStatus.failed) ...[
+        if (showFallback) ...[
           const SizedBox(height: 12),
           _buildFallbackButton(),
         ],
@@ -280,14 +287,21 @@ class _NwcPaymentWidgetState extends ConsumerState<NwcPaymentWidget> {
         ),
         if (balanceSats != null) ...[
           const SizedBox(height: 8),
-          Text(
-            '${S.of(context)!.walletBalance}: ${_formatSats(balanceSats)} sats',
-            style: TextStyle(
-              color: hasEnoughBalance
-                  ? AppTheme.cream1.withAlpha(153)
-                  : Colors.red.shade300,
-              fontSize: 13,
-            ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '${S.of(context)!.walletBalance}: ${_formatSats(balanceSats)} sats',
+                style: TextStyle(
+                  color: hasEnoughBalance
+                      ? AppTheme.cream1.withAlpha(153)
+                      : Colors.red.shade300,
+                  fontSize: 13,
+                ),
+              ),
+              const SizedBox(width: 4),
+              _buildRefreshBalanceButton(hasEnoughBalance),
+            ],
           ),
         ],
       ],
@@ -414,11 +428,51 @@ class _NwcPaymentWidgetState extends ConsumerState<NwcPaymentWidget> {
     return TextButton.icon(
       onPressed: widget.onFallbackToManual,
       icon: const Icon(LucideIcons.qrCode, size: 16),
-      label: Text(S.of(context)!.nwcPayManually),
+      label: Text(S.of(context)!.nwcShowInvoice),
       style: TextButton.styleFrom(
         foregroundColor: AppTheme.cream1.withAlpha(179),
       ),
     );
+  }
+
+  Widget _buildRefreshBalanceButton(bool hasEnoughBalance) {
+    if (_refreshingBalance) {
+      return const SizedBox(
+        width: 14,
+        height: 14,
+        child: CircularProgressIndicator(
+          color: AppTheme.mostroGreen,
+          strokeWidth: 2,
+        ),
+      );
+    }
+
+    return InkWell(
+      onTap: _refreshBalance,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.all(2),
+        child: Icon(
+          LucideIcons.refreshCw,
+          size: 14,
+          color: hasEnoughBalance
+              ? AppTheme.cream1.withAlpha(153)
+              : Colors.red.shade300,
+        ),
+      ),
+    );
+  }
+
+  /// Manually refreshes the wallet balance (e.g. after the user tops up the
+  /// connected wallet from outside the app).
+  Future<void> _refreshBalance() async {
+    if (_refreshingBalance) return;
+    setState(() => _refreshingBalance = true);
+    try {
+      await ref.read(nwcProvider.notifier).refreshBalance();
+    } finally {
+      if (mounted) setState(() => _refreshingBalance = false);
+    }
   }
 
   String _truncatePreimage(String? value, int keep) {


### PR DESCRIPTION
## Summary

When paying via NWC, the user is no longer stuck if the connected wallet has insufficient funds or the payment fails.

- Always show a "Show invoice" button in the NWC payment flow so the user can pay the invoice from another wallet, keeping the order alive instead of having to cancel.
- Add a manual refresh button next to the wallet balance so it updates instantly after topping up the wallet, without waiting for the periodic refresh.
- Add `nwcShowInvoice` localization key (en/es/it/fr/de).

Closes #476
