### PR TITLE
fix(restore): show new-invoice prompt for failed payout in settled-hold-invoice

### DIFF
--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:dart_nostr/nostr/core/key_pairs.dart';
 import 'package:dart_nostr/nostr/model/event/event.dart';
@@ -732,15 +733,15 @@ class RestoreService {
               .where((d) => d.orderId == orderDetail.id)
               .firstOrNull;
 
+          final session = ref
+              .read(sessionNotifierProvider.notifier)
+              .getSessionByOrderId(orderDetail.id);
+
           // Determine action and create dispute if needed
           Action action;
           Dispute? dispute;
 
           if (restoredDispute != null && order.status == Status.dispute) {
-            final session = ref
-                .read(sessionNotifierProvider.notifier)
-                .getSessionByOrderId(orderDetail.id);
-
             final initiator = restoredDispute.initiator;
             final bool userInitiated =
                 (initiator == 'buyer' && session?.role == Role.buyer) ||
@@ -766,9 +767,6 @@ class RestoreService {
             logger.i('Restore: dispute found for order ${orderDetail.id}');
           } else {
             // Regular order without dispute
-            final session = ref
-                .read(sessionNotifierProvider.notifier)
-                .getSessionByOrderId(orderDetail.id);
             action = _getActionFromStatus(order.status, session?.role);
           }
 
@@ -838,19 +836,38 @@ class RestoreService {
               }
             }
 
+            // `settled-hold-invoice` is overloaded for the buyer (see issue
+            // #615): it covers both "hold settled, sats in flight" and "payout
+            // failed, awaiting a new invoice", so rebuilding from the snapshot
+            // status alone always lands on the "paying sats" screen. Resolve
+            // the substate from the stored history instead.
+            final replay = await restoreReplayPlan(
+              snapshotAction: action,
+              snapshotTimestamp: orderDetail.createdAt ??
+                  DateTime.now().millisecondsSinceEpoch,
+              status: order.status,
+              role: session?.role,
+              loadStoredMessages: () =>
+                  storage.getAllMessagesForOrderId(orderDetail.id),
+            );
+            if (replay.action != action) {
+              logger.i(
+                'Restore: detected failed payout for order ${orderDetail.id}, '
+                'replaying ${replay.action.value} instead of ${action.value}',
+              );
+            }
+
             // Create regular order message with Order payload
             final mostroMessage = MostroMessage<Order>(
               id: orderDetail.id,
-              action: action,
+              action: replay.action,
               payload: order,
-              timestamp:
-                  orderDetail.createdAt ??
-                  DateTime.now().millisecondsSinceEpoch,
+              timestamp: replay.timestamp,
             );
 
             // Save order message to storage
             final key =
-                '${orderDetail.id}_restore_${action.value}_${DateTime.now().millisecondsSinceEpoch}';
+                '${orderDetail.id}_restore_${replay.action.value}_${DateTime.now().millisecondsSinceEpoch}';
             await storage.addMessage(key, mostroMessage);
 
             // Update state with order message
@@ -1168,6 +1185,73 @@ Future<Map<String, dynamic>> decodeRestoreMessage(
     throw Exception('Restore message tuple is empty');
   }
   return contentList[0] as Map<String, dynamic>;
+}
+
+/// Detects the "payout failed, awaiting a new invoice" substate of an order
+/// that Mostro reports as `settled-hold-invoice`. See issue #615.
+///
+/// `settled-hold-invoice` is overloaded for the buyer: it covers both "hold
+/// settled, sats in flight" and "payout failed, awaiting a new invoice", so the
+/// snapshot status alone cannot recover the failed substate. Only the stored
+/// message history can, through two independent signals:
+///
+/// - `Action.paymentFailed`, which Mostro sends on the first failed payout, is
+///   definitive on its own. (The *status* `payment-failed` is client-side and
+///   never travels on the wire; the action does.) It is not sent on retries, so
+///   a restored history may well be missing it.
+/// - `Action.addInvoice`, which Mostro reuses to ask for a payout invoice after
+///   a failed payment. The same action also opens the normal buyer flow, so it
+///   is a signal only when its payload carries `settled-hold-invoice`; the
+///   early one carries `waiting-buyer-invoice`. This is the discriminator
+///   [OrderState.updateWith] already uses.
+///
+/// Reading the payload rather than the position in the history keeps this
+/// correct no matter how complete or how ordered the relay-replayed history
+/// that reaches storage during the restore window happens to be.
+bool restoreHasFailedPayoutSignal(List<MostroMessage> messages) => messages.any(
+      (m) =>
+          m.action == Action.paymentFailed ||
+          (m.action == Action.addInvoice &&
+              m.getPayload<Order>()?.status == Status.settledHoldInvoice),
+    );
+
+/// Picks the action and timestamp restore replays to rebuild one snapshot
+/// order, resolving the overloaded `settled-hold-invoice` status for the buyer.
+///
+/// Returns the snapshot's own action untouched unless the order is a buyer's
+/// `settled-hold-invoice` whose history carries a failed-payout signal (see
+/// [restoreHasFailedPayoutSignal]). In that case it replays `add-invoice`
+/// instead, which [OrderState.updateWith] maps to `payment-failed` because the
+/// payload carries `settled-hold-invoice` — landing the order on the
+/// new-invoice prompt rather than the "paying sats" screen.
+///
+/// [loadStoredMessages] is a callback so the history is read only for the
+/// orders that can need it.
+Future<({Action action, int timestamp})> restoreReplayPlan({
+  required Action snapshotAction,
+  required int snapshotTimestamp,
+  required Status status,
+  required Role? role,
+  required Future<List<MostroMessage>> Function() loadStoredMessages,
+}) async {
+  if (status != Status.settledHoldInvoice || role != Role.buyer) {
+    return (action: snapshotAction, timestamp: snapshotTimestamp);
+  }
+
+  final stored = await loadStoredMessages();
+  if (!restoreHasFailedPayoutSignal(stored)) {
+    return (action: snapshotAction, timestamp: snapshotTimestamp);
+  }
+
+  // Stamp the replay after every message already in storage. A later
+  // OrderNotifier.sync() replays storage sorted by timestamp, so seeding from
+  // the order creation time instead would let an older re-delivered
+  // `released`/`settled` replay last and drag the buyer back to "paying sats",
+  // making the fix non-persistent across provider recreation or app restart.
+  final latest = stored
+      .map((m) => m.timestamp ?? 0)
+      .fold(snapshotTimestamp, math.max);
+  return (action: Action.addInvoice, timestamp: latest + 1);
 }
 
 /// Thrown when Mostro responds with cant-do: invalid_trade_index to

--- a/test/features/restore/restore_failed_payout_test.dart
+++ b/test/features/restore/restore_failed_payout_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models.dart';
+import 'package:mostro_mobile/data/enums.dart';
+import 'package:mostro_mobile/features/order/models/order_state.dart';
+import 'package:mostro_mobile/features/restore/restore_manager.dart';
+
+/// Regression coverage for issue #615: restoring an order that Mostro reports
+/// as `settled-hold-invoice` after a failed Lightning payout must land on the
+/// new-invoice prompt (`add-invoice` + `payment-failed`), not "paying sats"
+/// (`released` + `settled-hold-invoice`).
+
+MostroMessage<Order> _msg(
+  Action action, {
+  int? timestamp,
+  Status payloadStatus = Status.settledHoldInvoice,
+}) =>
+    MostroMessage<Order>(
+      action: action,
+      id: 'order-1',
+      timestamp: timestamp,
+      payload: Order(
+        id: 'order-1',
+        kind: OrderType.buy,
+        status: payloadStatus,
+        amount: 500,
+        fiatCode: 'USD',
+        fiatAmount: 50,
+        paymentMethod: 'Cash',
+      ),
+    );
+
+/// The payout request Mostro sends after a failed payment: `add-invoice`
+/// carrying a settled order.
+MostroMessage<Order> _payoutAddInvoice({int? timestamp}) =>
+    _msg(Action.addInvoice, timestamp: timestamp);
+
+/// The `add-invoice` that opens the normal buyer flow, before any settlement.
+MostroMessage<Order> _earlyAddInvoice({int? timestamp}) => _msg(
+      Action.addInvoice,
+      timestamp: timestamp,
+      payloadStatus: Status.waitingBuyerInvoice,
+    );
+
+/// Replays a sequence of actions onto a fresh order state, mirroring how
+/// RestoreService.restore() applies snapshot-derived messages via
+/// OrderNotifier.updateStateFromMessage().
+OrderState _replay(List<Action> actions) {
+  OrderState state = OrderState(
+    action: Action.newOrder,
+    status: Status.pending,
+    order: null,
+  );
+  for (final action in actions) {
+    state = state.updateWith(_msg(action));
+  }
+  return state;
+}
+
+Future<({Action action, int timestamp})> _plan({
+  required List<MostroMessage> stored,
+  Action snapshotAction = Action.released,
+  int snapshotTimestamp = 100,
+  Status status = Status.settledHoldInvoice,
+  Role? role = Role.buyer,
+  void Function()? onLoad,
+}) =>
+    restoreReplayPlan(
+      snapshotAction: snapshotAction,
+      snapshotTimestamp: snapshotTimestamp,
+      status: status,
+      role: role,
+      loadStoredMessages: () async {
+        onLoad?.call();
+        return stored;
+      },
+    );
+
+void main() {
+  group('restoreHasFailedPayoutSignal', () {
+    test('returns false for empty history', () {
+      expect(restoreHasFailedPayoutSignal([]), isFalse);
+    });
+
+    // Mostro sends payment-failed on the first failed payout only, so it is
+    // definitive when present but cannot be required.
+    test('returns true when payment-failed is present', () {
+      expect(
+        restoreHasFailedPayoutSignal([
+          _msg(Action.paymentFailed, timestamp: 1),
+        ]),
+        isTrue,
+      );
+    });
+
+    // The payout add-invoice is told apart from the early one by its payload
+    // status, the same discriminator OrderState.updateWith uses, so a partial
+    // or out-of-order relay-replayed history cannot fool it either way.
+    test('returns true for an add-invoice carrying a settled order', () {
+      expect(
+        restoreHasFailedPayoutSignal([_payoutAddInvoice(timestamp: 1)]),
+        isTrue,
+      );
+    });
+
+    test('returns true for a payout add-invoice with no release in history',
+        () {
+      expect(
+        restoreHasFailedPayoutSignal([_payoutAddInvoice(timestamp: 1)]),
+        isTrue,
+      );
+    });
+
+    test('returns false for the early waiting-buyer-invoice add-invoice', () {
+      expect(
+        restoreHasFailedPayoutSignal([
+          _earlyAddInvoice(timestamp: 1),
+          _msg(Action.released, timestamp: 2),
+        ]),
+        isFalse,
+      );
+    });
+
+    // Partial happy-path history: the relay delivered the early add-invoice but
+    // not the release yet. Ordering alone would misread this as a failed payout.
+    test('returns false for a lone early add-invoice with no release yet', () {
+      expect(
+        restoreHasFailedPayoutSignal([_earlyAddInvoice(timestamp: 1)]),
+        isFalse,
+      );
+    });
+
+    test('returns false for a settled order with no failed-payout signal', () {
+      expect(
+        restoreHasFailedPayoutSignal([
+          _msg(Action.holdInvoicePaymentSettled, timestamp: 1),
+        ]),
+        isFalse,
+      );
+    });
+  });
+
+  group('restoreReplayPlan', () {
+    test('replays add-invoice for a buyer whose payout failed', () async {
+      final plan = await _plan(stored: [_payoutAddInvoice(timestamp: 1)]);
+
+      expect(plan.action, equals(Action.addInvoice));
+    });
+
+    test('keeps the snapshot action for a buyer with no failed payout',
+        () async {
+      final plan = await _plan(
+        stored: [_msg(Action.holdInvoicePaymentSettled, timestamp: 1)],
+      );
+
+      expect(plan.action, equals(Action.released));
+      expect(plan.timestamp, equals(100));
+    });
+
+    // The seller never sees the payout prompt: settled-hold-invoice means the
+    // hold was settled and the trade is over for them.
+    test('keeps the snapshot action for a seller', () async {
+      var loaded = false;
+      final plan = await _plan(
+        stored: [_payoutAddInvoice(timestamp: 1)],
+        role: Role.seller,
+        onLoad: () => loaded = true,
+      );
+
+      expect(plan.action, equals(Action.released));
+      expect(loaded, isFalse, reason: 'history is only read when it can matter');
+    });
+
+    test('keeps the snapshot action for another status', () async {
+      var loaded = false;
+      final plan = await _plan(
+        stored: [_payoutAddInvoice(timestamp: 1)],
+        status: Status.active,
+        snapshotAction: Action.buyerTookOrder,
+        onLoad: () => loaded = true,
+      );
+
+      expect(plan.action, equals(Action.buyerTookOrder));
+      expect(loaded, isFalse, reason: 'history is only read when it can matter');
+    });
+
+    // A later OrderNotifier.sync() replays storage sorted by timestamp, so the
+    // replayed add-invoice has to outrank every message already there or an
+    // older released would win and drag the buyer back to "paying sats".
+    test('stamps the replay after the latest stored message', () async {
+      final plan = await _plan(
+        stored: [
+          _msg(Action.released, timestamp: 900),
+          _payoutAddInvoice(timestamp: 950),
+        ],
+      );
+
+      expect(plan.timestamp, equals(951));
+    });
+
+    test('never stamps the replay before the snapshot timestamp', () async {
+      final plan = await _plan(
+        stored: [_payoutAddInvoice(timestamp: 5)],
+        snapshotTimestamp: 100,
+      );
+
+      expect(plan.timestamp, equals(101));
+    });
+
+    test('tolerates stored messages with no timestamp', () async {
+      final plan = await _plan(stored: [_payoutAddInvoice()]);
+
+      expect(plan.action, equals(Action.addInvoice));
+      expect(plan.timestamp, equals(101));
+    });
+  });
+
+  group('restore state rebuild for settled-hold-invoice + buyer', () {
+    test('failed payout replays to payment-failed + add-invoice '
+        '(new-invoice prompt)', () {
+      final state = _replay([Action.addInvoice]);
+
+      expect(state.status, equals(Status.paymentFailed));
+      expect(state.action, equals(Action.addInvoice));
+    });
+
+    test('happy path replays to settled-hold-invoice + released (paying sats)',
+        () {
+      final state = _replay([Action.released]);
+
+      expect(state.status, equals(Status.settledHoldInvoice));
+      expect(state.action, equals(Action.released));
+    });
+  });
+}


### PR DESCRIPTION
Closes #615

When Mostro's Lightning payout to the buyer fails, the order stays at `settled-hold-invoice` and the daemon asks for a new invoice. On restore the state was rebuilt purely from the snapshot status, so this substate regressed into the "released / paying sats" screen instead of the new-invoice prompt.

`settled-hold-invoice` is overloaded for the buyer: it covers both "hold settled, sats in flight" and "payout failed, awaiting a new invoice". The snapshot status alone cannot tell them apart, so restore has to resolve the substate from the stored message history.

## Changes

- Add `restoreHasFailedPayoutSignal()`, which reads the same discriminator `OrderState.updateWith` already uses since `ca094cab`: `payment-failed`, or an `add-invoice` whose payload carries `settled-hold-invoice`. The `add-invoice` that opens the normal buyer flow carries `waiting-buyer-invoice`, so neither a partial nor an out-of-order relay-replayed history can be misread as a failed payout.
- Add `restoreReplayPlan()`, which replays `add-invoice` in place of the snapshot action for a buyer's failed payout. `updateWith` maps that to `payment-failed` on its own, so no synthetic `payment-failed` message is fabricated or persisted.
- Stamp the replayed message after every message already in storage, so a later `OrderNotifier.sync()` cannot replay an older `released` last and drag the buyer back to "paying sats".
- Hoist the session lookup that was duplicated in both branches of the restore loop.
- Add regression tests.

## Scope

`ca094cab` on `main` already covers the persistence half: `sync()` converges to `payment-failed` from the real stored `add-invoice`, whose arrival timestamp outranks the synthetic `released` stamped at `createdAt`. What remained broken, and what this PR fixes, is the **initial post-restore state**: the first render after restore, before any further message arrives.

## Acceptance criteria

- [x] Restore with a failed payout shows the new-invoice prompt, not "paying sats".
- [x] Happy path (`settled-hold-invoice` with no failed payout) still shows "released / paying sats".
- [x] A seller in `settled-hold-invoice` is unaffected.
- [x] Post-restore state matches pre-restore state and survives a later `sync()`.
- [x] Regression tests for signal detection, the replay plan (role gate, status gate, timestamp seeding) and the rebuilt state.

## Verification

- `flutter analyze`: no issues
- `flutter test`: 1116 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order restoration for “failed payout, awaiting new invoice” cases, reliably replaying the correct recovery sequence while preserving message timing and ordering.
  * Restored order state accurately across successful and failed payout histories, including cases with missing timestamps.

* **Tests**
  * Added regression coverage for failed-payout detection, state rebuilding, replay selection, timing, ordering, and negative scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
