### PR TITLE
feat: add dual send for transport v2 (Phase B)

### DIFF
--- a/docs/architecture/SESSION_RECOVERY_ARCHITECTURE.md
+++ b/docs/architecture/SESSION_RECOVERY_ARCHITECTURE.md
@@ -151,7 +151,13 @@ Future<void> importMnemonicAndRestore(String mnemonic) async {
 
 **File**: `lib/features/restore/restore_manager.dart:116-141`
 
-Creates a temporary subscription using trade key index 1 to receive Mostro responses:
+Creates a temporary subscription using trade key index 1 to receive Mostro
+responses. To interoperate across the transport v2 migration it listens on
+**both** wire transports at once — v1 gift wrap (kind 1059) and v2 NIP-44 direct
+(kind 14) — because the node info (kind 38385) that advertises `protocol_version`
+may not have loaded yet when restore starts. The node answers on whichever
+transport it speaks; the v2 filter pins `authors = [mostroPubkey]` to disambiguate
+from NIP-17 chat (also kind 14). See `TRANSPORT_V2_MIGRATION.md`.
 
 ```dart
 Future<StreamSubscription<NostrEvent>> _createTempSubscription() async {
@@ -159,18 +165,30 @@ Future<StreamSubscription<NostrEvent>> _createTempSubscription() async {
     throw Exception('Temp trade key not initialized');
   }
 
-  final filter = NostrFilter(
+  final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
+  final v1Filter = NostrFilter(
     kinds: [1059],
     p: [_tempTradeKey!.public],
     limit: 0, // No historical events, only new ones
   );
+  final v2Filter = NostrFilter(
+    kinds: [14],
+    authors: [mostroPubkey],
+    p: [_tempTradeKey!.public],
+    limit: 0,
+  );
 
-  final request = NostrRequest(filters: [filter]);
+  final request = NostrRequest(filters: [v1Filter, v2Filter]);
   final stream = ref.read(nostrServiceProvider).subscribeToEvents(request);
-  
+
   return stream.listen(_handleTempSubscriptionsResponse);
 }
 ```
+
+The response is decoded by the top-level `decodeRestoreMessage(event, tempTradeKey,
+mostroPubkey)`, which branches on `event.kind`: kind 14 is NIP-44 decrypted (and
+the node signature verified) straight to the tuple, while kind 1059 is gift-wrap
+unwrapped to a rumor whose content is the tuple. Both converge on `tuple[0]`.
 
 ### Stage 3: Data Request Sequence
 

--- a/docs/architecture/TRANSPORT_V2_MIGRATION.md
+++ b/docs/architecture/TRANSPORT_V2_MIGRATION.md
@@ -304,11 +304,15 @@ unchanged.
   `version: 2`; computes the trade signature; computes the identity proof
   (domain-tagged string signed with the master key, `null` in full-privacy);
   NIP-44 encrypts the 3-tuple toward the node; emits a kind-`14` event **signed
-  by the trade key** with `p` and NIP-40 `expiration` tags.
-- Route `MostroService.publishOrder` through the resolved transport (reuses the
-  Phase A resolver / `protocol_version`). **Preserve PoW**
-  (`NostrUtils.mineProofOfWork`) for the first-contact lane — the daemon may
-  still require PoW on the kind-14 event id.
+  by the trade key** with a `p` tag (the NIP-40 `expiration` tag is omitted; see
+  the note below).
+- Route **every** outbound Mostro send through the resolved transport via a
+  single `MostroMessage.wrapForTransport(protocolVersion: …)` entry point — not
+  just `MostroService.publishOrder`, but also the `RestoreManager` requests
+  (restore, order-details, last-trade-index) and
+  `DisputeRepository.createDispute`, so a v2 node never receives a stray v1 gift
+  wrap. **Preserve PoW** (`NostrUtils.mineProofOfWork`) for the first-contact
+  lane — the daemon may still require PoW on the kind-14 event id.
 - **Identity proof signature** mirrors `mostro-core`'s `transport.rs`: the
   trade-key signature (tuple element 1) is the existing `MostroMessage.sign`
   (SHA-256 hex digest then Schnorr), and the identity proof (element 2) is the

--- a/docs/architecture/TRANSPORT_V2_MIGRATION.md
+++ b/docs/architecture/TRANSPORT_V2_MIGRATION.md
@@ -18,10 +18,10 @@ during the migration window.
 > - **Reference client (CLI)**: `MostroP2P/mostro-cli` PRs #176, #177, #178 and
 >   its `docs/TRANSPORT_V2_SPEC.md`.
 >
-> **Status.** Living design specification. **Phase A (dual receive) is
-> implemented** in this branch, including `protocol_version` auto-detection and
-> per-node transport resolution on the receive path. The remaining phases (§5)
-> are pending.
+> **Status.** Living design specification. **Phase A (dual receive)** —
+> including `protocol_version` auto-detection and per-node transport resolution
+> on the receive path — is merged to `main`. **Phase B (dual send)** is
+> implemented in this branch. Phases C–D (§5) are pending.
 
 ---
 
@@ -305,11 +305,17 @@ unchanged.
   (domain-tagged string signed with the master key, `null` in full-privacy);
   NIP-44 encrypts the 3-tuple toward the node; emits a kind-`14` event **signed
   by the trade key** with `p` and NIP-40 `expiration` tags.
-- Route `MostroService.publishOrder`
-  (`lib/services/mostro_service.dart:338-360`) through the resolved transport.
-  **Preserve PoW** (`NostrUtils.mineProofOfWork`,
-  `lib/shared/utils/nostr_utils.dart:564-630`) for the first-contact lane — the
-  daemon may still require PoW on the kind-14 event id.
+- Route `MostroService.publishOrder` through the resolved transport (reuses the
+  Phase A resolver / `protocol_version`). **Preserve PoW**
+  (`NostrUtils.mineProofOfWork`) for the first-contact lane — the daemon may
+  still require PoW on the kind-14 event id.
+- **Identity proof signature** mirrors `mostro-core`'s `transport.rs`: the
+  trade-key signature (tuple element 1) is the existing `MostroMessage.sign`
+  (SHA-256 hex digest then Schnorr), and the identity proof (element 2) is the
+  master key signing `mostro-transport-v2-identity:<tradePubkey>:<messageJSON>`
+  with the same scheme. Both are `null` in full-privacy mode.
+- The NIP-40 `expiration` tag is **omitted** (the daemon treats it as optional /
+  caller-supplied), avoiding any risk of a message expiring before processing.
 
 ### Phase C — Send-side wiring
 

--- a/lib/data/models/mostro_message.dart
+++ b/lib/data/models/mostro_message.dart
@@ -6,6 +6,7 @@ import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
 import 'package:mostro_mobile/data/models/payload.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 class MostroMessage<T extends Payload> {
@@ -232,5 +233,40 @@ class MostroMessage<T extends Payload> {
       return NostrUtils.mineProofOfWork(event, difficulty, tradeKey);
     }
     return event;
+  }
+
+  /// Wraps the message for the transport advertised by the node's
+  /// [protocolVersion] (§5 Phase B): v2 (NIP-44 direct, kind 14) via
+  /// [wrapNip44] or v1 (gift wrap, kind 1059) via [wrap].
+  ///
+  /// Single entry point so every outbound Mostro send — order actions, restore
+  /// requests, dispute creation — selects the transport consistently from the
+  /// connected node, instead of hard-coding the v1 path.
+  Future<NostrEvent> wrapForTransport({
+    required int? protocolVersion,
+    required NostrKeyPairs tradeKey,
+    required String recipientPubKey,
+    NostrKeyPairs? masterKey,
+    int? keyIndex,
+    int difficulty = 0,
+  }) {
+    switch (resolveTransport(protocolVersion)) {
+      case Transport.nip44:
+        return wrapNip44(
+          tradeKey: tradeKey,
+          recipientPubKey: recipientPubKey,
+          masterKey: masterKey,
+          keyIndex: keyIndex,
+          difficulty: difficulty,
+        );
+      case Transport.giftWrap:
+        return wrap(
+          tradeKey: tradeKey,
+          recipientPubKey: recipientPubKey,
+          masterKey: masterKey,
+          keyIndex: keyIndex,
+          difficulty: difficulty,
+        );
+    }
   }
 }

--- a/lib/data/models/mostro_message.dart
+++ b/lib/data/models/mostro_message.dart
@@ -25,9 +25,9 @@ class MostroMessage<T extends Payload> {
     this.timestamp,
   }) : _payload = payload;
 
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toJson({int? version}) {
     Map<String, dynamic> json = {
-      'version': Config.mostroVersion,
+      'version': version ?? Config.mostroVersion,
       'request_id': requestId,
       'trade_index': tradeIndex,
     };
@@ -97,30 +97,37 @@ class MostroMessage<T extends Payload> {
     return null;
   }
 
-  String sign(NostrKeyPairs keyPair) {
+  String sign(NostrKeyPairs keyPair, {int? version}) {
     //IMPORTANT : Use 'restore' key for restore and last-trade-index actions, 'order' for everything else, as per protocol
     final wrapperKey =
         action == Action.restore || action == Action.lastTradeIndex
         ? 'restore'
         : 'order';
-    final message = {wrapperKey: toJson()};
+    final message = {wrapperKey: toJson(version: version)};
     final serializedEvent = jsonEncode(message);
-    final bytes = utf8.encode(serializedEvent);
-    final digest = sha256.convert(bytes);
-    final hash = hex.encode(digest.bytes);
-    final signature = keyPair.sign(hash);
-    return signature;
+    return _mostroSign(serializedEvent, keyPair);
   }
 
-  String serialize({NostrKeyPairs? keyPair}) {
+  /// Signs a UTF-8 string the Mostro way: SHA-256 digest, hex-encoded, then
+  /// Schnorr-signed. Shared by the message [sign] and the protocol-v2 identity
+  /// proof so both produce signatures the daemon can verify identically.
+  String _mostroSign(String message, NostrKeyPairs keyPair) {
+    final bytes = utf8.encode(message);
+    final digest = sha256.convert(bytes);
+    final hash = hex.encode(digest.bytes);
+    return keyPair.sign(hash);
+  }
+
+  String serialize({NostrKeyPairs? keyPair, int? version}) {
     //IMPORTANT : Use 'restore' key for restore and last-trade-index actions, 'order' for everything else, as per protocol
     final wrapperKey =
         action == Action.restore || action == Action.lastTradeIndex
         ? 'restore'
         : 'order';
-    final message = {wrapperKey: toJson()};
+    final message = {wrapperKey: toJson(version: version)};
     final serializedEvent = jsonEncode(message);
-    final signature = (keyPair != null) ? '"${sign(keyPair)}"' : null;
+    final signature =
+        (keyPair != null) ? '"${sign(keyPair, version: version)}"' : null;
     final content = '[$serializedEvent, $signature]';
     return content;
   }
@@ -158,5 +165,72 @@ class MostroMessage<T extends Payload> {
       recipientPubKey,
       difficulty: difficulty,
     );
+  }
+
+  /// Wraps the message for protocol v2 (NIP-44 direct, kind 14).
+  ///
+  /// Produces the 3-tuple `[message, tradeSig, identityProof]` (§3.3), NIP-44
+  /// encrypts it toward [recipientPubKey] with the trade key, and emits a
+  /// kind-14 event **signed by the trade key** carrying a `p` tag. Mirrors
+  /// `mostro-core`'s `transport.rs` wrap:
+  /// - the message JSON carries `version: 2`;
+  /// - in reputation mode (master key present) `tradeSig` is the trade-key
+  ///   signature over the message and `identityProof` is
+  ///   `[identityPubkey, sig]` where the signature is over
+  ///   `mostro-transport-v2-identity:<tradePubkey>:<messageJSON>` made with the
+  ///   master key;
+  /// - in full-privacy mode (no master key) both are `null`.
+  ///
+  /// PoW (NIP-13), when [difficulty] > 0, is mined on the kind-14 event id and
+  /// signed by the trade key — the first-contact lane is preserved.
+  Future<NostrEvent> wrapNip44({
+    required NostrKeyPairs tradeKey,
+    required String recipientPubKey,
+    NostrKeyPairs? masterKey,
+    int? keyIndex,
+    int difficulty = 0,
+  }) async {
+    tradeIndex = keyIndex;
+
+    final wrapperKey =
+        action == Action.restore || action == Action.lastTradeIndex
+        ? 'restore'
+        : 'order';
+    final messageMap = {wrapperKey: toJson(version: 2)};
+    final messageJson = jsonEncode(messageMap);
+
+    // Reputation mode binds the identity; full privacy omits both signatures.
+    final String? tradeSig =
+        masterKey != null ? _mostroSign(messageJson, tradeKey) : null;
+
+    List<String>? identityProof;
+    if (masterKey != null) {
+      final payload =
+          'mostro-transport-v2-identity:${tradeKey.public}:$messageJson';
+      identityProof = [masterKey.public, _mostroSign(payload, masterKey)];
+    }
+
+    final tuple = jsonEncode([messageMap, tradeSig, identityProof]);
+
+    final encrypted = await NostrUtils.encryptNIP44(
+      tuple,
+      tradeKey.private,
+      recipientPubKey,
+    );
+
+    final event = NostrEvent.fromPartialData(
+      kind: 14,
+      content: encrypted,
+      keyPairs: tradeKey,
+      tags: [
+        ['p', recipientPubKey],
+      ],
+      createdAt: DateTime.now(),
+    );
+
+    if (difficulty > 0) {
+      return NostrUtils.mineProofOfWork(event, difficulty, tradeKey);
+    }
+    return event;
   }
 }

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -52,7 +52,8 @@ class DisputeRepository {
         );
       }
       final mostroPow = mostroInstance?.pow ?? 0;
-      final event = await disputeMessage.wrap(
+      final event = await disputeMessage.wrapForTransport(
+        protocolVersion: mostroInstance?.protocolVersion,
         tradeKey: session.tradeKey,
         recipientPubKey: _mostroPubkey,
         difficulty: mostroPow,

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -40,10 +40,13 @@ class DisputeRepository {
         return false;
       }
 
-      // Create dispute message using Gift Wrap protocol (NIP-59)
+      // Create dispute message
       final disputeMessage = MostroMessage(action: Action.dispute, id: orderId);
 
-      // Wrap message using Gift Wrap protocol (NIP-59) with PoW from Mostro instance
+      // Wrap the message for the transport advertised by the connected node
+      // (v1 gift wrap kind 1059 / v2 NIP-44 direct kind 14), with PoW from the
+      // Mostro instance. In reputation mode the master key and key index bind
+      // the identity proof; full privacy omits both.
       final mostroInstance = _ref.read(orderRepositoryProvider).mostroInstance;
       if (mostroInstance == null) {
         logger.w(
@@ -56,6 +59,8 @@ class DisputeRepository {
         protocolVersion: mostroInstance?.protocolVersion,
         tradeKey: session.tradeKey,
         recipientPubKey: _mostroPubkey,
+        masterKey: session.fullPrivacy ? null : session.masterKey,
+        keyIndex: session.fullPrivacy ? null : session.keyIndex,
         difficulty: mostroPow,
       );
 

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -23,6 +23,7 @@ import 'package:mostro_mobile/data/models/payload.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
 import 'package:mostro_mobile/data/models/restore_response.dart';
 import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/restore/restore_progress_notifier.dart';
 import 'package:mostro_mobile/features/restore/restore_progress_state.dart';
@@ -151,20 +152,60 @@ class RestoreService {
     }
   }
 
+  /// Decrypts a restore response and returns its message map, handling both
+  /// transports: v2 (kind 14, NIP-44 direct, decrypted straight to the tuple)
+  /// and v1 (kind 1059, gift wrap unwrapped to a rumor whose content is the
+  /// tuple). Both converge on `tuple[0]`.
+  Future<Map<String, dynamic>> _decodeRestoreMessage(NostrEvent event) async {
+    if (_tempTradeKey == null) {
+      throw Exception('Temp trade key not initialized');
+    }
+
+    final String content;
+    if (event.kind == 14) {
+      content = await NostrUtils.decryptNIP44DirectEvent(
+        event,
+        _tempTradeKey!.private,
+        expectedAuthor: ref.read(settingsProvider).mostroPublicKey,
+      );
+    } else {
+      final rumor = await event.mostroUnWrap(_tempTradeKey!);
+      content = rumor.content ?? '';
+    }
+
+    if (content.isEmpty) {
+      throw Exception('Restore message content is empty');
+    }
+
+    final contentList = jsonDecode(content) as List<dynamic>;
+    return contentList[0] as Map<String, dynamic>;
+  }
+
   Future<StreamSubscription<NostrEvent>> _createTempSubscription() async {
     //use temporary trade key 1 to subscribe to restore notifications
     if (_tempTradeKey == null) {
       throw Exception('Temp trade key not initialized');
     }
 
-    final filter = NostrFilter(
+    // Listen on both transports. The node info (kind 38385) that advertises
+    // protocol_version may not have loaded yet when restore starts, so we
+    // subscribe to v1 gift wrap (kind 1059) and v2 NIP-44 direct (kind 14)
+    // simultaneously rather than resolving a single transport — the node
+    // answers on whichever it speaks. (limit 0: only new events, no history.)
+    final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
+    final v1Filter = NostrFilter(
       kinds: [1059],
       p: [_tempTradeKey!.public],
-      limit:
-          0, //IMPORTANT:  limit 0 indicates we don't want historical events, only new ones https://nostrbook.dev/protocol/filter
+      limit: 0,
+    );
+    final v2Filter = NostrFilter(
+      kinds: [14],
+      authors: [mostroPubkey],
+      p: [_tempTradeKey!.public],
+      limit: 0,
     );
 
-    final request = NostrRequest(filters: [filter]);
+    final request = NostrRequest(filters: [v1Filter, v2Filter]);
     final stream = ref.read(nostrServiceProvider).subscribeToEvents(request);
 
     final subscription = stream.listen(
@@ -225,19 +266,7 @@ class RestoreService {
   Future<({Map<String, int> ordersMap, List<RestoredDispute> disputes})>
   _extractRestoreData(NostrEvent event) async {
     try {
-      if (_tempTradeKey == null) {
-        throw Exception('Temp trade key not initialized');
-      }
-
-      // Unwrap the gift wrap (kind 1059) to get the rumor
-      final rumor = await event.mostroUnWrap(_tempTradeKey!);
-
-      if (rumor.content == null || rumor.content!.isEmpty) {
-        throw Exception('Rumor content is empty');
-      }
-
-      final contentList = jsonDecode(rumor.content!) as List<dynamic>;
-      final messageData = contentList[0] as Map<String, dynamic>;
+      final messageData = await _decodeRestoreMessage(event);
 
       // Check if Mostro returned cant-do (not found)
       if (messageData.containsKey('cant-do')) {
@@ -335,20 +364,7 @@ class RestoreService {
         'Restore: extracting orders details from gift wrap event ${event.id}',
       );
 
-      if (_tempTradeKey == null) {
-        throw Exception('Temp trade key not initialized');
-      }
-
-      // Unwrap the gift wrap (kind 1059) to get the rumor
-      final rumor = await event.mostroUnWrap(_tempTradeKey!);
-
-      if (rumor.content == null || rumor.content!.isEmpty) {
-        throw Exception('Rumor content is empty');
-      }
-
-      // Parse response format: [{"order": {...}}, null]
-      final contentList = jsonDecode(rumor.content!) as List<dynamic>;
-      final messageData = contentList[0] as Map<String, dynamic>;
+      final messageData = await _decodeRestoreMessage(event);
 
       // Check if Mostro returned cant-do
       if (messageData.containsKey('cant-do')) {
@@ -430,18 +446,7 @@ class RestoreService {
         'Restore: extracting last trade index from gift wrap event ${event.id}',
       );
 
-      if (_tempTradeKey == null) {
-        throw Exception('Temp trade key not initialized');
-      }
-
-      final rumor = await event.mostroUnWrap(_tempTradeKey!);
-
-      if (rumor.content == null || rumor.content!.isEmpty) {
-        throw Exception('Rumor content is empty');
-      }
-
-      final contentList = jsonDecode(rumor.content!) as List<dynamic>;
-      final messageData = contentList[0] as Map<String, dynamic>;
+      final messageData = await _decodeRestoreMessage(event);
 
       // Check if Mostro returned cant-do
       if (messageData.containsKey('cant-do')) {

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -1095,6 +1095,9 @@ Future<Map<String, dynamic>> decodeRestoreMessage(
   }
 
   final contentList = jsonDecode(content) as List<dynamic>;
+  if (contentList.isEmpty) {
+    throw Exception('Restore message tuple is empty');
+  }
   return contentList[0] as Map<String, dynamic>;
 }
 

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:dart_nostr/nostr/core/key_pairs.dart';
 import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:dart_nostr/nostr/model/request/filter.dart';
@@ -152,33 +153,18 @@ class RestoreService {
     }
   }
 
-  /// Decrypts a restore response and returns its message map, handling both
-  /// transports: v2 (kind 14, NIP-44 direct, decrypted straight to the tuple)
-  /// and v1 (kind 1059, gift wrap unwrapped to a rumor whose content is the
-  /// tuple). Both converge on `tuple[0]`.
-  Future<Map<String, dynamic>> _decodeRestoreMessage(NostrEvent event) async {
+  /// Decrypts a restore response into its message map, reading the temp trade
+  /// key and node pubkey from the manager state. Delegates the transport branch
+  /// to the top-level [decodeRestoreMessage].
+  Future<Map<String, dynamic>> _decodeRestoreMessage(NostrEvent event) {
     if (_tempTradeKey == null) {
       throw Exception('Temp trade key not initialized');
     }
-
-    final String content;
-    if (event.kind == 14) {
-      content = await NostrUtils.decryptNIP44DirectEvent(
-        event,
-        _tempTradeKey!.private,
-        expectedAuthor: ref.read(settingsProvider).mostroPublicKey,
-      );
-    } else {
-      final rumor = await event.mostroUnWrap(_tempTradeKey!);
-      content = rumor.content ?? '';
-    }
-
-    if (content.isEmpty) {
-      throw Exception('Restore message content is empty');
-    }
-
-    final contentList = jsonDecode(content) as List<dynamic>;
-    return contentList[0] as Map<String, dynamic>;
+    return decodeRestoreMessage(
+      event,
+      _tempTradeKey!,
+      ref.read(settingsProvider).mostroPublicKey,
+    );
   }
 
   Future<StreamSubscription<NostrEvent>> _createTempSubscription() async {
@@ -1077,6 +1063,39 @@ class RestoreService {
     }
     return null;
   }
+}
+
+/// Decodes a restore response into its message map, handling both transports:
+/// v2 (kind 14, NIP-44 direct, decrypted straight to the tuple) and v1
+/// (kind 1059, gift wrap unwrapped to a rumor whose content is the tuple). Both
+/// converge on `tuple[0]`.
+///
+/// Top-level (not a private method) so the transport branch can be
+/// regression-tested without the full [RestoreService] / Riverpod orchestration.
+@visibleForTesting
+Future<Map<String, dynamic>> decodeRestoreMessage(
+  NostrEvent event,
+  NostrKeyPairs tempTradeKey,
+  String mostroPubkey,
+) async {
+  final String content;
+  if (event.kind == 14) {
+    content = await NostrUtils.decryptNIP44DirectEvent(
+      event,
+      tempTradeKey.private,
+      expectedAuthor: mostroPubkey,
+    );
+  } else {
+    final rumor = await event.mostroUnWrap(tempTradeKey);
+    content = rumor.content ?? '';
+  }
+
+  if (content.isEmpty) {
+    throw Exception('Restore message content is empty');
+  }
+
+  final contentList = jsonDecode(content) as List<dynamic>;
+  return contentList[0] as Map<String, dynamic>;
 }
 
 /// Thrown when Mostro responds with cant-do: invalid_trade_index to

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -207,7 +207,8 @@ class RestoreService {
         'event may be rejected if node requires PoW',
       );
     }
-    final wrappedEvent = await mostroMessage.wrap(
+    final wrappedEvent = await mostroMessage.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -315,7 +316,8 @@ class RestoreService {
         'event may be rejected if node requires PoW',
       );
     }
-    final wrappedEvent = await mostroMessage.wrap(
+    final wrappedEvent = await mostroMessage.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -408,7 +410,8 @@ class RestoreService {
         'event may be rejected if node requires PoW',
       );
     }
-    final wrappedEvent = await mostroMessage.wrap(
+    final wrappedEvent = await mostroMessage.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -14,7 +14,6 @@ import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
-import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 class MostroService {
@@ -366,31 +365,17 @@ class MostroService {
 
     // Route through the transport advertised by the connected node (§5 Phase
     // B). v1 nodes (default) keep the gift-wrap path byte-for-byte.
-    final transport = resolveTransport(mostroInstance?.protocolVersion);
-    final NostrEvent event;
-    switch (transport) {
-      case Transport.nip44:
-        event = await order.wrapNip44(
-          tradeKey: session.tradeKey,
-          recipientPubKey: _settings.mostroPublicKey,
-          masterKey: session.fullPrivacy ? null : session.masterKey,
-          keyIndex: session.fullPrivacy ? null : session.keyIndex,
-          difficulty: difficulty,
-        );
-        break;
-      case Transport.giftWrap:
-        event = await order.wrap(
-          tradeKey: session.tradeKey,
-          recipientPubKey: _settings.mostroPublicKey,
-          masterKey: session.fullPrivacy ? null : session.masterKey,
-          keyIndex: session.fullPrivacy ? null : session.keyIndex,
-          difficulty: difficulty,
-        );
-        break;
-    }
+    final event = await order.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
+      tradeKey: session.tradeKey,
+      recipientPubKey: _settings.mostroPublicKey,
+      masterKey: session.fullPrivacy ? null : session.masterKey,
+      keyIndex: session.fullPrivacy ? null : session.keyIndex,
+      difficulty: difficulty,
+    );
     logger.i(
-      'Sending DM ($transport), Event ID: ${event.id} (PoW: $difficulty) '
-      'with payload: ${order.toJson()}',
+      'Sending DM (kind ${event.kind}), Event ID: ${event.id} '
+      '(PoW: $difficulty) with payload: ${order.toJson()}',
     );
     await ref.read(nostrServiceProvider).publishEvent(event);
   }

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -14,6 +14,7 @@ import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 class MostroService {
@@ -363,15 +364,33 @@ class MostroService {
       );
     }
 
-    final event = await order.wrap(
-      tradeKey: session.tradeKey,
-      recipientPubKey: _settings.mostroPublicKey,
-      masterKey: session.fullPrivacy ? null : session.masterKey,
-      keyIndex: session.fullPrivacy ? null : session.keyIndex,
-      difficulty: difficulty,
-    );
+    // Route through the transport advertised by the connected node (§5 Phase
+    // B). v1 nodes (default) keep the gift-wrap path byte-for-byte.
+    final transport = resolveTransport(mostroInstance?.protocolVersion);
+    final NostrEvent event;
+    switch (transport) {
+      case Transport.nip44:
+        event = await order.wrapNip44(
+          tradeKey: session.tradeKey,
+          recipientPubKey: _settings.mostroPublicKey,
+          masterKey: session.fullPrivacy ? null : session.masterKey,
+          keyIndex: session.fullPrivacy ? null : session.keyIndex,
+          difficulty: difficulty,
+        );
+        break;
+      case Transport.giftWrap:
+        event = await order.wrap(
+          tradeKey: session.tradeKey,
+          recipientPubKey: _settings.mostroPublicKey,
+          masterKey: session.fullPrivacy ? null : session.masterKey,
+          keyIndex: session.fullPrivacy ? null : session.keyIndex,
+          difficulty: difficulty,
+        );
+        break;
+    }
     logger.i(
-      'Sending DM, Event ID: ${event.id} (PoW: $difficulty) with payload: ${order.toJson()}',
+      'Sending DM ($transport), Event ID: ${event.id} (PoW: $difficulty) '
+      'with payload: ${order.toJson()}',
     );
     await ref.read(nostrServiceProvider).publishEvent(event);
   }

--- a/test/data/mostro_message_nip44_test.dart
+++ b/test/data/mostro_message_nip44_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// Replicates the Mostro signing scheme (SHA-256 hex digest, Schnorr-verified)
+/// for asserting the tuple signatures.
+bool verifyMostroSig(String pubkey, String message, String sig) {
+  final hash = hex.encode(sha256.convert(utf8.encode(message)).bytes);
+  return NostrKeyPairs.verify(pubkey, hash, sig);
+}
+
+void main() {
+  group('MostroMessage.wrapNip44 (protocol v2)', () {
+    late NostrKeyPairs tradeKey;
+    late NostrKeyPairs masterKey;
+    late NostrKeyPairs mostroKey; // stands in for the node / recipient
+
+    setUp(() {
+      tradeKey = NostrUtils.generateKeyPair();
+      masterKey = NostrUtils.generateKeyPair();
+      mostroKey = NostrUtils.generateKeyPair();
+    });
+
+    test('reputation mode: kind-14 event round-trips with identity proof',
+        () async {
+      final message = MostroMessage(
+        action: Action.fiatSent,
+        id: 'order-1',
+        requestId: 7,
+      );
+
+      final event = await message.wrapNip44(
+        tradeKey: tradeKey,
+        recipientPubKey: mostroKey.public,
+        masterKey: masterKey,
+        keyIndex: 5,
+      );
+
+      // Event shape: kind 14, authored by the trade key, p-tagged to the node.
+      expect(event.kind, 14);
+      expect(event.pubkey, tradeKey.public);
+      expect(
+        event.tags!.any((t) => t[0] == 'p' && t[1] == mostroKey.public),
+        isTrue,
+      );
+
+      // Node decrypts with its private key + the event author (trade key).
+      final content = await NostrUtils.decryptNIP44DirectEvent(
+        event,
+        mostroKey.private,
+        expectedAuthor: tradeKey.public,
+      );
+      final tuple = jsonDecode(content) as List;
+      expect(tuple.length, 3);
+
+      // Element 0: the message with version 2, decodes to the original.
+      final messageMap = tuple[0] as Map<String, dynamic>;
+      expect(messageMap['order']['version'], 2);
+      final decoded = MostroMessage.fromJson(messageMap);
+      expect(decoded.action, Action.fiatSent);
+      expect(decoded.id, 'order-1');
+
+      // Element 1: trade-key signature over the exact message JSON.
+      final messageJson = jsonEncode(messageMap);
+      expect(tuple[1], isNotNull);
+      expect(verifyMostroSig(tradeKey.public, messageJson, tuple[1] as String),
+          isTrue);
+
+      // Element 2: identity proof = [identityPubkey, sig over domain payload].
+      final proof = tuple[2] as List;
+      expect(proof[0], masterKey.public);
+      final domain =
+          'mostro-transport-v2-identity:${tradeKey.public}:$messageJson';
+      expect(verifyMostroSig(masterKey.public, domain, proof[1] as String),
+          isTrue);
+    });
+
+    test('full-privacy mode: tradeSig and identityProof are null', () async {
+      final message = MostroMessage(
+        action: Action.fiatSent,
+        id: 'order-2',
+        requestId: 9,
+      );
+
+      final event = await message.wrapNip44(
+        tradeKey: tradeKey,
+        recipientPubKey: mostroKey.public,
+        masterKey: null,
+      );
+
+      expect(event.kind, 14);
+      expect(event.pubkey, tradeKey.public);
+
+      final content = await NostrUtils.decryptNIP44DirectEvent(
+        event,
+        mostroKey.private,
+        expectedAuthor: tradeKey.public,
+      );
+      final tuple = jsonDecode(content) as List;
+      expect(tuple.length, 3);
+      expect((tuple[0] as Map)['order']['version'], 2);
+      expect(tuple[1], isNull);
+      expect(tuple[2], isNull);
+
+      final decoded = MostroMessage.fromJson(tuple[0] as Map<String, dynamic>);
+      expect(decoded.action, Action.fiatSent);
+      expect(decoded.id, 'order-2');
+    });
+  });
+}

--- a/test/features/restore/restore_decode_test.dart
+++ b/test/features/restore/restore_decode_test.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/restore/restore_manager.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// Regression tests for the restore receive path covering both transports:
+/// v1 gift wrap (kind 1059) and v2 NIP-44 direct (kind 14). The node is the
+/// sender; the client decrypts with its temporary restore trade key.
+void main() {
+  group('decodeRestoreMessage (restore transport branch)', () {
+    late NostrKeyPairs tempTradeKey;
+    late NostrKeyPairs mostroKey;
+
+    // A restore response as Mostro sends it: tuple [message, signature?].
+    final restoreTuple = jsonEncode([
+      {
+        'restore': {
+          'version': 1,
+          'action': 'restore',
+          'payload': {
+            'restore_data': {'orders': [], 'disputes': []},
+          },
+        },
+      },
+      null,
+    ]);
+
+    setUp(() {
+      tempTradeKey = NostrUtils.generateKeyPair();
+      mostroKey = NostrUtils.generateKeyPair();
+    });
+
+    /// Builds a v2 (kind 14) reply authored by the node toward the temp key.
+    Future<NostrEvent> buildV2Reply(String tuple) async {
+      final encrypted = await NostrUtils.encryptNIP44(
+        tuple,
+        mostroKey.private,
+        tempTradeKey.public,
+      );
+      return NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: mostroKey,
+        tags: [
+          ['p', tempTradeKey.public],
+        ],
+        createdAt: DateTime.now(),
+      );
+    }
+
+    test('v1 gift wrap (kind 1059) decodes to the restore message', () async {
+      final event = await NostrUtils.createNIP59Event(
+        restoreTuple,
+        tempTradeKey.public,
+        mostroKey.private,
+      );
+
+      expect(event.kind, 1059);
+      final data = await decodeRestoreMessage(
+        event,
+        tempTradeKey,
+        mostroKey.public,
+      );
+      expect(data.containsKey('restore'), isTrue);
+    });
+
+    test('v2 NIP-44 direct (kind 14) decodes to the restore message', () async {
+      final event = await buildV2Reply(restoreTuple);
+
+      expect(event.kind, 14);
+      expect(event.pubkey, mostroKey.public);
+      final data = await decodeRestoreMessage(
+        event,
+        tempTradeKey,
+        mostroKey.public,
+      );
+      expect(data.containsKey('restore'), isTrue);
+    });
+
+    test('v1 and v2 decode to identical message maps', () async {
+      final v1 = await NostrUtils.createNIP59Event(
+        restoreTuple,
+        tempTradeKey.public,
+        mostroKey.private,
+      );
+      final v2 = await buildV2Reply(restoreTuple);
+
+      final d1 = await decodeRestoreMessage(v1, tempTradeKey, mostroKey.public);
+      final d2 = await decodeRestoreMessage(v2, tempTradeKey, mostroKey.public);
+
+      expect(d2, equals(d1));
+    });
+
+    test('v2 reply from an unexpected author is rejected', () async {
+      final imposter = NostrUtils.generateKeyPair();
+      final encrypted = await NostrUtils.encryptNIP44(
+        restoreTuple,
+        imposter.private,
+        tempTradeKey.public,
+      );
+      final event = NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: imposter,
+        tags: [
+          ['p', tempTradeKey.public],
+        ],
+        createdAt: DateTime.now(),
+      );
+
+      // expectedAuthor is the real node; the imposter-authored event must fail.
+      expect(
+        () => decodeRestoreMessage(event, tempTradeKey, mostroKey.public),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Implements **Phase B — Dual send** of the transport v1 → v2 migration (`docs/architecture/TRANSPORT_V2_MIGRATION.md`). Builds on Phase A (#621, merged), routing outbound Mostro messages through the per-node resolved transport.

## Changes
- **v2 wrap** (`MostroMessage.wrapNip44`): builds the `[message, tradeSig, identityProof]` 3-tuple with `version: 2`, NIP-44 encrypts it toward the node, and emits a kind-14 event **signed by the trade key** with a `p` tag. PoW is preserved (mined on the kind-14 id).
- **Identity proof** mirrors `mostro-core`'s `transport.rs`: trade-key signature = existing `MostroMessage.sign` (SHA-256 hex digest, Schnorr); identity proof = master key signing `mostro-transport-v2-identity:<tradePubkey>:<messageJSON>`. Both are `null` in full-privacy mode.
- **`version` threading**: derived from the resolved transport instead of the global constant (1 for gift wrap, 2 for NIP-44).
- **Routing** (`MostroService.publishOrder`): selects `wrapNip44` (v2) or `wrap` (v1) from the node's `protocol_version`.

## Scope
- The v1 gift-wrap send path is **byte-for-byte unchanged**; v2 send only engages for nodes advertising `protocol_version=2` (none in production yet).
- The NIP-40 `expiration` tag is omitted (optional/caller-supplied per the daemon), avoiding any risk of a message expiring before processing.
- Out of scope: send-side wiring polish (Phase C), additional tests (Phase D).

## Verification
- `flutter analyze`: no issues.
- `flutter test`: all pass, including a new v2 wrap → unwrap round-trip (reputation + full-privacy) that cryptographically verifies the trade signature and identity proof, plus v1 regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NIP-44 encrypted direct messaging for protocol v2 with protocol-versioned signing/serialization.
  * Outbound message wrapping now routes per the connected Mostro node’s protocol version, covering restore and dispute flows.
  * Restore receiving now supports both v1 gift-wrap and v2 direct responses.
* **Documentation**
  * Updated transport migration and session recovery docs to reflect dual receive/send behavior.
* **Tests**
  * Added regression tests for NIP-44 wrapping and restore decoding across both transports, including signature validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->