### PR TITLE
feat: re-apply dual send for transport v2 (Phase B) without Riverpod 3.x

### DIFF
--- a/docs/architecture/SESSION_RECOVERY_ARCHITECTURE.md
+++ b/docs/architecture/SESSION_RECOVERY_ARCHITECTURE.md
@@ -151,7 +151,13 @@ Future<void> importMnemonicAndRestore(String mnemonic) async {
 
 **File**: `lib/features/restore/restore_manager.dart:116-141`
 
-Creates a temporary subscription using trade key index 1 to receive Mostro responses:
+Creates a temporary subscription using trade key index 1 to receive Mostro
+responses. To interoperate across the transport v2 migration it listens on
+**both** wire transports at once — v1 gift wrap (kind 1059) and v2 NIP-44 direct
+(kind 14) — because the node info (kind 38385) that advertises `protocol_version`
+may not have loaded yet when restore starts. The node answers on whichever
+transport it speaks; the v2 filter pins `authors = [mostroPubkey]` to disambiguate
+from NIP-17 chat (also kind 14). See `TRANSPORT_V2_MIGRATION.md`.
 
 ```dart
 Future<StreamSubscription<NostrEvent>> _createTempSubscription() async {
@@ -159,18 +165,30 @@ Future<StreamSubscription<NostrEvent>> _createTempSubscription() async {
     throw Exception('Temp trade key not initialized');
   }
 
-  final filter = NostrFilter(
+  final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
+  final v1Filter = NostrFilter(
     kinds: [1059],
     p: [_tempTradeKey!.public],
     limit: 0, // No historical events, only new ones
   );
+  final v2Filter = NostrFilter(
+    kinds: [14],
+    authors: [mostroPubkey],
+    p: [_tempTradeKey!.public],
+    limit: 0,
+  );
 
-  final request = NostrRequest(filters: [filter]);
+  final request = NostrRequest(filters: [v1Filter, v2Filter]);
   final stream = ref.read(nostrServiceProvider).subscribeToEvents(request);
-  
+
   return stream.listen(_handleTempSubscriptionsResponse);
 }
 ```
+
+The response is decoded by the top-level `decodeRestoreMessage(event, tempTradeKey,
+mostroPubkey)`, which branches on `event.kind`: kind 14 is NIP-44 decrypted (and
+the node signature verified) straight to the tuple, while kind 1059 is gift-wrap
+unwrapped to a rumor whose content is the tuple. Both converge on `tuple[0]`.
 
 ### Stage 3: Data Request Sequence
 

--- a/docs/architecture/SESSION_RECOVERY_ARCHITECTURE.md
+++ b/docs/architecture/SESSION_RECOVERY_ARCHITECTURE.md
@@ -120,6 +120,40 @@ Future<void> saveSession(Session session) async {
 }
 ```
 
+### 5. Session Lifecycle Lock
+
+**Location**: `lib/shared/providers/session_lifecycle_lock_provider.dart`
+
+A shared async mutex (`SessionLifecycleLock`) that **serializes session-mutating
+critical sections so they never interleave**. It prevents an orphaned-session
+TOCTOU race: a node-switch restore resets all sessions (`_clearAll()` +
+rebuild), and if an order flow creates a session concurrently, the reset can wipe
+the just-created session while its order was already published — the session
+disappears from "My Trades" but the daemon still has the order.
+
+**Who acquires it:**
+
+- **Order flows** (session creation + the dependent publish, held together so the
+  pair is atomic w.r.t. the reset):
+  - `AddOrderNotifier.submitOrder`
+  - `OrderNotifier.takeSellOrder` / `takeBuyOrder`
+  - `OrderNotifier.sendFiatSent` / `releaseOrder` (range-order child session via
+    `_prepareChildOrderIfNeeded` → `createChildOrderSession`)
+- **Restore** holds the lock at a high level across `_clearAll()` + the rebuild
+  (`initRestoreProcess`, `syncTradeIndex`).
+
+**Why there is no deadlock:** the lock is non-reentrant. Restore rebuilds via
+`saveSession()`, which does **not** take the lock, and `newSession()` /
+`createChildOrderSession()` do not call each other. So while restore holds the
+lock, order flows queue behind it (bounded by restore timeouts) rather than
+deadlocking.
+
+**Known residual (deferred):** the lock releases after publish, not after the
+first daemon ack. A restore starting in that narrow window can still wipe a
+pending session before its response arrives. Tracked for a follow-up (restore
+should preserve pending/awaiting-ack sessions) rather than holding the lock
+across the network round-trip.
+
 ## Recovery Process Flow
 
 ### Stage 1: Mnemonic Import and Cleanup

--- a/docs/architecture/TRANSPORT_V2_MIGRATION.md
+++ b/docs/architecture/TRANSPORT_V2_MIGRATION.md
@@ -18,10 +18,10 @@ during the migration window.
 > - **Reference client (CLI)**: `MostroP2P/mostro-cli` PRs #176, #177, #178 and
 >   its `docs/TRANSPORT_V2_SPEC.md`.
 >
-> **Status.** Living design specification. **Phase A (dual receive) is
-> implemented** in this branch, including `protocol_version` auto-detection and
-> per-node transport resolution on the receive path. The remaining phases (§5)
-> are pending.
+> **Status.** Living design specification. **Phase A (dual receive)** —
+> including `protocol_version` auto-detection and per-node transport resolution
+> on the receive path — is merged to `main`. **Phase B (dual send)** is
+> implemented in this branch. Phases C–D (§5) are pending.
 
 ---
 
@@ -304,12 +304,22 @@ unchanged.
   `version: 2`; computes the trade signature; computes the identity proof
   (domain-tagged string signed with the master key, `null` in full-privacy);
   NIP-44 encrypts the 3-tuple toward the node; emits a kind-`14` event **signed
-  by the trade key** with `p` and NIP-40 `expiration` tags.
-- Route `MostroService.publishOrder`
-  (`lib/services/mostro_service.dart:338-360`) through the resolved transport.
-  **Preserve PoW** (`NostrUtils.mineProofOfWork`,
-  `lib/shared/utils/nostr_utils.dart:564-630`) for the first-contact lane — the
-  daemon may still require PoW on the kind-14 event id.
+  by the trade key** with a `p` tag (the NIP-40 `expiration` tag is omitted; see
+  the note below).
+- Route **every** outbound Mostro send through the resolved transport via a
+  single `MostroMessage.wrapForTransport(protocolVersion: …)` entry point — not
+  just `MostroService.publishOrder`, but also the `RestoreManager` requests
+  (restore, order-details, last-trade-index) and
+  `DisputeRepository.createDispute`, so a v2 node never receives a stray v1 gift
+  wrap. **Preserve PoW** (`NostrUtils.mineProofOfWork`) for the first-contact
+  lane — the daemon may still require PoW on the kind-14 event id.
+- **Identity proof signature** mirrors `mostro-core`'s `transport.rs`: the
+  trade-key signature (tuple element 1) is the existing `MostroMessage.sign`
+  (SHA-256 hex digest then Schnorr), and the identity proof (element 2) is the
+  master key signing `mostro-transport-v2-identity:<tradePubkey>:<messageJSON>`
+  with the same scheme. Both are `null` in full-privacy mode.
+- The NIP-40 `expiration` tag is **omitted** (the daemon treats it as optional /
+  caller-supplied), avoiding any risk of a message expiring before processing.
 
 ### Phase C — Send-side wiring
 

--- a/docs/architecture/TRANSPORT_V2_MIGRATION.md
+++ b/docs/architecture/TRANSPORT_V2_MIGRATION.md
@@ -113,7 +113,7 @@ natural home with no new fetch.
 | inner payload | 2-tuple `[message, sig?]` | 3-tuple `[message, tradeSig?, identityProof?]` |
 | identity proof | carried inside the seal | carried **inside** the NIP-44 ciphertext |
 | `message.version` | `1` | `2` |
-| expiration | none | NIP-40 `expiration` tag |
+| expiration | none | optional NIP-40 tag — **this client omits it** (§3.3, §5) |
 
 ### 3.1 The Mostro message (identical logical content)
 
@@ -177,8 +177,10 @@ This string becomes the rumor content, sealed and gift-wrapped by
 
 This entire 3-tuple JSON string is NIP-44 encrypted with `tradeKey.private` →
 `mostroPubkey` and placed in the `content` of a kind-`14` event that is **signed
-by the trade key**, carries a `["p", "<mostroPubkey>"]` tag and a NIP-40
-`["expiration", "<unix>"]` tag.
+by the trade key** and carries a `["p", "<mostroPubkey>"]` tag. The NIP-40
+`["expiration", "<unix>"]` tag is **optional and this client omits it** — the
+daemon manages its own expiration and accepts events with or without it (§5
+Phase B).
 
 ### 3.4 Kind 14 is overloaded — disambiguation
 
@@ -200,7 +202,7 @@ rumor (k1, NIP-44)                      NIP-44 encrypt tuple (tradeKey -> mostro
   -> seal (k13, NIP-44)                 wrap in k14 event:
     -> wrap (k1059, ephemeral author)     - author = trade key (SIGNED)
       - p tag = mostro pubkey             - p tag = mostro pubkey
-      - optional PoW (NIP-13)             - expiration tag (NIP-40)
+      - optional PoW (NIP-13)             - (no expiration tag; §3.3)
 publish                                   - optional PoW (NIP-13, first-contact)
                                         publish
 ```
@@ -318,8 +320,13 @@ unchanged.
   (SHA-256 hex digest then Schnorr), and the identity proof (element 2) is the
   master key signing `mostro-transport-v2-identity:<tradePubkey>:<messageJSON>`
   with the same scheme. Both are `null` in full-privacy mode.
-- The NIP-40 `expiration` tag is **omitted** (the daemon treats it as optional /
-  caller-supplied), avoiding any risk of a message expiring before processing.
+- The NIP-40 `expiration` tag is **omitted**. It is optional: `mostro-core`
+  supports it and the daemon accepts events with or without it (its receive path
+  does not validate expiration; it manages its own window). Reference clients
+  differ — the Rust app and `mostro-cli` also omit it, while `Mostrix` adds a
+  default 30-day window. This client omits it, avoiding any risk of a message
+  expiring before processing; adding a generous window later is a safe, optional
+  hygiene improvement.
 
 ### Phase C — Send-side wiring
 
@@ -363,6 +370,16 @@ unchanged.
   event id. Keep `mineProofOfWork` and the `maxPowDifficulty` guard.
 - **NIP-17 peer chat (also kind 14)** → not touched; disambiguated from Mostro
   v2 by `author = mostroPubkey` + `p` tag.
+- **Disputes now carry identity in reputation mode** →
+  `DisputeRepository.createDispute` passes the master key + key index through
+  `wrapForTransport`, so a reputation-mode dispute binds identity like every other
+  Mostro send. Previously disputes were always sent full-privacy-shaped
+  (`event.identity = trade key`), ignoring the user's privacy mode. This is a
+  deliberate change to the v1 dispute wire — the one exception to "v1
+  byte-for-byte unchanged" — and was confirmed accepted by the daemon on **both
+  v1 and v2**. The daemon does not require it (`check_trade_index` skips disputes;
+  `dispute_action` identifies the disputer by event sender), so full-privacy
+  disputes stay identity-less as before.
 
 ---
 
@@ -376,7 +393,7 @@ unchanged.
 
 ---
 
-**Last Updated**: 2026-06-17
+**Last Updated**: 2026-07-01
 **Related docs**: `NOSTR.md` (Nostr integration), `MULTI_MOSTRO_SUPPORT.md`
 (kind-38385 info-event parsing), `ANTI_ABUSE_BOND.md` (info-event tag parsing
 and PoW), `SESSION_AND_KEY_MANAGEMENT.md` (trade vs master keys).

--- a/lib/data/models/mostro_message.dart
+++ b/lib/data/models/mostro_message.dart
@@ -98,13 +98,17 @@ class MostroMessage<T extends Payload> {
     return null;
   }
 
+  /// Wrapper key for the message envelope: 'restore' for restore and
+  /// last-trade-index actions, 'order' for everything else, as per protocol.
+  /// Single source of truth — it is load-bearing for the signature, so the
+  /// signed content must be identical across sign/serialize/wrapNip44.
+  String get _wrapperKey =>
+      action == Action.restore || action == Action.lastTradeIndex
+      ? 'restore'
+      : 'order';
+
   String sign(NostrKeyPairs keyPair, {int? version}) {
-    //IMPORTANT : Use 'restore' key for restore and last-trade-index actions, 'order' for everything else, as per protocol
-    final wrapperKey =
-        action == Action.restore || action == Action.lastTradeIndex
-        ? 'restore'
-        : 'order';
-    final message = {wrapperKey: toJson(version: version)};
+    final message = {_wrapperKey: toJson(version: version)};
     final serializedEvent = jsonEncode(message);
     return _mostroSign(serializedEvent, keyPair);
   }
@@ -120,12 +124,7 @@ class MostroMessage<T extends Payload> {
   }
 
   String serialize({NostrKeyPairs? keyPair, int? version}) {
-    //IMPORTANT : Use 'restore' key for restore and last-trade-index actions, 'order' for everything else, as per protocol
-    final wrapperKey =
-        action == Action.restore || action == Action.lastTradeIndex
-        ? 'restore'
-        : 'order';
-    final message = {wrapperKey: toJson(version: version)};
+    final message = {_wrapperKey: toJson(version: version)};
     final serializedEvent = jsonEncode(message);
     final signature =
         (keyPair != null) ? '"${sign(keyPair, version: version)}"' : null;
@@ -193,11 +192,7 @@ class MostroMessage<T extends Payload> {
   }) async {
     tradeIndex = keyIndex;
 
-    final wrapperKey =
-        action == Action.restore || action == Action.lastTradeIndex
-        ? 'restore'
-        : 'order';
-    final messageMap = {wrapperKey: toJson(version: 2)};
+    final messageMap = {_wrapperKey: toJson(version: 2)};
     final messageJson = jsonEncode(messageMap);
 
     // Reputation mode binds the identity; full privacy omits both signatures.

--- a/lib/data/models/mostro_message.dart
+++ b/lib/data/models/mostro_message.dart
@@ -6,6 +6,7 @@ import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
 import 'package:mostro_mobile/data/models/payload.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 class MostroMessage<T extends Payload> {
@@ -25,9 +26,9 @@ class MostroMessage<T extends Payload> {
     this.timestamp,
   }) : _payload = payload;
 
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toJson({int? version}) {
     Map<String, dynamic> json = {
-      'version': Config.mostroVersion,
+      'version': version ?? Config.mostroVersion,
       'request_id': requestId,
       'trade_index': tradeIndex,
     };
@@ -97,30 +98,37 @@ class MostroMessage<T extends Payload> {
     return null;
   }
 
-  String sign(NostrKeyPairs keyPair) {
+  String sign(NostrKeyPairs keyPair, {int? version}) {
     //IMPORTANT : Use 'restore' key for restore and last-trade-index actions, 'order' for everything else, as per protocol
     final wrapperKey =
         action == Action.restore || action == Action.lastTradeIndex
         ? 'restore'
         : 'order';
-    final message = {wrapperKey: toJson()};
+    final message = {wrapperKey: toJson(version: version)};
     final serializedEvent = jsonEncode(message);
-    final bytes = utf8.encode(serializedEvent);
-    final digest = sha256.convert(bytes);
-    final hash = hex.encode(digest.bytes);
-    final signature = keyPair.sign(hash);
-    return signature;
+    return _mostroSign(serializedEvent, keyPair);
   }
 
-  String serialize({NostrKeyPairs? keyPair}) {
+  /// Signs a UTF-8 string the Mostro way: SHA-256 digest, hex-encoded, then
+  /// Schnorr-signed. Shared by the message [sign] and the protocol-v2 identity
+  /// proof so both produce signatures the daemon can verify identically.
+  String _mostroSign(String message, NostrKeyPairs keyPair) {
+    final bytes = utf8.encode(message);
+    final digest = sha256.convert(bytes);
+    final hash = hex.encode(digest.bytes);
+    return keyPair.sign(hash);
+  }
+
+  String serialize({NostrKeyPairs? keyPair, int? version}) {
     //IMPORTANT : Use 'restore' key for restore and last-trade-index actions, 'order' for everything else, as per protocol
     final wrapperKey =
         action == Action.restore || action == Action.lastTradeIndex
         ? 'restore'
         : 'order';
-    final message = {wrapperKey: toJson()};
+    final message = {wrapperKey: toJson(version: version)};
     final serializedEvent = jsonEncode(message);
-    final signature = (keyPair != null) ? '"${sign(keyPair)}"' : null;
+    final signature =
+        (keyPair != null) ? '"${sign(keyPair, version: version)}"' : null;
     final content = '[$serializedEvent, $signature]';
     return content;
   }
@@ -158,5 +166,107 @@ class MostroMessage<T extends Payload> {
       recipientPubKey,
       difficulty: difficulty,
     );
+  }
+
+  /// Wraps the message for protocol v2 (NIP-44 direct, kind 14).
+  ///
+  /// Produces the 3-tuple `[message, tradeSig, identityProof]` (§3.3), NIP-44
+  /// encrypts it toward [recipientPubKey] with the trade key, and emits a
+  /// kind-14 event **signed by the trade key** carrying a `p` tag. Mirrors
+  /// `mostro-core`'s `transport.rs` wrap:
+  /// - the message JSON carries `version: 2`;
+  /// - in reputation mode (master key present) `tradeSig` is the trade-key
+  ///   signature over the message and `identityProof` is
+  ///   `[identityPubkey, sig]` where the signature is over
+  ///   `mostro-transport-v2-identity:<tradePubkey>:<messageJSON>` made with the
+  ///   master key;
+  /// - in full-privacy mode (no master key) both are `null`.
+  ///
+  /// PoW (NIP-13), when [difficulty] > 0, is mined on the kind-14 event id and
+  /// signed by the trade key — the first-contact lane is preserved.
+  Future<NostrEvent> wrapNip44({
+    required NostrKeyPairs tradeKey,
+    required String recipientPubKey,
+    NostrKeyPairs? masterKey,
+    int? keyIndex,
+    int difficulty = 0,
+  }) async {
+    tradeIndex = keyIndex;
+
+    final wrapperKey =
+        action == Action.restore || action == Action.lastTradeIndex
+        ? 'restore'
+        : 'order';
+    final messageMap = {wrapperKey: toJson(version: 2)};
+    final messageJson = jsonEncode(messageMap);
+
+    // Reputation mode binds the identity; full privacy omits both signatures.
+    final String? tradeSig =
+        masterKey != null ? _mostroSign(messageJson, tradeKey) : null;
+
+    List<String>? identityProof;
+    if (masterKey != null) {
+      final payload =
+          'mostro-transport-v2-identity:${tradeKey.public}:$messageJson';
+      identityProof = [masterKey.public, _mostroSign(payload, masterKey)];
+    }
+
+    final tuple = jsonEncode([messageMap, tradeSig, identityProof]);
+
+    final encrypted = await NostrUtils.encryptNIP44(
+      tuple,
+      tradeKey.private,
+      recipientPubKey,
+    );
+
+    final event = NostrEvent.fromPartialData(
+      kind: 14,
+      content: encrypted,
+      keyPairs: tradeKey,
+      tags: [
+        ['p', recipientPubKey],
+      ],
+      createdAt: DateTime.now(),
+    );
+
+    if (difficulty > 0) {
+      return NostrUtils.mineProofOfWork(event, difficulty, tradeKey);
+    }
+    return event;
+  }
+
+  /// Wraps the message for the transport advertised by the node's
+  /// [protocolVersion] (§5 Phase B): v2 (NIP-44 direct, kind 14) via
+  /// [wrapNip44] or v1 (gift wrap, kind 1059) via [wrap].
+  ///
+  /// Single entry point so every outbound Mostro send — order actions, restore
+  /// requests, dispute creation — selects the transport consistently from the
+  /// connected node, instead of hard-coding the v1 path.
+  Future<NostrEvent> wrapForTransport({
+    required int? protocolVersion,
+    required NostrKeyPairs tradeKey,
+    required String recipientPubKey,
+    NostrKeyPairs? masterKey,
+    int? keyIndex,
+    int difficulty = 0,
+  }) {
+    switch (resolveTransport(protocolVersion)) {
+      case Transport.nip44:
+        return wrapNip44(
+          tradeKey: tradeKey,
+          recipientPubKey: recipientPubKey,
+          masterKey: masterKey,
+          keyIndex: keyIndex,
+          difficulty: difficulty,
+        );
+      case Transport.giftWrap:
+        return wrap(
+          tradeKey: tradeKey,
+          recipientPubKey: recipientPubKey,
+          masterKey: masterKey,
+          keyIndex: keyIndex,
+          difficulty: difficulty,
+        );
+    }
   }
 }

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -40,10 +40,13 @@ class DisputeRepository {
         return false;
       }
 
-      // Create dispute message using Gift Wrap protocol (NIP-59)
+      // Create dispute message
       final disputeMessage = MostroMessage(action: Action.dispute, id: orderId);
 
-      // Wrap message using Gift Wrap protocol (NIP-59) with PoW from Mostro instance
+      // Wrap the message for the transport advertised by the connected node
+      // (v1 gift wrap kind 1059 / v2 NIP-44 direct kind 14), with PoW from the
+      // Mostro instance. In reputation mode the master key and key index bind
+      // the identity proof; full privacy omits both.
       final mostroInstance = _ref.read(orderRepositoryProvider).mostroInstance;
       if (mostroInstance == null) {
         logger.w(
@@ -52,9 +55,12 @@ class DisputeRepository {
         );
       }
       final mostroPow = mostroInstance?.pow ?? 0;
-      final event = await disputeMessage.wrap(
+      final event = await disputeMessage.wrapForTransport(
+        protocolVersion: mostroInstance?.protocolVersion,
         tradeKey: session.tradeKey,
         recipientPubKey: _mostroPubkey,
+        masterKey: session.fullPrivacy ? null : session.masterKey,
+        keyIndex: session.fullPrivacy ? null : session.keyIndex,
         difficulty: mostroPow,
       );
 

--- a/lib/features/order/notifiers/add_order_notifier.dart
+++ b/lib/features/order/notifiers/add_order_notifier.dart
@@ -5,7 +5,6 @@ import 'package:mostro_mobile/data/models.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/features/order/notifiers/abstract_mostro_notifier.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
-import 'package:mostro_mobile/features/restore/restore_manager.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/services/mostro_service.dart';
@@ -110,12 +109,10 @@ class AddOrderNotifier extends AbstractMostroNotifier {
 
     // A node-switch restore resets all sessions (RestoreService._clearAll).
     // Serialize the whole create critical section (session creation + publish)
-    // with the restore behind a shared lock so the new session cannot be wiped
-    // by an interleaving reset (TOCTOU-safe): while we hold the lock no reset
-    // runs, and if a restore is in progress we block here until it releases.
-    final release =
-        await ref.read(restoreServiceProvider).acquireSessionLock();
-    try {
+    // with the restore behind the shared session lock so the new session cannot
+    // be wiped by an interleaving reset (TOCTOU-safe): while we hold the lock no
+    // reset runs, and if a restore is in progress we block until it releases.
+    await ref.read(sessionLifecycleLockProvider).withSessionLock(() async {
       final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
       session = await sessionNotifier.newSession(
         requestId: requestId,
@@ -128,9 +125,7 @@ class AddOrderNotifier extends AbstractMostroNotifier {
 
       await mostroService.submitOrder(message);
       state = state.updateWith(message);
-    } finally {
-      release();
-    }
+    });
   }
 
   /// Reset notifier state for retry after out_of_range_sats_amount error

--- a/lib/features/order/notifiers/add_order_notifier.dart
+++ b/lib/features/order/notifiers/add_order_notifier.dart
@@ -5,6 +5,7 @@ import 'package:mostro_mobile/data/models.dart';
 import 'package:mostro_mobile/shared/providers.dart';
 import 'package:mostro_mobile/features/order/notifiers/abstract_mostro_notifier.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/restore/restore_manager.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/services/mostro_service.dart';
@@ -100,6 +101,11 @@ class AddOrderNotifier extends AbstractMostroNotifier {
   }
 
   Future<void> submitOrder(Order order) async {
+    // A node-switch restore/sync resets all sessions (RestoreService._clearAll).
+    // Creating the order while it runs would have its session wiped, orphaning
+    // the order on the daemon. Wait for any in-flight restore to finish first.
+    await ref.read(restoreServiceProvider).awaitOperationCompletion();
+
     final message = MostroMessage<Order>(
       action: Action.newOrder,
       id: null,

--- a/lib/features/order/notifiers/add_order_notifier.dart
+++ b/lib/features/order/notifiers/add_order_notifier.dart
@@ -109,10 +109,10 @@ class AddOrderNotifier extends AbstractMostroNotifier {
     );
 
     // A node-switch restore resets all sessions (RestoreService._clearAll).
-    // Serialize session creation with the restore behind a shared lock so the
-    // new session cannot be wiped by an interleaving reset (TOCTOU-safe): while
-    // we hold the lock no reset runs, and if a restore is in progress we block
-    // here until it releases.
+    // Serialize the whole create critical section (session creation + publish)
+    // with the restore behind a shared lock so the new session cannot be wiped
+    // by an interleaving reset (TOCTOU-safe): while we hold the lock no reset
+    // runs, and if a restore is in progress we block here until it releases.
     final release =
         await ref.read(restoreServiceProvider).acquireSessionLock();
     try {
@@ -125,12 +125,12 @@ class AddOrderNotifier extends AbstractMostroNotifier {
       // Start 10s timeout cleanup timer for create orders
       AbstractMostroNotifier.startSessionTimeoutCleanupForRequestId(
           requestId, ref);
+
+      await mostroService.submitOrder(message);
+      state = state.updateWith(message);
     } finally {
       release();
     }
-
-    await mostroService.submitOrder(message);
-    state = state.updateWith(message);
   }
 
   /// Reset notifier state for retry after out_of_range_sats_amount error

--- a/lib/features/order/notifiers/add_order_notifier.dart
+++ b/lib/features/order/notifiers/add_order_notifier.dart
@@ -101,26 +101,34 @@ class AddOrderNotifier extends AbstractMostroNotifier {
   }
 
   Future<void> submitOrder(Order order) async {
-    // A node-switch restore/sync resets all sessions (RestoreService._clearAll).
-    // Creating the order while it runs would have its session wiped, orphaning
-    // the order on the daemon. Wait for any in-flight restore to finish first.
-    await ref.read(restoreServiceProvider).awaitOperationCompletion();
-
     final message = MostroMessage<Order>(
       action: Action.newOrder,
       id: null,
       requestId: requestId,
       payload: order,
     );
-    final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
-    session = await sessionNotifier.newSession(
-      requestId: requestId,
-      role: order.kind == OrderType.buy ? Role.buyer : Role.seller,
-    );
-    
-    // Start 10s timeout cleanup timer for create orders
-    AbstractMostroNotifier.startSessionTimeoutCleanupForRequestId(requestId, ref);
-    
+
+    // A node-switch restore resets all sessions (RestoreService._clearAll).
+    // Serialize session creation with the restore behind a shared lock so the
+    // new session cannot be wiped by an interleaving reset (TOCTOU-safe): while
+    // we hold the lock no reset runs, and if a restore is in progress we block
+    // here until it releases.
+    final release =
+        await ref.read(restoreServiceProvider).acquireSessionLock();
+    try {
+      final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
+      session = await sessionNotifier.newSession(
+        requestId: requestId,
+        role: order.kind == OrderType.buy ? Role.buyer : Role.seller,
+      );
+
+      // Start 10s timeout cleanup timer for create orders
+      AbstractMostroNotifier.startSessionTimeoutCleanupForRequestId(
+          requestId, ref);
+    } finally {
+      release();
+    }
+
     await mostroService.submitOrder(message);
     state = state.updateWith(message);
   }

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -189,11 +189,20 @@ class OrderNotifier extends AbstractMostroNotifier {
   }
 
   Future<void> sendFiatSent() async {
-    await mostroService.sendFiatSent(orderId);
+    // Range orders prepare a child session for the remainder via
+    // _prepareChildOrderIfNeeded -> createChildOrderSession. Serialize that
+    // creation + publish with the restore reset behind the shared session lock
+    // so a concurrent restore can't wipe the child session (TOCTOU-safe).
+    await ref.read(sessionLifecycleLockProvider).withSessionLock(() async {
+      await mostroService.sendFiatSent(orderId);
+    });
   }
 
   Future<void> releaseOrder() async {
-    await mostroService.releaseOrder(orderId);
+    // Same child-session protection as sendFiatSent (range-order remainder).
+    await ref.read(sessionLifecycleLockProvider).withSessionLock(() async {
+      await mostroService.releaseOrder(orderId);
+    });
   }
 
   Future<void> disputeOrder() async {

--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -86,44 +86,54 @@ class OrderNotifier extends AbstractMostroNotifier {
 
   Future<void> takeSellOrder(
       String orderId, int? amount, String? lnAddress) async {
-    final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
-    session = await sessionNotifier.newSession(
-      orderId: orderId,
-      role: Role.buyer,
-    );
+    // Serialize session creation + publish with the restore reset behind the
+    // shared session lock so the new session can't be wiped by a concurrent
+    // restore (TOCTOU-safe). See [SessionLifecycleLock].
+    await ref.read(sessionLifecycleLockProvider).withSessionLock(() async {
+      final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
+      session = await sessionNotifier.newSession(
+        orderId: orderId,
+        role: Role.buyer,
+      );
 
-    // Drop any stale grace timer/flag from a previous cycle on this order so
-    // it can't delete the session we just created (retake within 60s).
-    AbstractMostroNotifier.clearBondCancelDeletion(orderId);
+      // Drop any stale grace timer/flag from a previous cycle on this order so
+      // it can't delete the session we just created (retake within 60s).
+      AbstractMostroNotifier.clearBondCancelDeletion(orderId);
 
-    // Start 10s timeout cleanup timer for orphan session prevention
-    AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
-    
-    await mostroService.takeSellOrder(
-      orderId,
-      amount,
-      lnAddress,
-    );
+      // Start 10s timeout cleanup timer for orphan session prevention
+      AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
+
+      await mostroService.takeSellOrder(
+        orderId,
+        amount,
+        lnAddress,
+      );
+    });
   }
 
   Future<void> takeBuyOrder(String orderId, int? amount) async {
-    final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
-    session = await sessionNotifier.newSession(
-      orderId: orderId,
-      role: Role.seller,
-    );
+    // Serialize session creation + publish with the restore reset behind the
+    // shared session lock so the new session can't be wiped by a concurrent
+    // restore (TOCTOU-safe). See [SessionLifecycleLock].
+    await ref.read(sessionLifecycleLockProvider).withSessionLock(() async {
+      final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
+      session = await sessionNotifier.newSession(
+        orderId: orderId,
+        role: Role.seller,
+      );
 
-    // Drop any stale grace timer/flag from a previous cycle on this order so
-    // it can't delete the session we just created (retake within 60s).
-    AbstractMostroNotifier.clearBondCancelDeletion(orderId);
+      // Drop any stale grace timer/flag from a previous cycle on this order so
+      // it can't delete the session we just created (retake within 60s).
+      AbstractMostroNotifier.clearBondCancelDeletion(orderId);
 
-    // Start 10s timeout cleanup timer for orphan session prevention
-    AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
-    
-    await mostroService.takeBuyOrder(
-      orderId,
-      amount,
-    );
+      // Start 10s timeout cleanup timer for orphan session prevention
+      AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
+
+      await mostroService.takeBuyOrder(
+        orderId,
+        amount,
+      );
+    });
   }
 
   Future<void> sendInvoice(

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -63,6 +63,21 @@ class RestoreService {
 
   RestoreService(this.ref);
 
+  /// Whether a restore/sync operation that resets all sessions (via [_clearAll])
+  /// is currently running. Used to avoid racing the reset with user actions that
+  /// create sessions (e.g. order creation).
+  bool get isOperationInProgress => _operationInProgress;
+
+  /// Resolves when the in-flight restore/sync operation finishes, or immediately
+  /// if none is running. Callers that create sessions should await this first so
+  /// their session is not wiped by the restore's session reset. Safe against
+  /// hangs: every operation completes its completer in a `finally` block.
+  Future<void> awaitOperationCompletion() async {
+    if (_operationInProgress && _operationCompleter != null) {
+      await _operationCompleter!.future;
+    }
+  }
+
   Future<void> importMnemonicAndRestore(String mnemonic) async {
     logger.i('Restore: importing mnemonic');
 

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -61,26 +61,24 @@ class RestoreService {
   bool _operationInProgress = false;
   Completer<bool>? _operationCompleter;
 
+  /// Tail of the session critical-section lock chain. See [acquireSessionLock].
+  Future<void> _sessionLockTail = Future.value();
+
   RestoreService(this.ref);
 
-  /// Whether a restore/sync operation that resets all sessions (via [_clearAll])
-  /// is currently running. Used to avoid racing the reset with user actions that
-  /// create sessions (e.g. order creation).
-  bool get isOperationInProgress => _operationInProgress;
-
-  /// Resolves when no restore/sync operation is running. Callers that create
-  /// sessions should await this first so their session is not wiped by the
-  /// restore's session reset. Loops so that an operation starting while we wait
-  /// is also awaited. Safe against hangs: every operation completes its completer
-  /// in a `finally` block.
+  /// Acquires the session critical-section lock, serializing the restore session
+  /// reset ([_clearAll] in [initRestoreProcess]) with session-creating flows
+  /// (e.g. order creation) so they never interleave. This closes the TOCTOU
+  /// window that a wait-only check would leave open: a caller holding the lock
+  /// is guaranteed no reset runs until it releases, and vice versa.
   ///
-  /// Note: restore is only triggered from node-switch, mnemonic import, manual
-  /// restore and app-init sync — all mutually exclusive with order submission in
-  /// the UI — so a true cross-flow mutex is unnecessary here.
-  Future<void> awaitOperationCompletion() async {
-    while (_operationInProgress && _operationCompleter != null) {
-      await _operationCompleter!.future;
-    }
+  /// Returns a release callback the caller MUST invoke in a `finally` block.
+  Future<void Function()> acquireSessionLock() async {
+    final previous = _sessionLockTail;
+    final completer = Completer<void>();
+    _sessionLockTail = completer.future;
+    await previous;
+    return () => completer.complete();
   }
 
   Future<void> importMnemonicAndRestore(String mnemonic) async {
@@ -917,6 +915,9 @@ class RestoreService {
 
     _operationInProgress = true;
     _operationCompleter = Completer<bool>();
+    // Hold the session lock for the whole restore so order creation cannot
+    // interleave with the session reset (and rebuild) below.
+    final releaseSessionLock = await acquireSessionLock();
     bool success = false;
     bool noHistoryFound = false;
     try {
@@ -1038,6 +1039,7 @@ class RestoreService {
           .read(restoreProgressProvider.notifier)
           .showError(errorKey); // overlay maps the key to a localized message
     } finally {
+      releaseSessionLock();
       // Cleanup: always cancel subscription and clear keys
       logger.i('Restore: cleaning up subscription and keys');
       await _tempSubscription?.cancel();

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -37,6 +37,7 @@ import 'package:mostro_mobile/shared/providers/navigation_notifier_provider.dart
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/notifications_history_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_lifecycle_lock_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/notifications/providers/notifications_provider.dart';
@@ -61,25 +62,7 @@ class RestoreService {
   bool _operationInProgress = false;
   Completer<bool>? _operationCompleter;
 
-  /// Tail of the session critical-section lock chain. See [acquireSessionLock].
-  Future<void> _sessionLockTail = Future.value();
-
   RestoreService(this.ref);
-
-  /// Acquires the session critical-section lock, serializing the restore session
-  /// reset ([_clearAll] in [initRestoreProcess]) with session-creating flows
-  /// (e.g. order creation) so they never interleave. This closes the TOCTOU
-  /// window that a wait-only check would leave open: a caller holding the lock
-  /// is guaranteed no reset runs until it releases, and vice versa.
-  ///
-  /// Returns a release callback the caller MUST invoke in a `finally` block.
-  Future<void Function()> acquireSessionLock() async {
-    final previous = _sessionLockTail;
-    final completer = Completer<void>();
-    _sessionLockTail = completer.future;
-    await previous;
-    return () => completer.complete();
-  }
 
   Future<void> importMnemonicAndRestore(String mnemonic) async {
     logger.i('Restore: importing mnemonic');
@@ -915,9 +898,10 @@ class RestoreService {
 
     _operationInProgress = true;
     _operationCompleter = Completer<bool>();
-    // Hold the session lock for the whole restore so order creation cannot
-    // interleave with the session reset (and rebuild) below.
-    final releaseSessionLock = await acquireSessionLock();
+    // Hold the shared session lock for the whole restore so order/take flows
+    // cannot interleave with the session reset (and rebuild) below.
+    final releaseSessionLock =
+        await ref.read(sessionLifecycleLockProvider).acquire();
     bool success = false;
     bool noHistoryFound = false;
     try {

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -1084,6 +1084,12 @@ class RestoreService {
       _masterKey = keyManager.masterKeyPair;
       _tempTradeKey = await keyManager.deriveTradeKeyFromIndex(1);
 
+      // Wait for the node info event (kind 38385) before sending: at app init
+      // mostroInstance is still null, which makes wrapForTransport default to v1
+      // gift wrap. On a protocol v2 node the request would then go out as kind
+      // 1059 and never be answered, leaving the local key index stale.
+      await _waitForNodeConnectivity(ref.read(settingsProvider).mostroPublicKey);
+
       _tempSubscription = await _createTempSubscription();
 
       // Arm the completer before sending the request to avoid a race where

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -68,12 +68,17 @@ class RestoreService {
   /// create sessions (e.g. order creation).
   bool get isOperationInProgress => _operationInProgress;
 
-  /// Resolves when the in-flight restore/sync operation finishes, or immediately
-  /// if none is running. Callers that create sessions should await this first so
-  /// their session is not wiped by the restore's session reset. Safe against
-  /// hangs: every operation completes its completer in a `finally` block.
+  /// Resolves when no restore/sync operation is running. Callers that create
+  /// sessions should await this first so their session is not wiped by the
+  /// restore's session reset. Loops so that an operation starting while we wait
+  /// is also awaited. Safe against hangs: every operation completes its completer
+  /// in a `finally` block.
+  ///
+  /// Note: restore is only triggered from node-switch, mnemonic import, manual
+  /// restore and app-init sync — all mutually exclusive with order submission in
+  /// the UI — so a true cross-flow mutex is unnecessary here.
   Future<void> awaitOperationCompletion() async {
-    if (_operationInProgress && _operationCompleter != null) {
+    while (_operationInProgress && _operationCompleter != null) {
       await _operationCompleter!.future;
     }
   }

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -1066,6 +1066,11 @@ class RestoreService {
 
     _operationInProgress = true;
     _operationCompleter = Completer<bool>();
+    // Hold the shared session lock across the whole index repair so order/take
+    // flows cannot create a session (and publish) reading a stale trade index
+    // while it is being updated by setCurrentKeyIndex below.
+    final releaseSessionLock =
+        await ref.read(sessionLifecycleLockProvider).acquire();
     try {
       _masterKey = keyManager.masterKeyPair;
       _tempTradeKey = await keyManager.deriveTradeKeyFromIndex(1);
@@ -1101,6 +1106,7 @@ class RestoreService {
     } catch (e, stack) {
       logger.e('syncTradeIndex: failed', error: e, stackTrace: stack);
     } finally {
+      releaseSessionLock();
       await _tempSubscription?.cancel();
       _tempSubscription = null;
       _currentCompleter = null;

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:dart_nostr/nostr/core/key_pairs.dart';
 import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:dart_nostr/nostr/model/request/filter.dart';
@@ -24,6 +25,7 @@ import 'package:mostro_mobile/data/models/payload.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
 import 'package:mostro_mobile/data/models/restore_response.dart';
 import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/restore/restore_progress_notifier.dart';
 import 'package:mostro_mobile/features/restore/restore_progress_state.dart';
@@ -196,20 +198,45 @@ class RestoreService {
     }
   }
 
+  /// Decrypts a restore response into its message map, reading the temp trade
+  /// key and node pubkey from the manager state. Delegates the transport branch
+  /// to the top-level [decodeRestoreMessage].
+  Future<Map<String, dynamic>> _decodeRestoreMessage(NostrEvent event) {
+    if (_tempTradeKey == null) {
+      throw Exception('Temp trade key not initialized');
+    }
+    return decodeRestoreMessage(
+      event,
+      _tempTradeKey!,
+      ref.read(settingsProvider).mostroPublicKey,
+    );
+  }
+
   Future<StreamSubscription<NostrEvent>> _createTempSubscription() async {
     //use temporary trade key 1 to subscribe to restore notifications
     if (_tempTradeKey == null) {
       throw Exception('Temp trade key not initialized');
     }
 
-    final filter = NostrFilter(
+    // Listen on both transports. The node info (kind 38385) that advertises
+    // protocol_version may not have loaded yet when restore starts, so we
+    // subscribe to v1 gift wrap (kind 1059) and v2 NIP-44 direct (kind 14)
+    // simultaneously rather than resolving a single transport — the node
+    // answers on whichever it speaks. (limit 0: only new events, no history.)
+    final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
+    final v1Filter = NostrFilter(
       kinds: [1059],
       p: [_tempTradeKey!.public],
-      limit:
-          0, //IMPORTANT:  limit 0 indicates we don't want historical events, only new ones https://nostrbook.dev/protocol/filter
+      limit: 0,
+    );
+    final v2Filter = NostrFilter(
+      kinds: [14],
+      authors: [mostroPubkey],
+      p: [_tempTradeKey!.public],
+      limit: 0,
     );
 
-    final request = NostrRequest(filters: [filter]);
+    final request = NostrRequest(filters: [v1Filter, v2Filter]);
     final stream = ref.read(nostrServiceProvider).subscribeToEvents(request);
 
     final subscription = stream.listen(
@@ -252,7 +279,8 @@ class RestoreService {
         'event may be rejected if node requires PoW',
       );
     }
-    final wrappedEvent = await mostroMessage.wrap(
+    final wrappedEvent = await mostroMessage.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -269,19 +297,7 @@ class RestoreService {
   Future<({Map<String, int> ordersMap, List<RestoredDispute> disputes})>
   _extractRestoreData(NostrEvent event) async {
     try {
-      if (_tempTradeKey == null) {
-        throw Exception('Temp trade key not initialized');
-      }
-
-      // Unwrap the gift wrap (kind 1059) to get the rumor
-      final rumor = await event.mostroUnWrap(_tempTradeKey!);
-
-      if (rumor.content == null || rumor.content!.isEmpty) {
-        throw Exception('Rumor content is empty');
-      }
-
-      final contentList = jsonDecode(rumor.content!) as List<dynamic>;
-      final messageData = contentList[0] as Map<String, dynamic>;
+      final messageData = await _decodeRestoreMessage(event);
 
       // Check if Mostro returned cant-do (not found)
       if (messageData.containsKey('cant-do')) {
@@ -360,7 +376,8 @@ class RestoreService {
         'event may be rejected if node requires PoW',
       );
     }
-    final wrappedEvent = await mostroMessage.wrap(
+    final wrappedEvent = await mostroMessage.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -378,20 +395,7 @@ class RestoreService {
         'Restore: extracting orders details from gift wrap event ${event.id}',
       );
 
-      if (_tempTradeKey == null) {
-        throw Exception('Temp trade key not initialized');
-      }
-
-      // Unwrap the gift wrap (kind 1059) to get the rumor
-      final rumor = await event.mostroUnWrap(_tempTradeKey!);
-
-      if (rumor.content == null || rumor.content!.isEmpty) {
-        throw Exception('Rumor content is empty');
-      }
-
-      // Parse response format: [{"order": {...}}, null]
-      final contentList = jsonDecode(rumor.content!) as List<dynamic>;
-      final messageData = contentList[0] as Map<String, dynamic>;
+      final messageData = await _decodeRestoreMessage(event);
 
       // Check if Mostro returned cant-do
       if (messageData.containsKey('cant-do')) {
@@ -453,7 +457,8 @@ class RestoreService {
         'event may be rejected if node requires PoW',
       );
     }
-    final wrappedEvent = await mostroMessage.wrap(
+    final wrappedEvent = await mostroMessage.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -472,18 +477,7 @@ class RestoreService {
         'Restore: extracting last trade index from gift wrap event ${event.id}',
       );
 
-      if (_tempTradeKey == null) {
-        throw Exception('Temp trade key not initialized');
-      }
-
-      final rumor = await event.mostroUnWrap(_tempTradeKey!);
-
-      if (rumor.content == null || rumor.content!.isEmpty) {
-        throw Exception('Rumor content is empty');
-      }
-
-      final contentList = jsonDecode(rumor.content!) as List<dynamic>;
-      final messageData = contentList[0] as Map<String, dynamic>;
+      final messageData = await _decodeRestoreMessage(event);
 
       // Check if Mostro returned cant-do
       if (messageData.containsKey('cant-do')) {
@@ -1120,6 +1114,42 @@ class RestoreService {
     }
     return null;
   }
+}
+
+/// Decodes a restore response into its message map, handling both transports:
+/// v2 (kind 14, NIP-44 direct, decrypted straight to the tuple) and v1
+/// (kind 1059, gift wrap unwrapped to a rumor whose content is the tuple). Both
+/// converge on `tuple[0]`.
+///
+/// Top-level (not a private method) so the transport branch can be
+/// regression-tested without the full [RestoreService] / Riverpod orchestration.
+@visibleForTesting
+Future<Map<String, dynamic>> decodeRestoreMessage(
+  NostrEvent event,
+  NostrKeyPairs tempTradeKey,
+  String mostroPubkey,
+) async {
+  final String content;
+  if (event.kind == 14) {
+    content = await NostrUtils.decryptNIP44DirectEvent(
+      event,
+      tempTradeKey.private,
+      expectedAuthor: mostroPubkey,
+    );
+  } else {
+    final rumor = await event.mostroUnWrap(tempTradeKey);
+    content = rumor.content ?? '';
+  }
+
+  if (content.isEmpty) {
+    throw Exception('Restore message content is empty');
+  }
+
+  final contentList = jsonDecode(content) as List<dynamic>;
+  if (contentList.isEmpty) {
+    throw Exception('Restore message tuple is empty');
+  }
+  return contentList[0] as Map<String, dynamic>;
 }
 
 /// Thrown when Mostro responds with cant-do: invalid_trade_index to

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -363,7 +363,10 @@ class MostroService {
       );
     }
 
-    final event = await order.wrap(
+    // Route through the transport advertised by the connected node (§5 Phase
+    // B). v1 nodes (default) keep the gift-wrap path byte-for-byte.
+    final event = await order.wrapForTransport(
+      protocolVersion: mostroInstance?.protocolVersion,
       tradeKey: session.tradeKey,
       recipientPubKey: _settings.mostroPublicKey,
       masterKey: session.fullPrivacy ? null : session.masterKey,
@@ -371,7 +374,8 @@ class MostroService {
       difficulty: difficulty,
     );
     logger.i(
-      'Sending DM, Event ID: ${event.id} (PoW: $difficulty) with payload: ${order.toJson()}',
+      'Sending DM (kind ${event.kind}), Event ID: ${event.id} '
+      '(PoW: $difficulty) with payload: ${order.toJson()}',
     );
     await ref.read(nostrServiceProvider).publishEvent(event);
   }

--- a/lib/shared/providers.dart
+++ b/lib/shared/providers.dart
@@ -4,3 +4,4 @@ export 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 export 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 export 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 export 'package:mostro_mobile/shared/providers/navigation_notifier_provider.dart';
+export 'package:mostro_mobile/shared/providers/session_lifecycle_lock_provider.dart';

--- a/lib/shared/providers/session_lifecycle_lock_provider.dart
+++ b/lib/shared/providers/session_lifecycle_lock_provider.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Serializes session-mutating critical sections so they never interleave:
+/// session creation plus the dependent publish (order create, take buy/sell)
+/// and the restore session reset/rebuild. While one holder runs, no other
+/// critical section can — eliminating the TOCTOU window where a freshly created
+/// session could be wiped by a concurrent restore reset.
+///
+/// Single shared instance via [sessionLifecycleLockProvider]; every flow must
+/// go through the same instance for the serialization to hold.
+class SessionLifecycleLock {
+  Future<void> _tail = Future.value();
+
+  /// Acquires the lock, queued behind any current holder. Returns a release
+  /// callback the caller MUST invoke in a `finally` block. Prefer
+  /// [withSessionLock] for new call sites; use this only when an existing
+  /// try/finally already guarantees release.
+  Future<void Function()> acquire() async {
+    final previous = _tail;
+    final completer = Completer<void>();
+    _tail = completer.future;
+    await previous;
+    return () => completer.complete();
+  }
+
+  /// Runs [action] inside the critical section, releasing automatically even if
+  /// [action] throws. Do not call back into the lock from within [action] — it
+  /// is not re-entrant and would deadlock.
+  Future<T> withSessionLock<T>(Future<T> Function() action) async {
+    final release = await acquire();
+    try {
+      return await action();
+    } finally {
+      release();
+    }
+  }
+}
+
+final sessionLifecycleLockProvider =
+    Provider<SessionLifecycleLock>((ref) => SessionLifecycleLock());

--- a/test/data/mostro_message_nip44_test.dart
+++ b/test/data/mostro_message_nip44_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// Replicates the Mostro signing scheme (SHA-256 hex digest, Schnorr-verified)
+/// for asserting the tuple signatures.
+bool verifyMostroSig(String pubkey, String message, String sig) {
+  final hash = hex.encode(sha256.convert(utf8.encode(message)).bytes);
+  return NostrKeyPairs.verify(pubkey, hash, sig);
+}
+
+void main() {
+  group('MostroMessage.wrapNip44 (protocol v2)', () {
+    late NostrKeyPairs tradeKey;
+    late NostrKeyPairs masterKey;
+    late NostrKeyPairs mostroKey; // stands in for the node / recipient
+
+    setUp(() {
+      tradeKey = NostrUtils.generateKeyPair();
+      masterKey = NostrUtils.generateKeyPair();
+      mostroKey = NostrUtils.generateKeyPair();
+    });
+
+    test('reputation mode: kind-14 event round-trips with identity proof',
+        () async {
+      final message = MostroMessage(
+        action: Action.fiatSent,
+        id: 'order-1',
+        requestId: 7,
+      );
+
+      final event = await message.wrapNip44(
+        tradeKey: tradeKey,
+        recipientPubKey: mostroKey.public,
+        masterKey: masterKey,
+        keyIndex: 5,
+      );
+
+      // Event shape: kind 14, authored by the trade key, p-tagged to the node.
+      expect(event.kind, 14);
+      expect(event.pubkey, tradeKey.public);
+      expect(
+        event.tags!.any((t) => t[0] == 'p' && t[1] == mostroKey.public),
+        isTrue,
+      );
+
+      // Node decrypts with its private key + the event author (trade key).
+      final content = await NostrUtils.decryptNIP44DirectEvent(
+        event,
+        mostroKey.private,
+        expectedAuthor: tradeKey.public,
+      );
+      final tuple = jsonDecode(content) as List;
+      expect(tuple.length, 3);
+
+      // Element 0: the message with version 2, decodes to the original.
+      final messageMap = tuple[0] as Map<String, dynamic>;
+      expect(messageMap['order']['version'], 2);
+      final decoded = MostroMessage.fromJson(messageMap);
+      expect(decoded.action, Action.fiatSent);
+      expect(decoded.id, 'order-1');
+
+      // Element 1: trade-key signature over the exact message JSON.
+      final messageJson = jsonEncode(messageMap);
+      expect(tuple[1], isNotNull);
+      expect(verifyMostroSig(tradeKey.public, messageJson, tuple[1] as String),
+          isTrue);
+
+      // Element 2: identity proof = [identityPubkey, sig over domain payload].
+      final proof = tuple[2] as List;
+      expect(proof[0], masterKey.public);
+      final domain =
+          'mostro-transport-v2-identity:${tradeKey.public}:$messageJson';
+      expect(verifyMostroSig(masterKey.public, domain, proof[1] as String),
+          isTrue);
+    });
+
+    test('full-privacy mode: tradeSig and identityProof are null', () async {
+      final message = MostroMessage(
+        action: Action.fiatSent,
+        id: 'order-2',
+        requestId: 9,
+      );
+
+      final event = await message.wrapNip44(
+        tradeKey: tradeKey,
+        recipientPubKey: mostroKey.public,
+        masterKey: null,
+      );
+
+      expect(event.kind, 14);
+      expect(event.pubkey, tradeKey.public);
+
+      final content = await NostrUtils.decryptNIP44DirectEvent(
+        event,
+        mostroKey.private,
+        expectedAuthor: tradeKey.public,
+      );
+      final tuple = jsonDecode(content) as List;
+      expect(tuple.length, 3);
+      expect((tuple[0] as Map)['order']['version'], 2);
+      expect(tuple[1], isNull);
+      expect(tuple[2], isNull);
+
+      final decoded = MostroMessage.fromJson(tuple[0] as Map<String, dynamic>);
+      expect(decoded.action, Action.fiatSent);
+      expect(decoded.id, 'order-2');
+    });
+  });
+}

--- a/test/features/restore/restore_decode_test.dart
+++ b/test/features/restore/restore_decode_test.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/restore/restore_manager.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// Regression tests for the restore receive path covering both transports:
+/// v1 gift wrap (kind 1059) and v2 NIP-44 direct (kind 14). The node is the
+/// sender; the client decrypts with its temporary restore trade key.
+void main() {
+  group('decodeRestoreMessage (restore transport branch)', () {
+    late NostrKeyPairs tempTradeKey;
+    late NostrKeyPairs mostroKey;
+
+    // A restore response as Mostro sends it: tuple [message, signature?].
+    final restoreTuple = jsonEncode([
+      {
+        'restore': {
+          'version': 1,
+          'action': 'restore',
+          'payload': {
+            'restore_data': {'orders': [], 'disputes': []},
+          },
+        },
+      },
+      null,
+    ]);
+
+    setUp(() {
+      tempTradeKey = NostrUtils.generateKeyPair();
+      mostroKey = NostrUtils.generateKeyPair();
+    });
+
+    /// Builds a v2 (kind 14) reply authored by the node toward the temp key.
+    Future<NostrEvent> buildV2Reply(String tuple) async {
+      final encrypted = await NostrUtils.encryptNIP44(
+        tuple,
+        mostroKey.private,
+        tempTradeKey.public,
+      );
+      return NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: mostroKey,
+        tags: [
+          ['p', tempTradeKey.public],
+        ],
+        createdAt: DateTime.now(),
+      );
+    }
+
+    test('v1 gift wrap (kind 1059) decodes to the restore message', () async {
+      final event = await NostrUtils.createNIP59Event(
+        restoreTuple,
+        tempTradeKey.public,
+        mostroKey.private,
+      );
+
+      expect(event.kind, 1059);
+      final data = await decodeRestoreMessage(
+        event,
+        tempTradeKey,
+        mostroKey.public,
+      );
+      expect(data.containsKey('restore'), isTrue);
+    });
+
+    test('v2 NIP-44 direct (kind 14) decodes to the restore message', () async {
+      final event = await buildV2Reply(restoreTuple);
+
+      expect(event.kind, 14);
+      expect(event.pubkey, mostroKey.public);
+      final data = await decodeRestoreMessage(
+        event,
+        tempTradeKey,
+        mostroKey.public,
+      );
+      expect(data.containsKey('restore'), isTrue);
+    });
+
+    test('v1 and v2 decode to identical message maps', () async {
+      final v1 = await NostrUtils.createNIP59Event(
+        restoreTuple,
+        tempTradeKey.public,
+        mostroKey.private,
+      );
+      final v2 = await buildV2Reply(restoreTuple);
+
+      final d1 = await decodeRestoreMessage(v1, tempTradeKey, mostroKey.public);
+      final d2 = await decodeRestoreMessage(v2, tempTradeKey, mostroKey.public);
+
+      expect(d2, equals(d1));
+    });
+
+    test('v2 reply from an unexpected author is rejected', () async {
+      final imposter = NostrUtils.generateKeyPair();
+      final encrypted = await NostrUtils.encryptNIP44(
+        restoreTuple,
+        imposter.private,
+        tempTradeKey.public,
+      );
+      final event = NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: imposter,
+        tags: [
+          ['p', tempTradeKey.public],
+        ],
+        createdAt: DateTime.now(),
+      );
+
+      // expectedAuthor is the real node; the imposter-authored event must fail.
+      expect(
+        () => decodeRestoreMessage(event, tempTradeKey, mostroKey.public),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Re-applies the content of #624 (dual send for transport v2, Phase B) on top of `main` (post Riverpod 3.x rollback, #628), **without any Riverpod 3.x changes** from #613. Also includes a follow-up fix for an order-creation race surfaced while testing the restore flow.

The Phase B commit is a clean cherry-pick of the original #624 delta onto the reverted (Riverpod 2.6.1) base: byte-identical to the original and with no Riverpod 3.x API usage (only `ref.read(settingsProvider)`, identical in 2.x/3.x).

## Contents

### Transport v2 (Phase B) — re-apply of #624
- NIP-44 dual-receive/dual-send transport logic (`mostro_message.dart`, `mostro_service.dart`)
- Restore manager decode path + tests (`mostro_message_nip44_test.dart`, `restore_decode_test.dart`)
- Transport v2 migration docs

### Fix: order-creation race with node-switch restore
A node-switch restore resets all sessions (`RestoreService._clearAll` → `sessionNotifier.reset()`). Creating an order while that restore is in flight had its session wiped, leaving the order orphaned on the daemon (it consumed a trade index but never appeared in "My Trades").
- Expose `RestoreService.isOperationInProgress` / `awaitOperationCompletion()`
- `AddOrderNotifier.submitOrder` now waits for any in-flight restore to finish before creating the order session

## Verification
- `flutter analyze`: no issues.
- `flutter test`: all tests pass (479).
- Manual: order create + cancel round-trips end-to-end against both a v1 daemon (kind 1059 gift wrap) and a v2 daemon (kind 14 NIP-44 direct); transport is selected from the node's advertised `protocol_version`.

## Base
- Targets `main` (#628 already merged). No longer depends on the revert branch.

Original author: Andrea Diaz (Phase B preserved via cherry-pick).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol-versioned message serialization and transport-aware wrapping for v1 (gift-wrap) and v2 (NIP-44) across sending, disputes, and restores.
* **Bug Fixes**
  * Prevented restore/order session interleaving issues via a session lifecycle lock.
  * Improved restore decoding and temporary restore subscriptions to handle both transport variants together.
  * Updated dispute transport behavior to better match privacy mode expectations.
* **Documentation**
  * Updated session recovery and transport v2 migration guidance.
* **Tests**
  * Added coverage for v2 NIP-44 wrapping and restore decoding for both transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->