### PR TITLE
feat: re-apply MWK (Malawi Kwacha) payment methods without Riverpod 3.x

### DIFF
--- a/assets/data/payment_methods.json
+++ b/assets/data/payment_methods.json
@@ -13,6 +13,7 @@
   "GBP": ["Revolut", "Monzo", "Wise", "Any national bank", "Bank Transfer", "Cash"],
   "JPY": ["PayPay", "Bank Transfer", "Cash"],
   "MLC": ["Transfermovil", "EnZona"],
+  "MWK": ["Airtel Money", "TNM Mpamba", "Bank Transfer", "Cash"],
   "MXN": ["SPEI", "CoDi", "Retiro Cajero BBVA", "Efectivo"],
   "NGN": ["Bank Transfer", "Cash"],
   "PEN": ["Yape", "Plin", "QR Yape", "Transferencia bancaria", "Cash"],


### PR DESCRIPTION
Summary

Re-applies the content of https://github.com/MostroP2P/mobile/pull/625 (MWK / Malawi Kwacha payment methods) on top of the rollback, without any Riverpod 3.x changes from https://github.com/MostroP2P/mobile/pull/613.

Clean cherry-pick of the original https://github.com/MostroP2P/mobile/pull/625 commit. The change is a single data-only addition to assets/data/payment_methods.json — no code, no Riverpod involvement.
Dependency

    Base: revert/riverpod-3x-rollback (

https://github.com/MostroP2P/mobile/pull/628). Merge https://github.com/MostroP2P/mobile/pull/628 first. GitHub will retarget this PR to main automatically once

    https://github.com/MostroP2P/mobile/pull/628 merges.

Original author: codaMW (preserved via cherry-pick).