### PR TITLE
fix(invoice): keep Submit reachable on Add Lightning Invoice when keyboard is open (#635)

### DIFF
--- a/lib/shared/widgets/add_lightning_invoice_widget.dart
+++ b/lib/shared/widgets/add_lightning_invoice_widget.dart
@@ -30,89 +30,93 @@ class AddLightningInvoiceWidget extends StatefulWidget {
 class _AddLightningInvoiceWidgetState extends State<AddLightningInvoiceWidget> {
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          S.of(context)!.pleaseEnterLightningInvoiceFor(
-            widget.amount.toString(),
-            widget.fiatCode,
-            widget.fiatAmount,
-            widget.orderId,
-          ),
-          style: const TextStyle(
-            color: AppTheme.textPrimary,
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-        const SizedBox(height: 16),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          decoration: BoxDecoration(
-            color: AppTheme.backgroundInput,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-          ),
-          child: TextFormField(
-            key: const Key('invoiceTextField'),
-            controller: widget.controller,
-            style: const TextStyle(color: AppTheme.textPrimary),
-            decoration: InputDecoration(
-              labelText: S.of(context)!.lightningInvoice,
-              labelStyle: const TextStyle(color: AppTheme.textSecondary),
-              hintText: S.of(context)!.enterInvoiceHere,
-              hintStyle: const TextStyle(color: AppTheme.textSecondary),
-              border: InputBorder.none,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              alignLabelWithHint: true,
-            ),
-            maxLines: 6,
-          ),
-        ),
-        const SizedBox(height: 16),
-        Row(
-          children: [
-            Expanded(
-              child: TextButton(
-                key: const Key('cancelInvoiceButton'),
-                onPressed: widget.onCancel,
-                child: Text(
-                  S.of(context)!.cancel,
-                  style: const TextStyle(
-                    color: AppTheme.textSecondary,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                  textAlign: TextAlign.center,
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            S.of(context)!.pleaseEnterLightningInvoiceFor(
+                  widget.amount.toString(),
+                  widget.fiatCode,
+                  widget.fiatAmount,
+                  widget.orderId,
                 ),
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: AppTheme.backgroundInput,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+            ),
+            child: TextFormField(
+              key: const Key('invoiceTextField'),
+              controller: widget.controller,
+              style: const TextStyle(color: AppTheme.textPrimary),
+              decoration: InputDecoration(
+                labelText: S.of(context)!.lightningInvoice,
+                labelStyle: const TextStyle(color: AppTheme.textSecondary),
+                hintText: S.of(context)!.enterInvoiceHere,
+                hintStyle: const TextStyle(color: AppTheme.textSecondary),
+                border: InputBorder.none,
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                alignLabelWithHint: true,
               ),
+              maxLines: 6,
             ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: ElevatedButton(
-                key: const Key('submitInvoiceButton'),
-                onPressed: widget.onSubmit,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppTheme.activeColor,
-                  foregroundColor: Colors.black,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-                ),
-                child: Text(
-                  S.of(context)!.submit,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: TextButton(
+                  key: const Key('cancelInvoiceButton'),
+                  onPressed: widget.onCancel,
+                  child: Text(
+                    S.of(context)!.cancel,
+                    style: const TextStyle(
+                      color: AppTheme.textSecondary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
                 ),
               ),
-            ),
-          ],
-        ),
-      ],
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  key: const Key('submitInvoiceButton'),
+                  onPressed: widget.onSubmit,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppTheme.activeColor,
+                    foregroundColor: Colors.black,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 12),
+                  ),
+                  child: Text(
+                    S.of(context)!.submit,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
> ## What
> Wraps the invoice form in `add_lightning_invoice_widget.dart` in a `SingleChildScrollView` so it scrolls instead of overflowing when the soft keyboard is open.
>
> ## Root cause
> `build` returned a bare `Column` containing a 6-line invoice `TextFormField`. When the keyboard opens, the `Scaffold` shrinks the available height; on some screen geometries the `Column` overflows and the Cancel/Submit `Row` is pushed past the hittable area the button renders but its tap target is clipped, so Submit does nothing. Dismissing the keyboard restores the viewport and it works again.
>
> ## Fix
> Wrapping the `Column` in a `SingleChildScrollView` keeps Submit reachable on any screen size. The `-w` diff shows the real change is just the wrapper; the rest is `dart format` reflow.
>
> ## Testing
> - `flutter analyze`: no issues.
> - Reached the Add Lightning Invoice screen via a full local E2E, but **the bug did not reproduce on my device (Nokia C31)**  Submit worked with the keyboard open, and still worked when I forced a smaller viewport via split-screen. Consistent with the diagnosis: the overflow only occurs on certain screen geometries. The report is on a Pixel 8a / Android 16.
> - Verified no-regression on my C31: Submit still works and the form now scrolls with the keyboard open.
> - @wchancao, could you confirm this resolves it on your Pixel 8a? I couldn't trigger the original overflow locally.

<img width="720" height="1600" alt="1000150223" src="https://github.com/user-attachments/assets/c94ef68d-58bd-4414-8c27-c601a47b1175" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Lightning invoice entry screen now scrolls, making it easier to use on smaller displays or when the keyboard is open.
  * Existing invoice input, cancel, and submit actions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->