### PR TITLE
fix: register push token for range-order child trade keys

### DIFF
--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -348,6 +348,12 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     _pendingChildSessions[tradeKey.public] = session;
     _emitState();
 
+    // Register the child trade key with the push server right away: the child
+    // order can be taken as soon as mostrod publishes it, and without this
+    // mapping the push server cannot wake the device (FCM) for events
+    // addressed to the child trade key while the app is killed or dozing.
+    _registerPushToken(tradeKey.public);
+
     logger.i(
       'Prepared child session for parent order $parentOrderId using key index $keyIndex',
     );
@@ -373,6 +379,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     _sessions[childOrderId] = session;
     await _storage.putSession(session);
     _emitState();
+
+    // Retry the push registration on link in case the creation-time attempt
+    // failed (e.g. offline right after release). registerToken is idempotent
+    // server-side, so a duplicate call is harmless.
+    _registerPushToken(session.tradeKey.public);
 
     logger.i(
       'Linked child order $childOrderId to prepared session (parent: ${session.parentOrderId})',

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -16,6 +16,7 @@ import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription.dart';
 import 'package:mostro_mobile/services/mostro_service.dart';
 import 'package:mostro_mobile/services/nostr_service.dart';
+import 'package:mostro_mobile/services/push_notification_service.dart';
 import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/features/order/notifiers/order_notifier.dart';
@@ -50,6 +51,7 @@ import 'mocks.mocks.dart';
   EncryptedImageUploadService,
   BlossomDownloadService,
   ChatRoomNotifier,
+  PushNotificationService,
 ], customMocks: [
   // Spy mock used to verify SubscriptionManager calls (the hand-written
   // MockSubscriptionManager below keeps its name; this one has a distinct name).

--- a/test/notifiers/session_notifier_test.dart
+++ b/test/notifiers/session_notifier_test.dart
@@ -1,0 +1,134 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/enums/role.dart';
+import 'package:mostro_mobile/features/key_manager/key_manager.dart';
+import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+
+import '../mocks.mocks.dart';
+
+void main() {
+  late MockRef mockRef;
+  late MockKeyManager mockKeyManager;
+  late MockSessionStorage mockStorage;
+  late MockPushNotificationService mockPushService;
+  late SessionNotifier notifier;
+
+  // Dummy private keys for testing purposes only
+  final masterKey = NostrKeyPairs(
+    private:
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  );
+  final childTradeKey = NostrKeyPairs(
+    private:
+        'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+  );
+
+  setUpAll(() {
+    provideDummy<KeyManager>(MockKeyManager());
+  });
+
+  setUp(() {
+    mockRef = MockRef();
+    mockKeyManager = MockKeyManager();
+    mockStorage = MockSessionStorage();
+    mockPushService = MockPushNotificationService();
+
+    when(mockRef.read(keyManagerProvider)).thenReturn(mockKeyManager);
+    when(mockKeyManager.masterKeyPair).thenReturn(masterKey);
+    when(mockPushService.registerToken(any)).thenAnswer((_) async => true);
+    when(mockStorage.putSession(any)).thenAnswer((_) async {});
+
+    notifier = SessionNotifier(
+      mockRef,
+      mockStorage,
+      Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+        defaultFiatCode: 'USD',
+        selectedLanguage: null,
+      ),
+    );
+    notifier.setPushNotificationService(mockPushService);
+  });
+
+  group('createChildOrderSession', () {
+    test('registers push token for the child trade key', () async {
+      // Act
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: 5,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      // Assert: the child trade key is registered with the push server so
+      // FCM can wake the device when the child order is taken.
+      await untilCalled(mockPushService.registerToken(childTradeKey.public));
+      verify(mockPushService.registerToken(childTradeKey.public)).called(1);
+    });
+
+    test('keeps the child session pending in state without an orderId',
+        () async {
+      // Act
+      final session = await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: 5,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      // Assert
+      expect(session.orderId, isNull);
+      expect(session.parentOrderId, 'parent-order-id');
+      expect(
+        notifier.state.any((s) => s.tradeKey.public == childTradeKey.public),
+        isTrue,
+      );
+    });
+  });
+
+  group('linkChildSessionToOrderId', () {
+    test('re-registers push token when linking the child order', () async {
+      // Arrange: a pending child session exists
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: 5,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      await untilCalled(mockPushService.registerToken(childTradeKey.public));
+      clearInteractions(mockPushService);
+
+      // Act
+      await notifier.linkChildSessionToOrderId(
+        'child-order-id',
+        childTradeKey.public,
+      );
+
+      // Assert: linking retries the registration (idempotent server-side),
+      // covering a failed creation-time attempt (e.g. offline after release).
+      await untilCalled(mockPushService.registerToken(childTradeKey.public));
+      verify(mockPushService.registerToken(childTradeKey.public)).called(1);
+      expect(
+        notifier.state.any((s) => s.orderId == 'child-order-id'),
+        isTrue,
+      );
+    });
+
+    test('does not register token when no pending child session exists',
+        () async {
+      // Act
+      await notifier.linkChildSessionToOrderId(
+        'child-order-id',
+        childTradeKey.public,
+      );
+
+      // Assert
+      verifyNever(mockPushService.registerToken(any));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Users report missing notifications when the **second part of a range order** is taken (the first part notifies fine). Reported by users on v1.3.0.

The FCM wake path depends on the push server having a `trade_pubkey → device_token` mapping (`/api/register`). That registration only happens in `SessionNotifier.saveSession()` → `_registerPushToken()`.

Range-order child sessions never go through `saveSession()`:

- `createChildOrderSession()` keeps the session in memory only (`_pendingChildSessions`), no registration.
- `linkChildSessionToOrderId()` persists via `_storage.putSession()` directly, bypassing `saveSession()`.

So the child trade key is **never registered with the push server**. When the child order is taken while the app is killed or dozing, the push server has no mapping for the `p`-tagged recipient, no FCM wake is sent, the background service never starts, and the maker gets no notification. The first part works because its trade key is registered at order creation (`add_order_notifier.dart`).

## Fix

- Register the child trade key at `createChildOrderSession()` time — the child order can be taken as soon as mostrod publishes it, so registration must not wait for the link.
- Register again in `linkChildSessionToOrderId()` as an idempotent retry, covering a failed creation-time attempt (e.g. device offline right after release).

Registration stays fire-and-forget and gated on the existing `isPushEnabledInSettings` check inside `PushNotificationService.registerToken()`.

## Test plan

- [x] New unit tests in `test/notifiers/session_notifier_test.dart`:
  - `createChildOrderSession` registers the push token for the child trade key
  - child session stays pending in state without an orderId
  - `linkChildSessionToOrderId` re-registers the token and links the session
  - no registration when there is no pending child session
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 485 tests pass

## Related

Part 1 of 3 PRs addressing the missing take-order notifications reported on v1.3.0. Part 2 persists pending child sessions for the background isolate; part 3 adds protocol-v2 (kind 14) support to mostro-push-server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push-notification registration for child order sessions.
  * Child-trade notifications can now reach devices before an order ID is available.
  * Registration is retried when a pending child session is linked to its order ID.

* **Tests**
  * Added coverage for child-session creation, linking, pending states, and notification registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->