### PR TITLE
fix: persist pending range-order child sessions across isolates and restarts

### DIFF
--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -81,6 +81,13 @@ class Config {
   static const int cleanupIntervalMinutes = 30;
   static const int sessionExpirationHours = 720;
 
+  /// Upper bound for a pending range-order child session (persisted without an
+  /// orderId while waiting for mostrod's child new-order message). The handoff
+  /// resolves in seconds, so a record still unlinked after this window never
+  /// will be. Bounded independently of [sessionExpirationHours] so orphan
+  /// records cannot accumulate when session expiration is disabled (0).
+  static const int pendingChildSessionExpirationHours = 48;
+
   // Notification configuration
   static String notificationChannelId = 'mostro_mobile';
   static int notificationId = 38383;

--- a/lib/data/repositories/session_storage.dart
+++ b/lib/data/repositories/session_storage.dart
@@ -73,6 +73,23 @@ class SessionStorage extends BaseStorage<Session> {
     await putItem('$pendingChildKeyPrefix${session.tradeKey.public}', session);
   }
 
+  /// Stores a linked child session under its orderId and removes its pending
+  /// record in a single transaction. Doing both atomically means a crash in
+  /// between can neither lose the session (pending gone, order not yet
+  /// written) nor leave the same session stored twice.
+  Future<void> promotePendingChildSession(Session session) async {
+    final orderId = session.orderId;
+    if (orderId == null) {
+      throw ArgumentError('Cannot promote a child session without an orderId');
+    }
+    final jsonMap = toDbMap(session);
+    final pendingKey = '$pendingChildKeyPrefix${session.tradeKey.public}';
+    await db.transaction((txn) async {
+      await store.record(orderId).put(txn, jsonMap);
+      await store.record(pendingKey).delete(txn);
+    });
+  }
+
   /// Removes the pending child session record for [tradeKeyPublic], if any.
   /// Called once the child order id is known and the session is re-stored
   /// under its orderId, or when an expired pending child is cleaned up.

--- a/lib/data/repositories/session_storage.dart
+++ b/lib/data/repositories/session_storage.dart
@@ -45,12 +45,39 @@ class SessionStorage extends BaseStorage<Session> {
     return Session.fromJson(clone);
   }
 
+  /// Record-key prefix for pending range-order child sessions, which have no
+  /// orderId yet and are keyed by their trade public key instead.
+  static const String pendingChildKeyPrefix = 'pending-child:';
+
   Future<void> putSession(Session session) async {
     if (session.orderId == null) {
       throw ArgumentError('Cannot store a session with an empty orderId');
     }
     await putItem(session.orderId!, session);
   }
+
+  /// Persists a pending range-order child session (no orderId yet), keyed by
+  /// its trade public key. Persisting it matters for two reasons: the session
+  /// must survive an app kill between release and the child new-order message,
+  /// and the background isolate loads sessions from this store to decrypt
+  /// events addressed to the child trade key.
+  Future<void> putPendingChildSession(Session session) async {
+    if (session.orderId != null) {
+      throw ArgumentError(
+        'Pending child session must not have an orderId; use putSession',
+      );
+    }
+    if (session.parentOrderId == null) {
+      throw ArgumentError('Pending child session requires a parentOrderId');
+    }
+    await putItem('$pendingChildKeyPrefix${session.tradeKey.public}', session);
+  }
+
+  /// Removes the pending child session record for [tradeKeyPublic], if any.
+  /// Called once the child order id is known and the session is re-stored
+  /// under its orderId, or when an expired pending child is cleaned up.
+  Future<void> deletePendingChildSession(String tradeKeyPublic) =>
+      deleteItem('$pendingChildKeyPrefix$tradeKeyPublic');
 
   /// Shortcut to get a single session by its ID.
   Future<Session?> getSession(String sessionId) => getItem(sessionId);

--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -10,6 +10,7 @@ import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:mostro_mobile/core/app.dart';
+import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/data/models/order.dart';
@@ -384,11 +385,11 @@ Future<MostroMessage?> _handleTradeKeyEvent(NostrEvent event, Session session) a
   final mostroMessage = MostroMessage.fromJson(result[0]);
   mostroMessage.timestamp = event.createdAt?.millisecondsSinceEpoch;
 
-  // If this is the new-order confirmation for a pending range-order child
-  // session, link it to the child order id right here. The foreground link
+  // If this message belongs to a pending range-order child session, link it to
+  // the child order id right here. The foreground link
   // (MostroService._maybeLinkChildOrder) never runs while the app is
-  // backgrounded or killed, and later events for the child order need the
-  // session stored under its orderId (e.g. role-gated notifications).
+  // backgrounded or killed, and this and later events for the child order need
+  // the session stored under its orderId (e.g. role-gated notifications).
   await _maybeLinkChildOrder(mostroMessage, session);
 
   // If this event transitions the order to Active, learn the counterpart's
@@ -403,41 +404,42 @@ Future<MostroMessage?> _handleTradeKeyEvent(NostrEvent event, Session session) a
 }
 
 /// Links a pending range-order child session to its concrete child order id
-/// when the new-order confirmation arrives while the app is backgrounded.
+/// when a message for that child arrives while the app is backgrounded.
 /// Mirrors MostroService._maybeLinkChildOrder for the background isolate:
 /// stores the session under its orderId and drops the pending record.
+///
+/// The trigger is any message carrying an order id, not just the child
+/// new-order confirmation: the device may well be woken (FCM) by a later
+/// event — the very take-order message this notification path exists for —
+/// while the new-order message was never delivered to this isolate. The child
+/// trade key is used by exactly one order, so any id other than the parent's
+/// identifies it.
 Future<void> _maybeLinkChildOrder(
   MostroMessage message,
   Session session,
 ) async {
-  if (message.action != mostro_action.Action.newOrder || message.id == null) {
-    return;
-  }
-  if (session.orderId != null || session.parentOrderId == null) {
-    return;
-  }
+  final childOrderId = message.id;
+  if (childOrderId == null || childOrderId.isEmpty) return;
+  if (session.orderId != null || session.parentOrderId == null) return;
+  if (childOrderId == session.parentOrderId) return;
 
   try {
-    session.orderId = message.id;
+    session.orderId = childOrderId;
 
-    final db = await openMostroDatabase('mostro.db');
-    const secureStorage = FlutterSecureStorage();
-    final sharedPrefs = SharedPreferencesAsync();
-    final keyStorage = KeyStorage(
-      secureStorage: secureStorage,
-      sharedPrefs: sharedPrefs,
-    );
-    final keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
-    final keyManager = KeyManager(keyStorage, keyDerivator);
-    await keyManager.init();
-    final sessionStorage = SessionStorage(keyManager, db: db);
-    await sessionStorage.putSession(session);
-    await sessionStorage.deletePendingChildSession(session.tradeKey.public);
+    final sessionStorage = await _openSessionStorage();
+    // Store under the orderId and drop the pending record in one transaction
+    // so a crash in between cannot lose the session.
+    await sessionStorage.promotePendingChildSession(session);
+    // Local write: the cached session list is stale now.
+    backgroundSessionCache.invalidate();
 
     logger.i(
-      'Background linked child order ${message.id} to parent ${session.parentOrderId}',
+      'Background linked child order $childOrderId to parent ${session.parentOrderId}',
     );
   } catch (e, stackTrace) {
+    // Keep the in-memory session pending so the next attempt (background or
+    // foreground) retries the link instead of assuming a stored orderId.
+    session.orderId = null;
     logger.e(
       'Failed to link child order in background: $e',
       stackTrace: stackTrace,
@@ -491,17 +493,7 @@ Future<void> _maybeUpdateSessionWithPeer(
     // Setting peer on the session computes the shared key via ECDH.
     session.peer = Peer(publicKey: peerPubkey);
 
-    final db = await openMostroDatabase('mostro.db');
-    const secureStorage = FlutterSecureStorage();
-    final sharedPrefs = SharedPreferencesAsync();
-    final keyStorage = KeyStorage(
-      secureStorage: secureStorage,
-      sharedPrefs: sharedPrefs,
-    );
-    final keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
-    final keyManager = KeyManager(keyStorage, keyDerivator);
-    await keyManager.init();
-    final sessionStorage = SessionStorage(keyManager, db: db);
+    final sessionStorage = await _openSessionStorage();
     await sessionStorage.putSession(session);
     // Local write: the cached session list is stale now.
     backgroundSessionCache.invalidate();
@@ -598,17 +590,26 @@ Future<String?> _loadMostroPubkey() async {
 /// Isolate-wide cache: reads go through it, local writes invalidate it.
 final BackgroundSessionCache backgroundSessionCache = BackgroundSessionCache();
 
+/// Opens a SessionStorage bound to the background isolate's own database and
+/// key manager handles. The isolate has no Riverpod container, so every
+/// persistence helper here has to build its own.
+Future<SessionStorage> _openSessionStorage() async {
+  final db = await openMostroDatabase('mostro.db');
+  const secureStorage = FlutterSecureStorage();
+  final sharedPrefs = SharedPreferencesAsync();
+  final keyStorage = KeyStorage(
+    secureStorage: secureStorage,
+    sharedPrefs: sharedPrefs,
+  );
+  final keyDerivator = KeyDerivator(Config.keyDerivationPath);
+  final keyManager = KeyManager(keyStorage, keyDerivator);
+  await keyManager.init();
+  return SessionStorage(keyManager, db: db);
+}
+
 Future<List<Session>> _loadSessionsFromDatabase() async {
   try {
-    final db = await openMostroDatabase('mostro.db');
-    const secureStorage = FlutterSecureStorage();
-    final sharedPrefs = SharedPreferencesAsync();
-    final keyStorage = KeyStorage(secureStorage: secureStorage, sharedPrefs: sharedPrefs);
-    final keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
-    final keyManager = KeyManager(keyStorage, keyDerivator);
-    
-    await keyManager.init();
-    final sessionStorage = SessionStorage(keyManager, db: db);
+    final sessionStorage = await _openSessionStorage();
     return await sessionStorage.getAll();
   } catch (e) {
     // Rethrow: an empty list is a valid answer the cache keeps for a whole TTL

--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -384,6 +384,13 @@ Future<MostroMessage?> _handleTradeKeyEvent(NostrEvent event, Session session) a
   final mostroMessage = MostroMessage.fromJson(result[0]);
   mostroMessage.timestamp = event.createdAt?.millisecondsSinceEpoch;
 
+  // If this is the new-order confirmation for a pending range-order child
+  // session, link it to the child order id right here. The foreground link
+  // (MostroService._maybeLinkChildOrder) never runs while the app is
+  // backgrounded or killed, and later events for the child order need the
+  // session stored under its orderId (e.g. role-gated notifications).
+  await _maybeLinkChildOrder(mostroMessage, session);
+
   // If this event transitions the order to Active, learn the counterpart's
   // tradeKey from the Order payload and persist it on the session so the
   // background service can immediately subscribe to P2P chat events.
@@ -393,6 +400,49 @@ Future<MostroMessage?> _handleTradeKeyEvent(NostrEvent event, Session session) a
   await _maybeUpdateSessionWithPeer(mostroMessage, session);
 
   return mostroMessage;
+}
+
+/// Links a pending range-order child session to its concrete child order id
+/// when the new-order confirmation arrives while the app is backgrounded.
+/// Mirrors MostroService._maybeLinkChildOrder for the background isolate:
+/// stores the session under its orderId and drops the pending record.
+Future<void> _maybeLinkChildOrder(
+  MostroMessage message,
+  Session session,
+) async {
+  if (message.action != mostro_action.Action.newOrder || message.id == null) {
+    return;
+  }
+  if (session.orderId != null || session.parentOrderId == null) {
+    return;
+  }
+
+  try {
+    session.orderId = message.id;
+
+    final db = await openMostroDatabase('mostro.db');
+    const secureStorage = FlutterSecureStorage();
+    final sharedPrefs = SharedPreferencesAsync();
+    final keyStorage = KeyStorage(
+      secureStorage: secureStorage,
+      sharedPrefs: sharedPrefs,
+    );
+    final keyDerivator = KeyDerivator("m/44'/1237'/38383'/0");
+    final keyManager = KeyManager(keyStorage, keyDerivator);
+    await keyManager.init();
+    final sessionStorage = SessionStorage(keyManager, db: db);
+    await sessionStorage.putSession(session);
+    await sessionStorage.deletePendingChildSession(session.tradeKey.public);
+
+    logger.i(
+      'Background linked child order ${message.id} to parent ${session.parentOrderId}',
+    );
+  } catch (e, stackTrace) {
+    logger.e(
+      'Failed to link child order in background: $e',
+      stackTrace: stackTrace,
+    );
+  }
 }
 
 /// Persists the peer on the given session when [message] is an action that

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -294,28 +294,34 @@ class MostroService {
     }
   }
 
+  /// Links a pending range-order child session to its concrete child order id.
+  ///
+  /// The trigger is any message carrying an order id, not just the child
+  /// new-order confirmation: after a restart (or when the confirmation was
+  /// only seen by the background isolate) the first message this notifier sees
+  /// for the child trade key can be a later one, and leaving the session
+  /// pending would keep the child order out of My Trades. The child trade key
+  /// is used by exactly one order, so any id other than the parent's
+  /// identifies it.
   Future<void> _maybeLinkChildOrder(
     MostroMessage message,
     Session session,
   ) async {
-    if (message.action != Action.newOrder || message.id == null) {
-      return;
-    }
-
-    if (session.orderId != null || session.parentOrderId == null) {
-      return;
-    }
+    final childOrderId = message.id;
+    if (childOrderId == null || childOrderId.isEmpty) return;
+    if (session.orderId != null || session.parentOrderId == null) return;
+    if (childOrderId == session.parentOrderId) return;
 
     final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
     await sessionNotifier.linkChildSessionToOrderId(
-      message.id!,
+      childOrderId,
       session.tradeKey.public,
     );
 
-    ref.read(orderNotifierProvider(message.id!).notifier).subscribe();
+    ref.read(orderNotifierProvider(childOrderId).notifier).subscribe();
 
     logger.i(
-      'Linked child order ${message.id} to parent ${session.parentOrderId}',
+      'Linked child order $childOrderId to parent ${session.parentOrderId}',
     );
   }
 

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -579,7 +579,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     String childOrderId,
     String tradeKeyPublic,
   ) async {
-    final session = _pendingChildSessions.remove(tradeKeyPublic);
+    final session = _pendingChildSessions[tradeKeyPublic];
     if (session == null) {
       logger.w(
         'No pending child session found for trade key $tradeKeyPublic; nothing to link.',
@@ -587,12 +587,22 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       return;
     }
 
+    // Store under the orderId and drop the pending record atomically so the
+    // session is neither lost nor restored twice on the next init. The
+    // in-memory maps are only updated once that write is durable: on failure
+    // the session stays pending (orderId reset) so the next message for the
+    // child retries the link instead of finding nothing to link.
     session.orderId = childOrderId;
+    try {
+      await _storage.promotePendingChildSession(session);
+    } catch (e) {
+      session.orderId = null;
+      logger.e('Failed to promote pending child session $tradeKeyPublic: $e');
+      rethrow;
+    }
+    _pendingChildSessions.remove(tradeKeyPublic);
     _sessions[childOrderId] = session;
     _claimOrderId(childOrderId, session);
-    // Store under the orderId and drop the pending record atomically so the
-    // session is neither lost nor restored twice on the next init.
-    await _storage.promotePendingChildSession(session);
     _emitState();
 
     // Retry the push registration on link in case the creation-time attempt

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -113,20 +113,67 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     return order != null && !order.status.isTerminal;
   }
 
+  /// Cutoff past which a persisted pending child session is discarded.
+  ///
+  /// Pending children are a short-lived handoff: mostrod publishes the child
+  /// order right after the release, so a record still unlinked after
+  /// [Config.pendingChildSessionExpirationHours] never will be. The bound
+  /// applies even when session expiration is disabled, otherwise orphan
+  /// records would pile up on disk and keep widening the orders subscription
+  /// filter on every launch. When session expiration is enabled and stricter,
+  /// it wins.
+  DateTime get _pendingChildCutoff {
+    final now = DateTime.now();
+    final pendingCutoff = now.subtract(
+      const Duration(hours: Config.pendingChildSessionExpirationHours),
+    );
+    if (_isForever) return pendingCutoff;
+    final sessionCutoff = now.subtract(Duration(hours: _expirationHours));
+    // The later cutoff is the stricter one.
+    return sessionCutoff.isAfter(pendingCutoff) ? sessionCutoff : pendingCutoff;
+  }
+
+  /// Restores a persisted record that carries no orderId. Only pending
+  /// range-order children are stored that way (keyed by trade key) so they
+  /// survive an app kill between release and the child new-order message; any
+  /// other orderId-less record can never be linked and is dropped.
+  Future<void> _restorePendingChildSession(Session session) async {
+    final isPendingChild = session.parentOrderId != null;
+    if (isPendingChild && session.startTime.isAfter(_pendingChildCutoff)) {
+      _pendingChildSessions[session.tradeKey.public] = session;
+      return;
+    }
+    if (!isPendingChild) {
+      logger.w(
+        'Dropping stored session without orderId nor parentOrderId '
+        '(trade key ${session.tradeKey.public})',
+      );
+    }
+    _evictSessionKeyMaterial(session);
+    await _dropPendingChildRecord(session.tradeKey.public);
+  }
+
+  /// Drops the pending record of a child session that no longer needs it
+  /// (linked under its orderId, or expired). Failures are logged instead of
+  /// thrown: the session is already stored correctly and a leftover pending
+  /// record expires on its own, whereas an exception here would skip the
+  /// state emission and the push-token retry of the caller.
+  Future<void> _dropPendingChildRecord(String tradeKeyPublic) async {
+    try {
+      await _storage.deletePendingChildSession(tradeKeyPublic);
+    } catch (e) {
+      logger.e(
+        'Failed to delete pending child record for $tradeKeyPublic: $e',
+      );
+    }
+  }
+
   Future<void> init() async {
     final allSessions = await _storage.getAllSessions();
     final cutoff = DateTime.now().subtract(Duration(hours: _expirationHours));
     for (final session in allSessions) {
-      // Pending range-order child sessions are persisted without an orderId
-      // (keyed by trade key) so they survive an app kill between release and
-      // the child new-order message. Restore them into the pending map.
       if (session.orderId == null) {
-        if (_isForever || session.startTime.isAfter(cutoff)) {
-          _pendingChildSessions[session.tradeKey.public] = session;
-        } else {
-          await _storage.deletePendingChildSession(session.tradeKey.public);
-          _evictSessionKeyMaterial(session);
-        }
+        await _restorePendingChildSession(session);
         continue;
       }
 
@@ -255,12 +302,14 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       logger.e('Storage pruning failed', error: e, stackTrace: stackTrace);
     }
 
-    if (_isForever) return;
-
+    // Pending children expire on their own bounded window, so their pass
+    // below runs even when session expiration is disabled.
+    final pendingCutoff = _pendingChildCutoff;
     final cutoff = DateTime.now().subtract(Duration(hours: _expirationHours));
     // Iterate the in-memory sessions: getAllSessions() re-decoded every row,
     // re-running trade-key derivation per session every 30 minutes.
-    final candidates = _sessions.values.toList();
+    final candidates =
+        _isForever ? const <Session>[] : _sessions.values.toList();
 
     for (final session in candidates) {
       if (session.startTime.isBefore(cutoff)) {
@@ -282,17 +331,16 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     // Expired pending child sessions (no orderId yet) are keyed by trade key
     // and have no associated order data to clean up, but their persisted
     // record must go too or init() would restore them on the next launch.
+    // This also covers pending children whose persistence failed and
+    // therefore only live in memory. pendingCutoff is already the stricter of
+    // the two windows, so this subsumes the session expiration cutoff.
     final expiredPending = _pendingChildSessions.values
-        .where((session) => session.startTime.isBefore(cutoff))
+        .where((session) => session.startTime.isBefore(pendingCutoff))
         .toList();
     for (final session in expiredPending) {
       _pendingChildSessions.remove(session.tradeKey.public);
       _evictSessionKeyMaterial(session);
-      try {
-        await _storage.deletePendingChildSession(session.tradeKey.public);
-      } catch (e) {
-        logger.e('Failed to delete expired pending child session: $e');
-      }
+      await _dropPendingChildRecord(session.tradeKey.public);
     }
 
     _emitState();
@@ -335,13 +383,18 @@ class SessionNotifier extends StateNotifier<List<Session>> {
   Future<void> saveSession(Session session) async {
     _sessions[session.orderId!] = session;
     _requestIdToSession.removeWhere((_, value) => identical(value, session));
-    if (_pendingChildSessions.remove(session.tradeKey.public) != null) {
-      // The session graduated from pending child to a real order session;
-      // drop the pending record so it is not restored again on init.
-      await _storage.deletePendingChildSession(session.tradeKey.public);
-    }
+    final wasPendingChild =
+        _pendingChildSessions.remove(session.tradeKey.public) != null;
     _claimOrderId(session.orderId!, session);
-    await _storage.putSession(session);
+    // A child session is stored under its orderId and its pending record is
+    // dropped in one transaction, so a crash in between cannot lose it. The
+    // parentOrderId check also clears records left behind when the link
+    // already happened in the background isolate.
+    if (wasPendingChild || session.parentOrderId != null) {
+      await _storage.promotePendingChildSession(session);
+    } else {
+      await _storage.putSession(session);
+    }
     _emitState();
 
     // Register push notification token for this trade
@@ -488,19 +541,24 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       role: role,
     );
 
-    _pendingChildSessions[tradeKey.public] = session;
-    _emitState();
-
     // Persist immediately: the session must survive an app kill between
     // release and the child new-order message, and the background isolate
     // loads sessions from storage to decrypt events addressed to this trade
     // key. Without this, child-order events received while the app is not in
-    // the foreground could never be decrypted (and never notified).
+    // the foreground could never be decrypted (and never notified). A failed
+    // write is propagated rather than swallowed: the caller is about to hand
+    // this trade key to mostrod as next_trade, and must not do so with a
+    // child the app cannot track after a restart.
     try {
       await _storage.putPendingChildSession(session);
     } catch (e) {
+      _evictSessionKeyMaterial(session);
       logger.e('Failed to persist pending child session: $e');
+      rethrow;
     }
+
+    _pendingChildSessions[tradeKey.public] = session;
+    _emitState();
 
     // Register the child trade key with the push server right away: the child
     // order can be taken as soon as mostrod publishes it, and without this
@@ -532,10 +590,9 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     session.orderId = childOrderId;
     _sessions[childOrderId] = session;
     _claimOrderId(childOrderId, session);
-    await _storage.putSession(session);
-    // The session is now stored under its orderId; drop the pending record so
-    // it is not restored twice on the next init.
-    await _storage.deletePendingChildSession(tradeKeyPublic);
+    // Store under the orderId and drop the pending record atomically so the
+    // session is neither lost nor restored twice on the next init.
+    await _storage.promotePendingChildSession(session);
     _emitState();
 
     // Retry the push registration on link in case the creation-time attempt

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -115,30 +115,36 @@ class SessionNotifier extends StateNotifier<List<Session>> {
 
   Future<void> init() async {
     final allSessions = await _storage.getAllSessions();
-    if (_isForever) {
-      for (final session in allSessions) {
-        _sessions[session.orderId!] = session;
-      }
-    } else {
-      final cutoff = DateTime.now().subtract(Duration(hours: _expirationHours));
-      for (final session in allSessions) {
-        if (session.startTime.isAfter(cutoff)) {
-          _sessions[session.orderId!] = session;
+    final cutoff = DateTime.now().subtract(Duration(hours: _expirationHours));
+    for (final session in allSessions) {
+      // Pending range-order child sessions are persisted without an orderId
+      // (keyed by trade key) so they survive an app kill between release and
+      // the child new-order message. Restore them into the pending map.
+      if (session.orderId == null) {
+        if (_isForever || session.startTime.isAfter(cutoff)) {
+          _pendingChildSessions[session.tradeKey.public] = session;
         } else {
-          if (await _isActiveSession(session)) {
-            logger.i('Skipping cleanup for active session ${session.orderId}');
-            _sessions[session.orderId!] = session;
-            continue;
-          }
-          await _storage.deleteSession(session.orderId!);
-          _sessions.remove(session.orderId!);
+          await _storage.deletePendingChildSession(session.tradeKey.public);
           _evictSessionKeyMaterial(session);
-          try {
-            await _cleanupSessionData(session);
-          } catch (e) {
-            logger
-                .e('Failed to cleanup data for session ${session.orderId}: $e');
-          }
+        }
+        continue;
+      }
+
+      if (_isForever || session.startTime.isAfter(cutoff)) {
+        _sessions[session.orderId!] = session;
+      } else {
+        if (await _isActiveSession(session)) {
+          logger.i('Skipping cleanup for active session ${session.orderId}');
+          _sessions[session.orderId!] = session;
+          continue;
+        }
+        await _storage.deleteSession(session.orderId!);
+        _sessions.remove(session.orderId!);
+        _evictSessionKeyMaterial(session);
+        try {
+          await _cleanupSessionData(session);
+        } catch (e) {
+          logger.e('Failed to cleanup data for session ${session.orderId}: $e');
         }
       }
     }
@@ -273,11 +279,21 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       }
     }
 
-    _pendingChildSessions.removeWhere((_, session) {
-      final expired = session.startTime.isBefore(cutoff);
-      if (expired) _evictSessionKeyMaterial(session);
-      return expired;
-    });
+    // Expired pending child sessions (no orderId yet) are keyed by trade key
+    // and have no associated order data to clean up, but their persisted
+    // record must go too or init() would restore them on the next launch.
+    final expiredPending = _pendingChildSessions.values
+        .where((session) => session.startTime.isBefore(cutoff))
+        .toList();
+    for (final session in expiredPending) {
+      _pendingChildSessions.remove(session.tradeKey.public);
+      _evictSessionKeyMaterial(session);
+      try {
+        await _storage.deletePendingChildSession(session.tradeKey.public);
+      } catch (e) {
+        logger.e('Failed to delete expired pending child session: $e');
+      }
+    }
 
     _emitState();
   }
@@ -319,7 +335,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
   Future<void> saveSession(Session session) async {
     _sessions[session.orderId!] = session;
     _requestIdToSession.removeWhere((_, value) => identical(value, session));
-    _pendingChildSessions.remove(session.tradeKey.public);
+    if (_pendingChildSessions.remove(session.tradeKey.public) != null) {
+      // The session graduated from pending child to a real order session;
+      // drop the pending record so it is not restored again on init.
+      await _storage.deletePendingChildSession(session.tradeKey.public);
+    }
     _claimOrderId(session.orderId!, session);
     await _storage.putSession(session);
     _emitState();
@@ -471,6 +491,17 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     _pendingChildSessions[tradeKey.public] = session;
     _emitState();
 
+    // Persist immediately: the session must survive an app kill between
+    // release and the child new-order message, and the background isolate
+    // loads sessions from storage to decrypt events addressed to this trade
+    // key. Without this, child-order events received while the app is not in
+    // the foreground could never be decrypted (and never notified).
+    try {
+      await _storage.putPendingChildSession(session);
+    } catch (e) {
+      logger.e('Failed to persist pending child session: $e');
+    }
+
     // Register the child trade key with the push server right away: the child
     // order can be taken as soon as mostrod publishes it, and without this
     // mapping the push server cannot wake the device (FCM) for events
@@ -502,6 +533,9 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     _sessions[childOrderId] = session;
     _claimOrderId(childOrderId, session);
     await _storage.putSession(session);
+    // The session is now stored under its orderId; drop the pending record so
+    // it is not restored twice on the next init.
+    await _storage.deletePendingChildSession(tradeKeyPublic);
     _emitState();
 
     // Retry the push registration on link in case the creation-time attempt

--- a/test/notifiers/pending_child_session_persistence_test.dart
+++ b/test/notifiers/pending_child_session_persistence_test.dart
@@ -1,0 +1,232 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/enums/role.dart';
+import 'package:mostro_mobile/data/repositories/session_storage.dart';
+import 'package:mostro_mobile/features/key_manager/key_manager.dart';
+import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:sembast/sembast_memory.dart';
+
+import '../mocks.mocks.dart';
+
+void main() {
+  late MockRef mockRef;
+  late MockKeyManager mockKeyManager;
+  late SessionStorage storage;
+
+  // Dummy private keys for testing purposes only
+  final masterKey = NostrKeyPairs(
+    private:
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  );
+  final childTradeKey = NostrKeyPairs(
+    private:
+        'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+  );
+  const childKeyIndex = 5;
+
+  Settings buildSettings({int? sessionExpirationHours}) => Settings(
+        relays: [],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'test',
+        defaultFiatCode: 'USD',
+        selectedLanguage: null,
+        sessionExpirationHours: sessionExpirationHours,
+      );
+
+  SessionNotifier buildNotifier({int? sessionExpirationHours}) =>
+      SessionNotifier(
+        mockRef,
+        storage,
+        buildSettings(sessionExpirationHours: sessionExpirationHours),
+      );
+
+  setUpAll(() {
+    provideDummy<KeyManager>(MockKeyManager());
+  });
+
+  setUp(() async {
+    mockRef = MockRef();
+    mockKeyManager = MockKeyManager();
+
+    when(mockRef.read(keyManagerProvider)).thenReturn(mockKeyManager);
+    when(mockKeyManager.masterKeyPair).thenReturn(masterKey);
+    when(mockKeyManager.deriveTradeKeyPair(childKeyIndex))
+        .thenReturn(childTradeKey);
+
+    final db = await newDatabaseFactoryMemory().openDatabase('sessions-test');
+    storage = SessionStorage(mockKeyManager, db: db);
+  });
+
+  group('createChildOrderSession persistence', () {
+    test('persists the pending child session to storage', () async {
+      // Arrange
+      final notifier = buildNotifier();
+
+      // Act
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      // Assert: the record is on disk, so the background isolate (which
+      // loads sessions from storage) can decrypt events addressed to the
+      // child trade key.
+      final stored = await storage.getAllSessions();
+      expect(stored, hasLength(1));
+      expect(stored.first.orderId, isNull);
+      expect(stored.first.parentOrderId, 'parent-order-id');
+      expect(stored.first.tradeKey.public, childTradeKey.public);
+    });
+
+    test('restores the pending child session after an app restart', () async {
+      // Arrange: a pending child exists, then the app is killed
+      final notifier = buildNotifier();
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      // Act: a fresh notifier over the same storage simulates the restart
+      final restarted = buildNotifier();
+      await restarted.init();
+
+      // Assert
+      final restored = restarted.state
+          .where((s) => s.tradeKey.public == childTradeKey.public)
+          .toList();
+      expect(restored, hasLength(1));
+      expect(restored.first.orderId, isNull);
+      expect(restored.first.parentOrderId, 'parent-order-id');
+    });
+
+    test('drops an expired pending child session on init', () async {
+      // Arrange: persist a pending child, then age it beyond expiration
+      final notifier = buildNotifier();
+      final session = await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      final aged = session.toJson()
+        ..['start_time'] = DateTime.now()
+            .subtract(const Duration(hours: 3))
+            .toIso8601String();
+      await storage.store
+          .record(
+            '${SessionStorage.pendingChildKeyPrefix}${childTradeKey.public}',
+          )
+          .put(storage.db, aged);
+
+      // Act: restart with a 1-hour expiration window
+      final restarted = buildNotifier(sessionExpirationHours: 1);
+      await restarted.init();
+
+      // Assert: not restored and removed from storage
+      expect(restarted.state, isEmpty);
+      expect(await storage.getAllSessions(), isEmpty);
+    });
+  });
+
+  group('linkChildSessionToOrderId persistence', () {
+    test('re-stores the session under its orderId and drops the pending one',
+        () async {
+      // Arrange
+      final notifier = buildNotifier();
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      // Act
+      await notifier.linkChildSessionToOrderId(
+        'child-order-id',
+        childTradeKey.public,
+      );
+
+      // Assert: a single record remains, keyed by the child order id
+      final stored = await storage.getAllSessions();
+      expect(stored, hasLength(1));
+      expect(stored.first.orderId, 'child-order-id');
+      expect(await storage.getSession('child-order-id'), isNotNull);
+    });
+
+    test('links a pending child restored after an app restart', () async {
+      // Arrange: pending child created, app killed, app restarted
+      final notifier = buildNotifier();
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      final restarted = buildNotifier();
+      await restarted.init();
+
+      // Act: the child new-order message arrives after the restart
+      await restarted.linkChildSessionToOrderId(
+        'child-order-id',
+        childTradeKey.public,
+      );
+
+      // Assert
+      expect(
+        restarted.getSessionByOrderId('child-order-id'),
+        isNotNull,
+      );
+      final stored = await storage.getAllSessions();
+      expect(stored, hasLength(1));
+      expect(stored.first.orderId, 'child-order-id');
+    });
+  });
+
+  group('SessionStorage pending child records', () {
+    test('putPendingChildSession rejects sessions that have an orderId',
+        () async {
+      final notifier = buildNotifier();
+      final session = await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      session.orderId = 'some-order-id';
+
+      expect(
+        () => storage.putPendingChildSession(session),
+        throwsArgumentError,
+      );
+    });
+
+    test('getAll includes pending child sessions for the background isolate',
+        () async {
+      // Arrange
+      final notifier = buildNotifier();
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      // Act: getAll() is what _loadSessionsFromDatabase uses in the
+      // background isolate to match events by trade key.
+      final all = await storage.getAll();
+
+      // Assert
+      expect(
+        all.any((s) => s.tradeKey.public == childTradeKey.public),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/notifiers/pending_child_session_persistence_test.dart
+++ b/test/notifiers/pending_child_session_persistence_test.dart
@@ -1,7 +1,9 @@
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/data/models/enums/role.dart';
+import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/data/repositories/session_storage.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
@@ -11,6 +13,17 @@ import 'package:sembast/sembast_memory.dart';
 
 import '../mocks.mocks.dart';
 
+/// SessionStorage whose pending-child write always fails, to exercise the
+/// persistence error path of createChildOrderSession.
+class _FailingPendingChildStorage extends SessionStorage {
+  _FailingPendingChildStorage(super.keyManager, {required super.db});
+
+  @override
+  Future<void> putPendingChildSession(Session session) async {
+    throw StateError('disk full');
+  }
+}
+
 void main() {
   late MockRef mockRef;
   late MockKeyManager mockKeyManager;
@@ -18,12 +31,10 @@ void main() {
 
   // Dummy private keys for testing purposes only
   final masterKey = NostrKeyPairs(
-    private:
-        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    private: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
   );
   final childTradeKey = NostrKeyPairs(
-    private:
-        'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    private: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
   );
   const childKeyIndex = 5;
 
@@ -42,6 +53,17 @@ void main() {
         storage,
         buildSettings(sessionExpirationHours: sessionExpirationHours),
       );
+
+  /// Rewrites the persisted pending child record with an older start time,
+  /// simulating a record that has been sitting on disk for [age].
+  Future<void> agePendingChildRecord(Duration age) async {
+    final key =
+        '${SessionStorage.pendingChildKeyPrefix}${childTradeKey.public}';
+    final stored = await storage.store.record(key).get(storage.db);
+    final aged = Map<String, dynamic>.from(stored!)
+      ..['start_time'] = DateTime.now().subtract(age).toIso8601String();
+    await storage.store.record(key).put(storage.db, aged);
+  }
 
   setUpAll(() {
     provideDummy<KeyManager>(MockKeyManager());
@@ -109,21 +131,13 @@ void main() {
     test('drops an expired pending child session on init', () async {
       // Arrange: persist a pending child, then age it beyond expiration
       final notifier = buildNotifier();
-      final session = await notifier.createChildOrderSession(
+      await notifier.createChildOrderSession(
         tradeKey: childTradeKey,
         keyIndex: childKeyIndex,
         parentOrderId: 'parent-order-id',
         role: Role.seller,
       );
-      final aged = session.toJson()
-        ..['start_time'] = DateTime.now()
-            .subtract(const Duration(hours: 3))
-            .toIso8601String();
-      await storage.store
-          .record(
-            '${SessionStorage.pendingChildKeyPrefix}${childTradeKey.public}',
-          )
-          .put(storage.db, aged);
+      await agePendingChildRecord(const Duration(hours: 3));
 
       // Act: restart with a 1-hour expiration window
       final restarted = buildNotifier(sessionExpirationHours: 1);
@@ -189,7 +203,174 @@ void main() {
     });
   });
 
+  group('pending child bounded lifetime', () {
+    test('keeps a pending child when session expiration is disabled', () async {
+      // Arrange: expiration disabled (0 == forever) and an old-ish record
+      final notifier = buildNotifier(sessionExpirationHours: 0);
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      await agePendingChildRecord(const Duration(hours: 3));
+
+      // Act
+      final restarted = buildNotifier(sessionExpirationHours: 0);
+      await restarted.init();
+
+      // Assert
+      expect(restarted.state, hasLength(1));
+      expect(await storage.getAllSessions(), hasLength(1));
+    });
+
+    test('drops a pending child past its own TTL even with expiration disabled',
+        () async {
+      // Arrange: a pending child that was never linked. With expiration
+      // disabled it would otherwise stay on disk (and in the orders filter)
+      // forever, so the bounded TTL has to apply on its own.
+      final notifier = buildNotifier(sessionExpirationHours: 0);
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      await agePendingChildRecord(
+        Duration(hours: Config.pendingChildSessionExpirationHours + 1),
+      );
+
+      // Act
+      final restarted = buildNotifier(sessionExpirationHours: 0);
+      await restarted.init();
+
+      // Assert
+      expect(restarted.state, isEmpty);
+      expect(await storage.getAllSessions(), isEmpty);
+    });
+
+    test('drops a stored record with neither orderId nor parentOrderId',
+        () async {
+      // Arrange: only pending children are stored without an orderId; any
+      // other such record can never be linked.
+      final notifier = buildNotifier();
+      await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      final key =
+          '${SessionStorage.pendingChildKeyPrefix}${childTradeKey.public}';
+      final stored = await storage.store.record(key).get(storage.db);
+      await storage.store.record(key).put(
+            storage.db,
+            Map<String, dynamic>.from(stored!)..['parent_order_id'] = null,
+          );
+
+      // Act
+      final restarted = buildNotifier();
+      await restarted.init();
+
+      // Assert
+      expect(restarted.state, isEmpty);
+      expect(await storage.getAllSessions(), isEmpty);
+    });
+
+    test('saveSession drops the pending record once the order id is known',
+        () async {
+      // Arrange
+      final notifier = buildNotifier();
+      final session = await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      // Act: the child session is saved through the generic path instead of
+      // linkChildSessionToOrderId
+      session.orderId = 'child-order-id';
+      await notifier.saveSession(session);
+
+      // Assert
+      final stored = await storage.getAllSessions();
+      expect(stored, hasLength(1));
+      expect(stored.first.orderId, 'child-order-id');
+    });
+
+    test(
+        'createChildOrderSession rethrows a persistence failure and leaves no '
+        'pending session behind', () async {
+      // Arrange
+      final failingStorage = _FailingPendingChildStorage(
+        mockKeyManager,
+        db: storage.db,
+      );
+      final notifier =
+          SessionNotifier(mockRef, failingStorage, buildSettings());
+
+      // Act
+      Future<Session> create() => notifier.createChildOrderSession(
+            tradeKey: childTradeKey,
+            keyIndex: childKeyIndex,
+            parentOrderId: 'parent-order-id',
+            role: Role.seller,
+          );
+
+      // Assert: the caller must not proceed as if the child were ready
+      await expectLater(create, throwsStateError);
+      expect(notifier.state, isEmpty);
+      expect(notifier.getSessionByTradeKey(childTradeKey.public), isNull);
+      expect(await storage.getAllSessions(), isEmpty);
+    });
+  });
+
   group('SessionStorage pending child records', () {
+    test(
+        'promotePendingChildSession stores the session under its orderId and '
+        'drops the pending record in one step', () async {
+      // Arrange
+      final notifier = buildNotifier();
+      final session = await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      session.orderId = 'child-order-id';
+
+      // Act
+      await storage.promotePendingChildSession(session);
+
+      // Assert
+      final pendingKey =
+          '${SessionStorage.pendingChildKeyPrefix}${childTradeKey.public}';
+      expect(
+          await storage.store.record(pendingKey).exists(storage.db), isFalse);
+      expect(await storage.store.record('child-order-id').exists(storage.db),
+          isTrue);
+      expect(await storage.getAllSessions(), hasLength(1));
+    });
+
+    test('promotePendingChildSession rejects sessions without an orderId',
+        () async {
+      final notifier = buildNotifier();
+      final session = await notifier.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+
+      expect(
+        () => storage.promotePendingChildSession(session),
+        throwsArgumentError,
+      );
+      // The pending record is untouched by a rejected promotion.
+      expect(await storage.getAll(), hasLength(1));
+    });
+
     test('putPendingChildSession rejects sessions that have an orderId',
         () async {
       final notifier = buildNotifier();

--- a/test/notifiers/pending_child_session_persistence_test.dart
+++ b/test/notifiers/pending_child_session_persistence_test.dart
@@ -24,6 +24,17 @@ class _FailingPendingChildStorage extends SessionStorage {
   }
 }
 
+/// SessionStorage whose promotion always fails, to exercise the durable-first
+/// ordering of linkChildSessionToOrderId.
+class _FailingPromotionStorage extends SessionStorage {
+  _FailingPromotionStorage(super.keyManager, {required super.db});
+
+  @override
+  Future<void> promotePendingChildSession(Session session) async {
+    throw StateError('disk full');
+  }
+}
+
 void main() {
   late MockRef mockRef;
   late MockKeyManager mockKeyManager;
@@ -200,6 +211,46 @@ void main() {
       final stored = await storage.getAllSessions();
       expect(stored, hasLength(1));
       expect(stored.first.orderId, 'child-order-id');
+    });
+  });
+
+  group('linkChildSessionToOrderId durability', () {
+    test('keeps the session pending when the promotion fails', () async {
+      // Arrange: create through a working storage so the pending record
+      // exists, then link through a storage whose promotion fails.
+      final creator = buildNotifier();
+      await creator.createChildOrderSession(
+        tradeKey: childTradeKey,
+        keyIndex: childKeyIndex,
+        parentOrderId: 'parent-order-id',
+        role: Role.seller,
+      );
+      final failingStorage = _FailingPromotionStorage(
+        mockKeyManager,
+        db: storage.db,
+      );
+      final notifier = SessionNotifier(mockRef, failingStorage, buildSettings());
+      await notifier.init();
+      expect(notifier.getSessionByTradeKey(childTradeKey.public), isNotNull);
+
+      // Act
+      Future<void> link() => notifier.linkChildSessionToOrderId(
+            'child-order-id',
+            childTradeKey.public,
+          );
+
+      // Assert: the failure is propagated and nothing moved in memory, so a
+      // later message for the child can retry the link.
+      await expectLater(link, throwsStateError);
+      final pending = notifier.getSessionByTradeKey(childTradeKey.public);
+      expect(pending, isNotNull);
+      expect(pending!.orderId, isNull);
+      expect(notifier.getSessionByOrderId('child-order-id'), isNull);
+      expect(notifier.state.where((s) => s.orderId == 'child-order-id'),
+          isEmpty);
+      final pendingKey =
+          '${SessionStorage.pendingChildKeyPrefix}${childTradeKey.public}';
+      expect(await storage.store.record(pendingKey).exists(storage.db), isTrue);
     });
   });
 

--- a/test/notifiers/session_notifier_test.dart
+++ b/test/notifiers/session_notifier_test.dart
@@ -48,6 +48,8 @@ void main() {
     when(mockKeyManager.getCurrentKeyIndex()).thenAnswer((_) async => 1);
     when(mockKeyManager.deriveTradeKey())
         .thenAnswer((_) async => derivedTradeKey);
+    when(mockStorage.putPendingChildSession(any)).thenAnswer((_) async {});
+    when(mockStorage.deletePendingChildSession(any)).thenAnswer((_) async {});
 
     notifier = SessionNotifier(
       mockRef,

--- a/test/notifiers/session_notifier_test.dart
+++ b/test/notifiers/session_notifier_test.dart
@@ -50,6 +50,7 @@ void main() {
         .thenAnswer((_) async => derivedTradeKey);
     when(mockStorage.putPendingChildSession(any)).thenAnswer((_) async {});
     when(mockStorage.deletePendingChildSession(any)).thenAnswer((_) async {});
+    when(mockStorage.promotePendingChildSession(any)).thenAnswer((_) async {});
 
     notifier = SessionNotifier(
       mockRef,


### PR DESCRIPTION
## Problem

Users report missing notifications when the **second part of a range order** is taken (v1.3.0 reports; companion PR: #640).

When the maker sends fiat-sent/release on a range order, `_prepareChildOrderIfNeeded` derives the next trade key and creates a *pending child session* — but `SessionNotifier.createChildOrderSession()` kept it **in memory only** (`_pendingChildSessions`). It was persisted only when `linkChildSessionToOrderId()` ran, which only happens in the **foreground** isolate (`MostroService._maybeLinkChildOrder`).

Two failure modes:

1. **App backgrounded** after release: the background isolate loads sessions from the sessions store (`_loadSessionsFromDatabase`), so events addressed to the child trade key (the child `new-order`, and anything after) **cannot be decrypted** — no notification is ever shown for the child order.
2. **App killed** before the child `new-order` was processed in foreground: the pending session is lost entirely. Every later event for the child trade key hits `No matching session found for recipient` and the child order becomes invisible until a restore.

## Fix

- **SessionStorage**: pending child sessions (no orderId yet) are persisted under a `pending-child:<tradeKeyPublic>` record key, via new `putPendingChildSession()` / `deletePendingChildSession()`. `getAll()` (used by the background isolate) naturally includes them.
- **SessionNotifier**:
  - `createChildOrderSession()` persists the pending session immediately.
  - `init()` restores pending children into memory after a restart (expired ones are deleted instead).
  - `linkChildSessionToOrderId()` / `saveSession()` drop the pending record once the session is stored under its orderId.
  - `_cleanup()` handles expired pending records safely (they have no orderId).
- **Background isolate** (`background_notification_service.dart`): when the child `new-order` confirmation arrives while backgrounded, link the session to the child order id right there (mirrors `MostroService._maybeLinkChildOrder`, same pattern as the existing `_maybeUpdateSessionWithPeer` persistence). Later events for the child order then find the session by orderId (role-gated notifications like `fiat-sent-ok`, admin DMs).

The foreground link path stays idempotent: if the background already linked, the foreground re-link is a no-op overwrite and the pending delete is a no-op.

## Test plan

- [x] New tests in `test/notifiers/pending_child_session_persistence_test.dart` (real `SessionStorage` over in-memory sembast):
  - pending child persisted on creation
  - pending child restored after an app restart
  - expired pending child dropped on init
  - link re-stores under the orderId and removes the pending record
  - link works on a pending child restored after restart
  - `putPendingChildSession` rejects sessions that already have an orderId
  - `getAll()` includes pending children (background isolate contract)
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 488 tests pass

## Related

Part 2 of 3 PRs for the missing take-order notifications on v1.3.0. Part 1: #640 (push token registration for child trade keys). Part 3: protocol-v2 (kind 14) support in mostro-push-server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pending child sessions are saved before an order ID is available.
  - Sessions are automatically linked when a confirmed child order is received, including through background processing.
  - Pending sessions are restored after app restarts and retained for up to 48 hours.

- **Bug Fixes**
  - Expired or orphaned pending sessions are removed automatically.
  - Duplicate order sessions are prevented.
  - Failed persistence no longer leaves behind an incomplete session.

- **Tests**
  - Added coverage for persistence, restoration, expiration, linking, background loading, and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->