### PR TITLE
fix: use Blossom servers that accept encrypted chat attachments

### DIFF
--- a/lib/core/config/blossom_config.dart
+++ b/lib/core/config/blossom_config.dart
@@ -1,19 +1,23 @@
 /// Configuration for Blossom server settings and upload parameters
 class BlossomConfig {
   /// Default Blossom servers used for media uploads
-  /// 
+  ///
   /// These servers are tried in order when uploading files.
   /// If one fails, the next server in the list is attempted.
+  ///
+  /// Chat attachments are encrypted before upload, so they are sent as
+  /// `application/octet-stream`. Only add servers that accept opaque blobs:
+  /// media-only servers reject them by sniffing the content, which fails
+  /// every attachment regardless of the original file type.
+  ///
+  /// Servers must also retain blobs indefinitely. Ephemeral hosts expire
+  /// files after weeks, which would silently break dispute evidence.
   static const List<String> defaultServers = [
-    'https://blossom.primal.net',
-    'https://blossom.band',
-    'https://nostr.media',
-    'https://blossom.sector01.com',
-    'https://24242.io',
-    'https://otherstuff.shaving.kiwi',
-    'https://blossom.f7z.io',
-    'https://nosto.re',
-    'https://blossom.poster.place',
+    'https://cdn.hzrd149.com',
+    'https://nostr.download',
+    'https://blossom-01.uid.ovh',
+    'https://files.sovbit.host',
+    'https://blssm.us',
   ];
   
   /// Default upload timeout duration


### PR DESCRIPTION
## Problem

Chat and dispute attachments fail for every user. All nine configured Blossom servers reject the upload, so `BlossomUploadHelper` exhausts the list and throws `All Blossom servers failed`.

## Root cause

Attachments are encrypted before upload, so they are sent as that reject opaque blobs. Encrypted data has no file signature, so content sniffing cannot classify it either — these servers could never have accepted our uploads.

Verified by uploading the same JPEG twice, changing only `Content-Type`:

| Server | `image/jpeg` | `octet-stream` |
|---|---|---|
| blossom.primal.net | 200 | 415 |
| blossom.band | 201 | 415 |
| nostr.media | 200 | 400 |
| 24242.io | 400 (already stored) | 400 |

The remaining five are down, whitelist-restricted, or misconfigured.

This was never working. The server list has not changed since the feature was added in #367, and the upload path is fully mocked in `file_messaging_test.dart`, so CI could not catch the mismatch.

## Fix

Replace the list with servers that accept opaque blobs, sourced from the kind 36363 community directory and verified individually. Each one was tested with a 3 MB blob: upload succeeds, `GET {server}/{sha256}` returns byte-identical data, and the URL scheme the client builds resolves.

Adds a comment documenting both selection criteria so media-only servers are not reintroduced.

## Verification

- `flutter analyze`: no issues
- `flutter test`: 485 passing
- Round-trip verified against all five servers

## Known limitations

- Retention is unverified for four of the five servers; none publish a policy. Hosts with published expiration were excluded, but this remains a risk for dispute evidence and argues for a Mostro-operated server.
- Only the server list changed. Pre-existing issues left untouched: `BlossomClient` builds the blob URL instead of using the one the server returns, and incoming `blossom_url` values are fetched automatically without host validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opaque encrypted chat attachments.
  * Blob storage is now documented as supporting indefinite retention.

* **Improvements**
  * Updated the default Blossom server list to five hosts, providing a streamlined set of storage options:
    * cdn.hzrd149.com
    * nostr.download
    * blossom-01.uid.ovh
    * files.sovbit.host
    * blssm.us

<!-- end of auto-generated comment: release notes by coderabbit.ai -->