### PR TITLE
fix: restore desktop release binaries by pinning Windows runner

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -72,7 +72,11 @@ jobs:
             artifact-path: build/macos/Build/Products/Release
             artifact-name: macos.zip
             package-command: zip -r
-          - os: windows-latest
+          # Pinned to windows-2022: windows-latest (windows-2025) ships only
+          # Visual Studio 2026, which Flutter 3.32.2 cannot use (CMake fails
+          # with "Visual Studio 16 2019 could not find any instance").
+          # Revisit when upgrading Flutter to a version that supports VS 2026.
+          - os: windows-2022
             platform: windows
             build-command: flutter build windows --release
             artifact-path: build/windows/x64/runner/Release
@@ -205,6 +209,9 @@ jobs:
   publish:
     name: Publish desktop assets to release
     needs: [build-desktop, setup-version]
+    # Run even if some platform builds failed, so successful builds are still
+    # attached to the release (fail-fast is disabled in the build matrix).
+    if: ${{ !cancelled() && needs.setup-version.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download all desktop artifacts


### PR DESCRIPTION
## Problem

Desktop binaries (Linux, Windows, macOS) stopped being attached to releases starting with v1.2.8 (v1.3.0 is also affected). No workflow changes caused this — the `desktop.yml` runs have been failing since June 12.

## Root cause

1. Between the last successful run (May 21) and the v1.2.8 release (June 12), GitHub migrated the `windows-latest` runner to the `windows-2025-vs2026` image, which ships **only Visual Studio 2026**. Flutter 3.32.2 (pinned in the workflow) cannot use it, so the Windows build fails with:
   ```
   CMake Error at CMakeLists.txt:3 (project):
     Generator "Visual Studio 16 2019" could not find any instance of Visual Studio.
   ```
2. The `publish` job depends on the whole `build-desktop` matrix, so when the Windows leg failed the job was **skipped** — and the Linux and macOS artifacts that built successfully were never attached to the release either.

Failed runs: [June 12 (v1.2.8)](https://github.com/MostroP2P/mobile/actions/runs/27422210782), [June 16](https://github.com/MostroP2P/mobile/actions/runs/27635962859), [July 3 (v1.3.0)](https://github.com/MostroP2P/mobile/actions/runs/28675055957) — in all three, only the Windows build failed and `publish` was skipped.

## Fix

- **Pin the Windows build to `windows-2022`**, the only current image that still includes VS 2022 (`windows-2025` is now aliased to the VS 2026 image as well). A comment notes to revisit when Flutter is upgraded to a version supporting VS 2026.
- **Run `publish` even if a platform build fails** (`if: !cancelled() && setup-version succeeded`), so successful builds are always attached to the release. The matrix already has `fail-fast: false`; this closes the remaining gap.

## Test plan

- [x] YAML syntax validated
- [ ] After merge: trigger `desktop.yml` manually (`gh workflow run desktop.yml`) — `pubspec.yaml` on main is at 1.3.0, so this will also backfill the missing v1.3.0 desktop assets
- [ ] Verify all three binaries are attached to the v1.3.0 release
- [ ] Next tagged release attaches Linux/Windows/macOS binaries automatically


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows desktop build reliability by using a compatible build environment.
  * Publishing can now proceed when individual platform builds fail, provided version setup completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->