### PR TITLE
fix: migrate dispute chat from gift wrap to kind-14 chat envelope

### DIFF
--- a/docs/architecture/DISPUTE_CHAT_KIND14.md
+++ b/docs/architecture/DISPUTE_CHAT_KIND14.md
@@ -64,7 +64,7 @@ reject a mismatch between inner and outer timestamps as a replay defense.
 NostrFilter(
   kinds: [14],
   authors: [chatKeys.sign.public],
-  since: DateTime.now().subtract(NostrEventExtensions.chatDefaultLookback), // 7 days
+  since: cursorSince ?? defaultLookback, // persisted per-conversation cursor
   limit: NostrEventExtensions.chatDefaultLimit, // 100
 )
 ```
@@ -72,10 +72,19 @@ NostrFilter(
 The spec requires filtering by `authors`, **never by `#p`**: a `#p` filter would let any
 third party flood the subscription with junk events tagged to the conversation pubkey.
 
-The `since` lookback and `limit` match the spec defaults (7 days / 100 events). A durable
-per-conversation `since` cursor (advanced only after accepting an event, clamped to the
-local clock) is a possible future refinement; on-disk history plus outer-id dedup already
-covers reconnection in practice.
+The backlog is bounded by a **durable per-conversation `since` cursor**
+(`DisputeChatCursorStore`, persisted in SharedPreferences), as the spec mandates:
+
+- The cursor advances **only after `chatUnwrap` accepts an event**, clamped to
+  `min(accepted_timestamp, local_now)` so a future-dated event within the skew tolerance
+  cannot suppress later messages.
+- Subscriptions use `cursor − 10 min` (overlap window) so an event late-delivered by a
+  slow relay is not filtered out forever; outer-id dedup absorbs the re-delivered tail.
+- Conversations with no accepted events yet fall back to the spec-default 7-day lookback
+  (`chatDefaultLookback`).
+- The grouped `SubscriptionManager` filter covers several conversations with one REQ, so
+  it uses the **earliest** cursor across sessions — wider than necessary for some
+  conversations, which dedup absorbs, but never narrower.
 
 Kind 14 is also used by transport-v2 Mostro protocol messages (user↔mostro). The two
 never collide: protocol events are authored by the Mostro pubkey and addressed to the
@@ -111,6 +120,7 @@ event id (`eventStore.hasItem`) and UI state by inner event id.
 | Envelope (`chatWrap`/`chatUnwrap`) | `lib/data/models/nostr_event.dart` |
 | Dispute chat notifier (subscribe/send/receive/history) | `lib/features/disputes/notifiers/dispute_chat_notifier.dart` |
 | Centralized `disputeChat` filter (also reused by background) | `lib/features/subscriptions/subscription_manager.dart` |
+| Durable `since` cursor (`DisputeChatCursorStore`) | `lib/services/dispute_chat_cursor_store.dart` |
 | Background push routing (`author == pub(K_sign)`) | `lib/features/notifications/services/background_notification_service.dart` |
 | Derivation + envelope tests (incl. official test vector) | `test/shared/utils/chat_keys_test.dart`, `test/data/models/nostr_event_chat_test.dart` |
 

--- a/docs/architecture/DISPUTE_CHAT_KIND14.md
+++ b/docs/architecture/DISPUTE_CHAT_KIND14.md
@@ -2,7 +2,9 @@
 
 > Wire format, key derivation, and client rules for the user↔admin dispute chat.
 > Replaces the legacy 1-layer gift wrap (kind 1059) previously used for dispute chat.
-> Protocol spec: https://mostro.network/protocol/chat.html
+> Protocol spec: https://mostro.network/protocol/chat.html (envelope, key derivation,
+> test vector) and https://mostro.network/protocol/dispute_chat.html (per-party admin
+> keys and dispute flow)
 
 ## Overview
 
@@ -62,11 +64,18 @@ reject a mismatch between inner and outer timestamps as a replay defense.
 NostrFilter(
   kinds: [14],
   authors: [chatKeys.sign.public],
+  since: DateTime.now().subtract(NostrEventExtensions.chatDefaultLookback), // 7 days
+  limit: NostrEventExtensions.chatDefaultLimit, // 100
 )
 ```
 
 The spec requires filtering by `authors`, **never by `#p`**: a `#p` filter would let any
 third party flood the subscription with junk events tagged to the conversation pubkey.
+
+The `since` lookback and `limit` match the spec defaults (7 days / 100 events). A durable
+per-conversation `since` cursor (advanced only after accepting an event, clamped to the
+local clock) is a possible future refinement; on-disk history plus outer-id dedup already
+covers reconnection in practice.
 
 Kind 14 is also used by transport-v2 Mostro protocol messages (user↔mostro). The two
 never collide: protocol events are authored by the Mostro pubkey and addressed to the

--- a/docs/architecture/DISPUTE_CHAT_KIND14.md
+++ b/docs/architecture/DISPUTE_CHAT_KIND14.md
@@ -1,0 +1,130 @@
+# Dispute Chat Kind-14 Envelope
+
+> Wire format, key derivation, and client rules for the user↔admin dispute chat.
+> Replaces the legacy 1-layer gift wrap (kind 1059) previously used for dispute chat.
+> Protocol spec: https://mostro.network/protocol/chat.html
+
+## Overview
+
+Dispute chat messages between a user and the assigned admin (solver) are exchanged as
+**kind 14 events** signed by a conversation-specific key, instead of gift wraps addressed
+to the raw ECDH shared pubkey. The Mostro daemon is not a party to this chat: both sides
+derive the same keys from their ECDH secret and talk directly through relays.
+
+The reference implementations are `mostro_core::chat` (Rust) and mostrix
+(`src/util/chat_utils.rs`). Mostrix sends **only** the kind-14 envelope, so this format is
+required for mobile users to receive admin messages.
+
+## Key Derivation
+
+The ECDH shared secret is unchanged from the legacy system — it is still
+`session.adminSharedKey`, computed as `ECDH(tradeKey.private, adminPubkey)` when
+`adminTookDispute` arrives (`session.setAdminPeer()`). What changed is that the secret is
+no longer used on the wire directly. It is expanded with HKDF-SHA256 (zero-filled salt)
+into two domain-separated keys:
+
+```text
+ECDH(tradeKey, adminPubkey)  →  32-byte shared secret (IKM)
+HKDF-SHA256(salt=zeros, ikm=secret):
+    expand(info="mostro:chat:conv:v1") → K_conv   (NIP-44 encryption + p tag)
+    expand(info="mostro:chat:sign:v1") → K_sign   (signs the outer kind 14)
+```
+
+If an expanded output is not a valid secp256k1 secret key (negligible probability), the
+derivation retries with a counter byte appended to the info, per the spec.
+
+**Implementation:** `ChatKeys` in `lib/shared/utils/chat_keys.dart`
+(`ChatKeys.fromSharedKey(session.adminSharedKey!)`). The official test vector from the
+spec is verified in `test/shared/utils/chat_keys_test.dart`.
+
+## Wire Format
+
+```text
+Plain-text message
+    → kind 1 TextNote signed by the sender's trade key (no tags)
+    → NIP-44 v2 self-encryption under K_conv (same key on both sides)
+    → kind 14 outer event:
+        pubkey     = pub(K_sign)          ← signed by K_sign
+        content    = NIP-44 ciphertext
+        tags       = exactly ONE p tag = pub(K_conv)
+        created_at = same real timestamp as the inner event
+```
+
+Unlike the legacy gift wrap, the outer timestamp is **real** (not randomized): recipients
+reject a mismatch between inner and outer timestamps as a replay defense.
+
+**Implementation:** `chatWrap()` / `chatUnwrap()` extensions in
+`lib/data/models/nostr_event.dart`.
+
+## Subscription
+
+```dart
+NostrFilter(
+  kinds: [14],
+  authors: [chatKeys.sign.public],
+)
+```
+
+The spec requires filtering by `authors`, **never by `#p`**: a `#p` filter would let any
+third party flood the subscription with junk events tagged to the conversation pubkey.
+
+Kind 14 is also used by transport-v2 Mostro protocol messages (user↔mostro). The two
+never collide: protocol events are authored by the Mostro pubkey and addressed to the
+trade key, chat events are authored by `pub(K_sign)`. Routing always checks the author.
+
+## Validation on Receive
+
+`chatUnwrap()` runs the mandatory spec checks cheapest-first:
+
+1. Outer author == `pub(K_sign)`
+2. Outer kind == 14
+3. Exactly one `p` tag, equal to `pub(K_conv)`
+4. Outer `created_at` not more than 60 s in the future vs. the local clock
+5. Encrypted content ≤ 64 KiB, checked before any crypto
+6. Outer event id recomputed and signature verified
+7. NIP-44 decrypt with K_conv; parse the inner event
+8. Inner event id recomputed and signature verified
+9. Inner pubkey ∈ allowed signers — `[tradeKey.public, adminPubkey]`
+10. Inner kind == 1
+11. |inner.created_at − outer.created_at| ≤ 60 s
+
+The event id is recomputed (not just signature-checked) because a BIP-340 signature only
+covers the id — without recomputation a tampered body with a stale id/sig pair would pass.
+
+Duplicate detection stays caller-owned: the notifier dedups relay re-deliveries by outer
+event id (`eventStore.hasItem`) and UI state by inner event id.
+
+## Implementation Map
+
+| Concern | File |
+|---------|------|
+| Key derivation (`ChatKeys`) | `lib/shared/utils/chat_keys.dart` |
+| Envelope (`chatWrap`/`chatUnwrap`) | `lib/data/models/nostr_event.dart` |
+| Dispute chat notifier (subscribe/send/receive/history) | `lib/features/disputes/notifiers/dispute_chat_notifier.dart` |
+| Centralized `disputeChat` filter (also reused by background) | `lib/features/subscriptions/subscription_manager.dart` |
+| Background push routing (`author == pub(K_sign)`) | `lib/features/notifications/services/background_notification_service.dart` |
+| Derivation + envelope tests (incl. official test vector) | `test/shared/utils/chat_keys_test.dart`, `test/data/models/nostr_event_chat_test.dart` |
+
+## Migration Notes
+
+- **Full wire replacement.** Sending and network subscriptions use only kind 14. There is
+  no network dual-read of legacy kind-1059 chat events.
+- **Local history keeps a legacy branch.** Dispute messages stored on disk before the
+  migration are kind-1059 gift wraps; `_loadHistoricalMessages()` unwraps stored events by
+  kind (14 → `chatUnwrap`, 1059 → `p2pUnwrap`), so existing history stays visible.
+- **Known accepted gap:** legacy 1059 chat events still sitting on relays but never
+  received before the app update are not fetched after it.
+- **P2P peer chat (buyer↔seller) is unchanged** and still uses the legacy 1-layer gift
+  wrap (`p2pWrap`/`p2pUnwrap`). Its migration to this same envelope is future work and
+  should reuse `ChatKeys` + `chatWrap`/`chatUnwrap` as-is.
+- **Multimedia is unaffected.** Attachment encryption (ChaCha20-Poly1305) keys off the raw
+  ECDH secret bytes (`NostrUtils.sharedKeyToBytes(adminSharedKey)`), not K_conv/K_sign, so
+  Blossom attachments remain compatible in both directions.
+
+## Privacy Trade-off (by design)
+
+The legacy gift wrap randomized the outer timestamp and used a fresh ephemeral author per
+message. The kind-14 envelope has a real timestamp and a stable per-dispute author
+(`pub(K_sign)`) — visible metadata the spec accepts in exchange for flood-resistant
+author-based filtering. This is a protocol decision, not something the client should work
+around.

--- a/docs/architecture/DISPUTE_CHAT_KIND14.md
+++ b/docs/architecture/DISPUTE_CHAT_KIND14.md
@@ -64,7 +64,7 @@ reject a mismatch between inner and outer timestamps as a replay defense.
 NostrFilter(
   kinds: [14],
   authors: [chatKeys.sign.public],
-  since: cursorSince ?? defaultLookback, // persisted per-conversation cursor
+  since: cursorSince ?? chatDefaultLookback, // persisted per-conversation cursor
   limit: NostrEventExtensions.chatDefaultLimit, // 100
 )
 ```
@@ -84,7 +84,10 @@ The backlog is bounded by a **durable per-conversation `since` cursor**
   (`chatDefaultLookback`).
 - The grouped `SubscriptionManager` filter covers several conversations with one REQ, so
   it uses the **earliest** cursor across sessions — wider than necessary for some
-  conversations, which dedup absorbs, but never narrower.
+  conversations, which dedup absorbs, but never narrower. Persisted cursors are
+  **warmed up from storage before the filter is built**, so a cold start (and the
+  background filters persisted from it) uses the durable cursor, not the default
+  lookback.
 
 Kind 14 is also used by transport-v2 Mostro protocol messages (user↔mostro). The two
 never collide: protocol events are authored by the Mostro pubkey and addressed to the

--- a/docs/architecture/DISPUTE_CHAT_MULTIMEDIA_PLAN.md
+++ b/docs/architecture/DISPUTE_CHAT_MULTIMEDIA_PLAN.md
@@ -23,9 +23,9 @@ The app has two chat systems that share encryption, upload, and rendering infras
 Both chats derive their key material the same way, but use different envelopes:
 
 1. **Key computation:** `ECDH(tradeKey.private, peerPubkey)` produces a shared key
-2. **P2P chat (legacy gift wrap):** inner event (kind 1) wrapped via
-   `p2pWrap(tradeKey, sharedKey.public)`, received as kind 1059 and unwrapped via
-   `event.p2pUnwrap(sharedKey)`
+2. **P2P chat (legacy gift wrap):** uses the raw ECDH shared key directly — inner
+   event (kind 1) wrapped via `p2pWrap(tradeKey, sharedKey.public)`, received as
+   kind 1059 and unwrapped via `event.p2pUnwrap(sharedKey)`
 3. **Dispute chat (kind-14 envelope):** the ECDH secret is HKDF-expanded into
    K_conv/K_sign (`ChatKeys.fromSharedKey`); messages are wrapped via
    `chatWrap(chatKeys)` and unwrapped via `chatUnwrap(chatKeys, allowedSigners)`.

--- a/docs/architecture/DISPUTE_CHAT_MULTIMEDIA_PLAN.md
+++ b/docs/architecture/DISPUTE_CHAT_MULTIMEDIA_PLAN.md
@@ -8,11 +8,11 @@ The app has two chat systems that share encryption, upload, and rendering infras
 
 | | P2P Chat (User-User) | Dispute Chat (User-Admin) |
 |-|----------------------|--------------------------|
-| **Encryption** | `p2pWrap()` with ECDH shared key | `p2pWrap()` with admin ECDH shared key |
-| **Key field** | `session.sharedKey` | `session.adminSharedKey` |
-| **Routing (`p` tag)** | Shared key pubkey | Admin shared key pubkey |
+| **Encryption** | `p2pWrap()` with ECDH shared key (legacy gift wrap) | `chatWrap()` kind-14 envelope with keys derived from admin ECDH shared key |
+| **Key field** | `session.sharedKey` | `session.adminSharedKey` (HKDF → K_conv/K_sign via `ChatKeys`) |
+| **Wire event** | Kind 1059, `p` tag = shared key pubkey | Kind 14, author = `pub(K_sign)`, `p` tag = `pub(K_conv)` |
 | **Message model** | `NostrEvent` | `DisputeChatMessage(NostrEvent)` with pending/error state |
-| **Storage** | Gift wrap events (encrypted) on disk | Gift wrap events (encrypted) on disk |
+| **Storage** | Gift wrap events (encrypted) on disk | Outer kind-14 events (encrypted) on disk; pre-migration 1059 history still readable |
 | **Multimedia** | Images + files via Blossom | Images + files via Blossom |
 | **Notifier** | `ChatRoomNotifier` | `DisputeChatNotifier` |
 | **Message bubble** | `MessageBubble` | `DisputeMessageBubble` |
@@ -20,14 +20,21 @@ The app has two chat systems that share encryption, upload, and rendering infras
 
 ## Encryption
 
-Both chats use NIP-59 gift wrap with 1-layer `p2pWrap`/`p2pUnwrap`:
+Both chats derive their key material the same way, but use different envelopes:
 
 1. **Key computation:** `ECDH(tradeKey.private, peerPubkey)` produces a shared key
-2. **Sending:** Inner event (kind 1, plain text or JSON) wrapped via `p2pWrap(tradeKey, sharedKey.public)`
-3. **Receiving:** Gift wrap (kind 1059) unwrapped via `event.p2pUnwrap(sharedKey)`
-4. **Storage:** Gift wrap event stored encrypted on disk; unwrapped on load
+2. **P2P chat (legacy gift wrap):** inner event (kind 1) wrapped via
+   `p2pWrap(tradeKey, sharedKey.public)`, received as kind 1059 and unwrapped via
+   `event.p2pUnwrap(sharedKey)`
+3. **Dispute chat (kind-14 envelope):** the ECDH secret is HKDF-expanded into
+   K_conv/K_sign (`ChatKeys.fromSharedKey`); messages are wrapped via
+   `chatWrap(chatKeys)` and unwrapped via `chatUnwrap(chatKeys, allowedSigners)`.
+   See `DISPUTE_CHAT_KIND14.md` for the full wire format and validation rules.
+4. **Storage:** the encrypted outer event is stored on disk and unwrapped on load
 
 For disputes, the "peer" is the admin. The shared key is computed when the admin takes the dispute (`session.setAdminPeer(adminPubkey)`). A session can have both `sharedKey` (P2P peer) and `adminSharedKey` (admin) simultaneously.
+
+Multimedia encryption is envelope-independent: attachment keys are the raw ECDH secret bytes (`NostrUtils.sharedKeyToBytes`), so the pipeline below applies unchanged to both chats.
 
 ## Multimedia Pipeline
 

--- a/docs/architecture/DISPUTE_CHAT_RESTORE.md
+++ b/docs/architecture/DISPUTE_CHAT_RESTORE.md
@@ -97,8 +97,9 @@ RestoreService.importMnemonicAndRestore()
 
 ### Dispute Chat Subscription During Restore
 
-`DisputeChatNotifier` subscribes to kind 1059 events addressed to the `adminSharedKey` — an
-ECDH keypair derived from `tradeKey` and the solver's public key.
+`DisputeChatNotifier` subscribes to kind 14 chat events authored by `pub(K_sign)` — a key
+HKDF-derived from the `adminSharedKey` ECDH secret (`tradeKey × solver pubkey`). See
+`DISPUTE_CHAT_KIND14.md` for the envelope and derivation details.
 
 For this to work post-restore, `Session.adminSharedKey` must be non-null at the time the
 dispute chat provider is first accessed. The restore flow guarantees this by passing

--- a/docs/architecture/NOSTR.md
+++ b/docs/architecture/NOSTR.md
@@ -23,13 +23,13 @@ The Mostro Mobile app is built on top of the Nostr protocol to provide a decentr
 - **Privacy**: Advanced encryption ensures trade communications remain private
 - **Censorship Resistance**: Multiple relay support prevents single points of failure
 - **Key Rotation**: Unique keys for each trade prevent transaction linking
-- **End-to-End Encryption**: All trade communications are NIP-44 encrypted — via NIP-59 gift wraps (protocol v1, P2P chat) or direct kind-14 envelopes (protocol v2, dispute chat)
+- **End-to-End Encryption**: All trade communications are NIP-44 encrypted. The envelope depends on the channel: user↔Mostro protocol messages follow the node's advertised `protocol_version` (NIP-59 gift wraps on v1, direct kind-14 events on v2), P2P peer chat uses legacy NIP-59 gift wraps, and dispute chat uses the kind-14 chat envelope — the latter two independently of the node's transport version
 
 ## Architecture
 
 ### High-Level Components
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                    Mostro Mobile App                        │
 ├─────────────────────────────────────────────────────────────┤
@@ -92,7 +92,7 @@ Implements the Mostro protocol specifics on top of Nostr:
 The app implements a sophisticated key management system following BIP-32 and NIP-06 standards:
 
 #### Master Key Generation
-```
+```text
 BIP-39 Mnemonic (12/24 words)
         ↓
 BIP-32 Seed (512 bits)
@@ -192,7 +192,7 @@ final subscription = await nostrService.subscribeToEvents(filters);
 The app implements a three-layer encryption system for all private communications:
 
 #### Layer Structure
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                     Kind 1059 Event                        │
 │                   (Wrapper Event)                          │
@@ -282,7 +282,7 @@ final orderFilters = [
 The app implements a comprehensive state machine for order lifecycle management:
 
 #### Order States
-```
+```text
 Pending → Waiting Payment → Active → Fiat Sent → Success
     ↓                         ↓           ↓
  Canceled               Canceled    Canceled

--- a/docs/architecture/NOSTR.md
+++ b/docs/architecture/NOSTR.md
@@ -23,7 +23,7 @@ The Mostro Mobile app is built on top of the Nostr protocol to provide a decentr
 - **Privacy**: Advanced encryption ensures trade communications remain private
 - **Censorship Resistance**: Multiple relay support prevents single points of failure
 - **Key Rotation**: Unique keys for each trade prevent transaction linking
-- **End-to-End Encryption**: All trade communications use NIP-59 gift wrapping
+- **End-to-End Encryption**: All trade communications are NIP-44 encrypted — via NIP-59 gift wraps (protocol v1, P2P chat) or direct kind-14 envelopes (protocol v2, dispute chat)
 
 ## Architecture
 
@@ -235,10 +235,17 @@ The app implements a three-layer encryption system for all private communication
 - **Market Discovery**: Browse available trades
 - **Order Metadata**: Trade parameters and requirements
 
-#### Chat Messages (Kind 1059)
+#### P2P Chat Messages (Kind 1059)
 - **Peer-to-Peer**: Direct communication between traders
-- **Admin Communication**: Support and dispute resolution
+- **Envelope**: Legacy 1-layer gift wrap (`p2pWrap`/`p2pUnwrap`) addressed to the ECDH shared pubkey
 - **Real-time**: Live chat during active trades
+
+#### Dispute Chat Messages (Kind 14)
+- **Admin Communication**: Support and dispute resolution with the assigned solver
+- **Envelope**: Kind-14 chat envelope signed by `K_sign`, NIP-44 encrypted under `K_conv`
+  (both HKDF-derived from the admin ECDH shared secret)
+- **Subscription**: By `authors = [pub(K_sign)]`, never by `#p` (flood resistance)
+- **Details**: See `DISPUTE_CHAT_KIND14.md`
 
 ### Event Filtering and Subscription
 

--- a/docs/architecture/P2P_CHAT_SYSTEM.md
+++ b/docs/architecture/P2P_CHAT_SYSTEM.md
@@ -4,6 +4,11 @@ This document describes how the peer-to-peer chat between trading parties works 
 
 For the **protocol specification** (NIP-59, ECDH, event format), see the [Mostro P2P Chat protocol](https://mostro.network/protocol/chat.html) ([source](https://github.com/MostroP2P/protocol)).
 
+> **Note:** P2P peer chat still uses the legacy 1-layer gift wrap (kind 1059) described
+> below. The spec's newer kind-14 chat envelope is already used by the **dispute chat**
+> (see `DISPUTE_CHAT_KIND14.md`); migrating P2P chat to it is pending and should reuse the
+> same `ChatKeys` / `chatWrap` / `chatUnwrap` primitives.
+
 ---
 
 ## Components

--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -358,6 +358,13 @@ extension NostrEventExtensions on NostrEvent {
   /// content, enforced before decrypting. Spec default: 64 KiB.
   static const chatMaxContentBytes = 64 * 1024;
 
+  /// Mostro chat envelope (kind 14): default subscription lookback window,
+  /// matching the spec default (7 days).
+  static const chatDefaultLookback = Duration(days: 7);
+
+  /// Mostro chat envelope (kind 14): default subscription event limit.
+  static const chatDefaultLimit = 100;
+
   /// Mostro chat: wrap this signed kind 1 event into a kind 14 envelope
   /// signed by `K_sign`, NIP-44 self-encrypted under `K_conv`.
   /// Supersedes the gift wrap (p2pWrap) for dispute and peer chat.
@@ -466,7 +473,14 @@ extension NostrEventExtensions on NostrEvent {
     if (decoded is! Map<String, dynamic>) {
       throw Exception('Malformed inner chat event');
     }
-    final inner = NostrEventExtensions.fromMap(decoded);
+    // fromMap casts fields without null checks; normalize a missing-field
+    // TypeError into the same Exception as malformed JSON
+    final NostrEvent inner;
+    try {
+      inner = NostrEventExtensions.fromMap(decoded);
+    } catch (e) {
+      throw Exception('Malformed inner chat event: $e');
+    }
 
     // 8. Inner id and signature (sender authentication)
     _verifyEventIntegrity(inner, 'inner');

--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -3,6 +3,7 @@ import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/range_amount.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
 import 'package:mostro_mobile/data/models/rating.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:dart_nostr/dart_nostr.dart';
@@ -346,6 +347,176 @@ extension NostrEventExtensions on NostrEvent {
       return innerEvent;
     } catch (e) {
       throw Exception('Failed to unwrap P2P chat message: $e');
+    }
+  }
+
+  /// Mostro chat envelope (kind 14): tolerated clock skew in seconds between
+  /// inner/outer timestamps and against the local clock. Spec default: 60.
+  static const chatMaxClockSkewSecs = 60;
+
+  /// Mostro chat envelope (kind 14): upper bound on the encrypted outer
+  /// content, enforced before decrypting. Spec default: 64 KiB.
+  static const chatMaxContentBytes = 64 * 1024;
+
+  /// Mostro chat: wrap this signed kind 1 event into a kind 14 envelope
+  /// signed by `K_sign`, NIP-44 self-encrypted under `K_conv`.
+  /// Supersedes the gift wrap (p2pWrap) for dispute and peer chat.
+  ///
+  /// The outer event shares this event's timestamp (recipients reject a
+  /// mismatch) and carries exactly one `p` tag = pub(K_conv).
+  /// Spec: https://mostro.network/protocol/chat.html
+  Future<NostrEvent> chatWrap(ChatKeys chatKeys) async {
+    if (kind != 1) {
+      throw ArgumentError('Expected kind 1 event for chat, got: $kind');
+    }
+
+    if (content == null || content!.isEmpty) {
+      throw ArgumentError('Message content is empty');
+    }
+
+    if (id == null || sig == null) {
+      throw ArgumentError('Inner chat event must be signed');
+    }
+
+    // NIP-44 self-encryption: K_conv is both sides of the key exchange
+    final encryptedContent = await NostrUtils.encryptNIP44(
+      jsonEncode(toMap()),
+      chatKeys.conv.private,
+      chatKeys.conv.public,
+    );
+
+    return NostrEvent.fromPartialData(
+      kind: 14,
+      content: encryptedContent,
+      keyPairs: chatKeys.sign,
+      tags: [
+        ["p", chatKeys.conv.public],
+      ],
+      createdAt: createdAt,
+    );
+  }
+
+  /// Mostro chat: unwrap a kind 14 envelope signed by `K_sign` and return
+  /// the verified inner kind 1 event.
+  ///
+  /// Runs the mandatory spec checks cheapest-first. [allowedSigners] are the
+  /// accepted inner pubkeys (trade key + admin pubkey for dispute chat).
+  /// The caller still owns rate limiting and duplicate detection.
+  /// [now] overrides the local clock for testing.
+  Future<NostrEvent> chatUnwrap(
+    ChatKeys chatKeys,
+    List<String> allowedSigners, {
+    DateTime? now,
+  }) async {
+    // 1-2. Outer author and kind
+    if (pubkey != chatKeys.sign.public) {
+      throw Exception(
+        'Outer event is not authored by the conversation signing key',
+      );
+    }
+
+    if (kind != 14) {
+      throw Exception('Expected kind 14 chat event, got: $kind');
+    }
+
+    // 3. Exactly one p tag equal to pub(K_conv)
+    final pTags =
+        (tags ?? []).where((t) => t.isNotEmpty && t[0] == 'p').toList();
+    if (pTags.length != 1 ||
+        pTags[0].length < 2 ||
+        pTags[0][1] != chatKeys.conv.public) {
+      throw Exception(
+        'Outer event must carry exactly one p tag for this conversation',
+      );
+    }
+
+    // 4. Absolute timestamp bound against the local clock
+    final localNow = now ?? DateTime.now();
+    if (createdAt == null ||
+        createdAt!.isAfter(
+          localNow.add(const Duration(seconds: chatMaxClockSkewSecs)),
+        )) {
+      throw Exception('Outer event is dated too far in the future');
+    }
+
+    // 5. Size bound before any crypto
+    if (content == null || content!.isEmpty) {
+      throw Exception('Chat event content is empty');
+    }
+    if (utf8.encode(content!).length > chatMaxContentBytes) {
+      throw Exception('Encrypted payload exceeds the accepted size');
+    }
+
+    // 6. Outer id and signature
+    _verifyEventIntegrity(this, 'outer');
+
+    // 7. Decrypt (NIP-44 self-decryption under K_conv)
+    final decrypted = await NostrUtils.decryptNIP44(
+      content!,
+      chatKeys.conv.private,
+      chatKeys.conv.public,
+    );
+
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(decrypted);
+    } catch (e) {
+      throw Exception('Malformed inner chat event: $e');
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw Exception('Malformed inner chat event');
+    }
+    final inner = NostrEventExtensions.fromMap(decoded);
+
+    // 8. Inner id and signature (sender authentication)
+    _verifyEventIntegrity(inner, 'inner');
+
+    // 9. Inner signer allowlist
+    if (!allowedSigners.contains(inner.pubkey)) {
+      throw Exception(
+        'Inner event is signed by a key that is not a party to this conversation',
+      );
+    }
+
+    // 10. Inner kind
+    if (inner.kind != 1) {
+      throw Exception('Inner chat event is not a kind 1 text note');
+    }
+
+    // 11. Relative timestamp bound (stale re-wrap defense)
+    final skew = (inner.createdAt!.millisecondsSinceEpoch ~/ 1000 -
+            createdAt!.millisecondsSinceEpoch ~/ 1000)
+        .abs();
+    if (skew > chatMaxClockSkewSecs) {
+      throw Exception('Inner and outer timestamps disagree');
+    }
+
+    return inner;
+  }
+
+  /// Verify that an event's id matches its content and its signature is
+  /// valid — both required, since a BIP-340 signature only covers the id.
+  static void _verifyEventIntegrity(NostrEvent event, String label) {
+    if (event.id == null ||
+        event.sig == null ||
+        event.kind == null ||
+        event.createdAt == null) {
+      throw Exception('The $label chat event is not properly signed');
+    }
+
+    final expectedId = NostrEvent.getEventId(
+      kind: event.kind!,
+      content: event.content ?? '',
+      createdAt: event.createdAt!,
+      tags: event.tags ?? [],
+      pubkey: event.pubkey,
+    );
+    if (expectedId != event.id) {
+      throw Exception('The $label chat event id does not match its content');
+    }
+
+    if (!NostrKeyPairs.verify(event.pubkey, event.id!, event.sig!)) {
+      throw Exception('Invalid $label chat event signature');
     }
   }
 

--- a/lib/data/models/session.dart
+++ b/lib/data/models/session.dart
@@ -204,6 +204,13 @@ class Session {
   String? get adminPubkey => _adminPubkey;
   NostrKeyPairs? get adminSharedKey => _adminSharedKey;
 
+  /// Inner event signers accepted in the dispute chat conversation.
+  /// adminPubkey is always set when adminSharedKey is (see setAdminPeer).
+  List<String> get disputeChatAllowedSigners => [
+        tradeKey.public,
+        if (_adminPubkey != null) _adminPubkey!,
+      ];
+
   /// Compute and store the admin shared key via ECDH
   void setAdminPeer(String adminPubkey) {
     if (adminPubkey.isEmpty || adminPubkey.length != 64) {

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -13,6 +13,7 @@ import 'package:mostro_mobile/features/chat/utils/message_type_helpers.dart';
 import 'package:mostro_mobile/services/encrypted_image_upload_service.dart';
 import 'package:mostro_mobile/services/encrypted_file_upload_service.dart';
 import 'package:mostro_mobile/shared/mixins/media_cache_mixin.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
@@ -74,8 +75,9 @@ class DisputeChatState {
 }
 
 /// Notifier for dispute chat messages
-/// Uses shared key encryption (p2pWrap/p2pUnwrap) with admin via ECDH.
-/// Stores gift wrap events (encrypted) on disk, same pattern as P2P chat.
+/// Uses the Mostro chat kind-14 envelope (chatWrap/chatUnwrap) with keys
+/// derived from the admin ECDH shared secret.
+/// Stores the encrypted outer events on disk, same pattern as P2P chat.
 class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCacheMixin {
   static final EncryptedImageUploadService _imageUploadService =
       EncryptedImageUploadService();
@@ -89,7 +91,26 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
   ProviderSubscription<dynamic>? _sessionListener;
   bool _isInitialized = false;
 
+  ChatKeys? _chatKeys;
+  String? _chatKeysSource;
+
   DisputeChatNotifier(this.disputeId, this.ref) : super(const DisputeChatState());
+
+  /// Derive (and cache) the K_conv/K_sign pair from the admin shared key.
+  ChatKeys _getChatKeys(Session session) {
+    final shared = session.adminSharedKey!;
+    if (_chatKeys == null || _chatKeysSource != shared.public) {
+      _chatKeys = ChatKeys.fromSharedKey(shared);
+      _chatKeysSource = shared.public;
+    }
+    return _chatKeys!;
+  }
+
+  /// Inner event signers accepted in this conversation.
+  List<String> _allowedSigners(Session session) => [
+        session.tradeKey.public,
+        if (session.adminPubkey != null) session.adminPubkey!,
+      ];
 
   /// Initialize the dispute chat by loading historical messages and subscribing to new events
   Future<void> initialize() async {
@@ -128,19 +149,21 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       _subscription = null;
     }
 
-    // Subscribe to kind 1059 (Gift Wrap) events routed to admin shared key
+    // Subscribe to kind 14 chat events authored by K_sign. The spec requires
+    // filtering by authors, not #p, to prevent third-party flooding.
+    final chatKeys = _getChatKeys(session);
     final nostrService = ref.read(nostrServiceProvider);
     final request = NostrRequest(
       filters: [
         NostrFilter(
-          kinds: [1059],
-          p: [session.adminSharedKey!.public],
+          kinds: [14],
+          authors: [chatKeys.sign.public],
         ),
       ],
     );
 
     _subscription = nostrService.subscribeToEvents(request).listen(_onChatEvent);
-    logger.i('Subscribed to kind 1059 via admin shared key for dispute: $disputeId');
+    logger.i('Subscribed to kind 14 chat via K_sign for dispute: $disputeId');
   }
 
   /// Listen for session changes and subscribe when admin shared key is ready
@@ -170,31 +193,26 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
     );
   }
 
-  /// Handle incoming chat events via p2pUnwrap.
-  /// Stores the gift wrap event (encrypted) to disk, then unwraps for display.
+  /// Handle incoming chat events via chatUnwrap.
+  /// Stores the outer event (encrypted) to disk, then unwraps for display.
   void _onChatEvent(NostrEvent event) async {
     try {
-      if (!mounted || event.kind != 1059) return;
+      if (!mounted || event.kind != 14) return;
 
       final session = _getSessionForDispute();
       if (session == null || session.adminSharedKey == null) return;
 
-      // Verify p tag matches admin shared key
-      final pTag = event.tags?.firstWhere(
-        (tag) => tag.isNotEmpty && tag[0] == 'p',
-        orElse: () => [],
-      ) ?? [];
-      if (pTag.isEmpty || pTag.length < 2 || pTag[1] != session.adminSharedKey!.public) {
-        return;
-      }
+      // Cheap pre-filter; chatUnwrap re-checks this among the spec checks
+      final chatKeys = _getChatKeys(session);
+      if (event.pubkey != chatKeys.sign.public) return;
 
-      // Check for duplicate gift wrap events
+      // Check for duplicate outer events (relay re-deliveries)
       final wrapperEventId = event.id;
       if (wrapperEventId == null) return;
       final eventStore = ref.read(eventStorageProvider);
       if (await eventStore.hasItem(wrapperEventId)) return;
 
-      // Store the gift wrap event (encrypted) to disk — same pattern as P2P chat
+      // Store the outer event (encrypted) to disk — same pattern as P2P chat
       await eventStore.putItem(
         wrapperEventId,
         {
@@ -211,12 +229,13 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       );
       if (!mounted) return;
 
-      // Unwrap using admin shared key (1-layer p2p decryption)
-      final unwrappedEvent = await event.p2pUnwrap(session.adminSharedKey!);
+      // Unwrap and authenticate: the inner event must be signed by a
+      // conversation party (trade key or admin pubkey)
+      final unwrappedEvent = await event.chatUnwrap(
+        chatKeys,
+        _allowedSigners(session),
+      );
       if (!mounted) return;
-
-      // SECURITY: The ECDH shared key IS the authentication.
-      // If p2pUnwrap succeeded, the sender holds the admin's private key.
 
       final messageText = unwrappedEvent.content ?? '';
       if (messageText.isEmpty) {
@@ -266,7 +285,8 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
   }
 
   /// Load historical messages from storage.
-  /// Reconstructs gift wrap events and unwraps them with adminSharedKey.
+  /// Reconstructs stored outer events and unwraps them: kind 14 via
+  /// chatUnwrap, legacy kind 1059 (pre-migration) via p2pUnwrap.
   Future<void> _loadHistoricalMessages() async {
     try {
       if (!mounted) return;
@@ -310,7 +330,7 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
             continue;
           }
 
-          // Reconstruct the gift wrap NostrEvent from stored data
+          // Reconstruct the outer NostrEvent from stored data
           final storedEvent = NostrEventExtensions.fromMap({
             'id': eventData['id'],
             'created_at': eventData['created_at'],
@@ -321,13 +341,20 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
             'tags': eventData['tags'],
           });
 
-          // Verify p tag matches our admin shared key
-          if (session.adminSharedKey!.public != storedEvent.recipient) {
-            continue;
+          // Decrypt and unwrap: kind 14 envelope, or legacy gift wrap
+          // stored before the kind-14 migration
+          final NostrEvent unwrappedEvent;
+          if (storedEvent.kind == 14) {
+            unwrappedEvent = await storedEvent.chatUnwrap(
+              _getChatKeys(session),
+              _allowedSigners(session),
+            );
+          } else {
+            if (session.adminSharedKey!.public != storedEvent.recipient) {
+              continue;
+            }
+            unwrappedEvent = await storedEvent.p2pUnwrap(session.adminSharedKey!);
           }
-
-          // Decrypt and unwrap the message
-          final unwrappedEvent = await storedEvent.p2pUnwrap(session.adminSharedKey!);
           if (!mounted) return;
           // Fire-and-forget: pre-download media without blocking history load
           unawaited(_processMessageContent(unwrappedEvent));
@@ -350,8 +377,8 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
     }
   }
 
-  /// Send a message in the dispute chat using p2pWrap with admin shared key.
-  /// Stores the gift wrap event (encrypted) on success.
+  /// Send a message in the dispute chat using the kind-14 chat envelope.
+  /// Stores the outer event (encrypted) on success.
   Future<void> sendMessage(String text) async {
     if (!mounted) return;
 
@@ -366,14 +393,12 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       return;
     }
 
-    // Create rumor (kind 1) with plain text content FIRST to get real event ID
+    // Create the inner event (kind 1, no tags per the chat spec) FIRST to
+    // get the real event ID used for optimistic UI and echo deduplication
     final rumor = NostrEvent.fromPartialData(
       keyPairs: session.tradeKey,
       content: text,
       kind: 1,
-      tags: [
-        ["p", session.adminSharedKey!.public],
-      ],
     );
 
     final rumorId = rumor.id;
@@ -393,11 +418,8 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       deduped.sort((a, b) => a.timestamp.compareTo(b.timestamp));
       state = state.copyWith(messages: deduped, error: null);
 
-      // Wrap using p2pWrap (1-layer, shared key routing)
-      final wrappedEvent = await rumor.p2pWrap(
-        session.tradeKey,
-        session.adminSharedKey!.public,
-      );
+      // Wrap into the kind-14 envelope (signed by K_sign, encrypted with K_conv)
+      final wrappedEvent = await rumor.chatWrap(_getChatKeys(session));
       if (!mounted) return;
 
       // Publish to network
@@ -412,7 +434,7 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
         return;
       }
 
-      // On success: store the gift wrap event (encrypted) to disk
+      // On success: store the outer event (encrypted) to disk
       final eventStore = ref.read(eventStorageProvider);
       await eventStore.putItem(
         wrappedEvent.id!,

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -106,11 +106,6 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
     return _chatKeys!;
   }
 
-  /// Inner event signers accepted in this conversation.
-  List<String> _allowedSigners(Session session) => [
-        session.tradeKey.public,
-        if (session.adminPubkey != null) session.adminPubkey!,
-      ];
 
   /// Initialize the dispute chat by loading historical messages and subscribing to new events
   Future<void> initialize() async {
@@ -158,6 +153,9 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
         NostrFilter(
           kinds: [14],
           authors: [chatKeys.sign.public],
+          since: DateTime.now()
+              .subtract(NostrEventExtensions.chatDefaultLookback),
+          limit: NostrEventExtensions.chatDefaultLimit,
         ),
       ],
     );
@@ -233,7 +231,7 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       // conversation party (trade key or admin pubkey)
       final unwrappedEvent = await event.chatUnwrap(
         chatKeys,
-        _allowedSigners(session),
+        session.disputeChatAllowedSigners,
       );
       if (!mounted) return;
 
@@ -347,7 +345,7 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
           if (storedEvent.kind == 14) {
             unwrappedEvent = await storedEvent.chatUnwrap(
               _getChatKeys(session),
-              _allowedSigners(session),
+              session.disputeChatAllowedSigners,
             );
           } else {
             if (session.adminSharedKey!.public != storedEvent.recipient) {

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -10,6 +10,7 @@ import 'package:mostro_mobile/features/chat/providers/active_chat_screens_provid
 import 'package:mostro_mobile/features/notifications/providers/notifications_provider.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/chat/utils/message_type_helpers.dart';
+import 'package:mostro_mobile/services/dispute_chat_cursor_store.dart';
 import 'package:mostro_mobile/services/encrypted_image_upload_service.dart';
 import 'package:mostro_mobile/services/encrypted_file_upload_service.dart';
 import 'package:mostro_mobile/shared/mixins/media_cache_mixin.dart';
@@ -148,13 +149,21 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
     // filtering by authors, not #p, to prevent third-party flooding.
     final chatKeys = _getChatKeys(session);
     final nostrService = ref.read(nostrServiceProvider);
+
+    // Persisted per-conversation cursor (spec MUST); default lookback for
+    // conversations with no accepted events yet
+    final cursorSince =
+        await ref.read(disputeChatCursorStoreProvider).sinceFor(disputeId);
+    if (!mounted) return;
+    final since = cursorSince ??
+        DateTime.now().subtract(NostrEventExtensions.chatDefaultLookback);
+
     final request = NostrRequest(
       filters: [
         NostrFilter(
           kinds: [14],
           authors: [chatKeys.sign.public],
-          since: DateTime.now()
-              .subtract(NostrEventExtensions.chatDefaultLookback),
+          since: since,
           limit: NostrEventExtensions.chatDefaultLimit,
         ),
       ],
@@ -234,6 +243,14 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
         session.disputeChatAllowedSigners,
       );
       if (!mounted) return;
+
+      // Advance the persisted since cursor only after the event is accepted
+      // (clamped to the local clock inside the store)
+      unawaited(
+        ref
+            .read(disputeChatCursorStoreProvider)
+            .advance(disputeId, event.createdAt!),
+      );
 
       final messageText = unwrappedEvent.content ?? '';
       if (messageText.isEmpty) {

--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -23,6 +23,7 @@ import 'package:mostro_mobile/features/key_manager/key_derivator.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager.dart';
 import 'package:mostro_mobile/features/key_manager/key_storage.dart';
 import 'package:mostro_mobile/features/notifications/utils/notification_data_extractor.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 import 'package:mostro_mobile/features/notifications/utils/notification_message_mapper.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
@@ -213,18 +214,17 @@ Future<MostroMessage?> _decryptAndProcessEvent(NostrEvent event) async {
 
     final sessions = await _loadSessionsFromDatabase();
 
-    // Try matching by adminSharedKey first (dispute chat DMs).
-    // Require non-null on both sides to prevent spurious null == null matches.
-    final adminSession = sessions.cast<Session?>().firstWhere(
-      (s) {
-        final adminPub = s?.adminSharedKey?.public;
-        return adminPub != null && adminPub == recipient;
-      },
-      orElse: () => null,
-    );
-
-    if (adminSession != null) {
-      return _processAdminDm(event, adminSession);
+    // Dispute chat (kind 14 envelope): the outer author is the K_sign key
+    // derived from the admin shared key, so match by author, not recipient.
+    if (event.kind == 14) {
+      for (final session in sessions) {
+        final adminShared = session.adminSharedKey;
+        if (adminShared == null) continue;
+        final chatKeys = ChatKeys.fromSharedKey(adminShared);
+        if (event.pubkey == chatKeys.sign.public) {
+          return _processAdminDm(event, session, chatKeys);
+        }
+      }
     }
 
     // Standard Mostro message: match by tradeKey
@@ -258,13 +258,17 @@ Future<MostroMessage?> _decryptAndProcessEvent(NostrEvent event) async {
   }
 }
 
-Future<MostroMessage?> _processAdminDm(NostrEvent event, Session session) async {
+Future<MostroMessage?> _processAdminDm(
+  NostrEvent event,
+  Session session,
+  ChatKeys chatKeys,
+) async {
   try {
-    final adminSharedKey = session.adminSharedKey;
-    if (adminSharedKey == null) {
-      return null;
-    }
-    final unwrapped = await event.p2pUnwrap(adminSharedKey);
+    final allowedSigners = [
+      session.tradeKey.public,
+      if (session.adminPubkey != null) session.adminPubkey!,
+    ];
+    final unwrapped = await event.chatUnwrap(chatKeys, allowedSigners);
     if (unwrapped.content == null || unwrapped.content!.isEmpty) {
       return null;
     }

--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -264,11 +264,10 @@ Future<MostroMessage?> _processAdminDm(
   ChatKeys chatKeys,
 ) async {
   try {
-    final allowedSigners = [
-      session.tradeKey.public,
-      if (session.adminPubkey != null) session.adminPubkey!,
-    ];
-    final unwrapped = await event.chatUnwrap(chatKeys, allowedSigners);
+    final unwrapped = await event.chatUnwrap(
+      chatKeys,
+      session.disputeChatAllowedSigners,
+    );
     if (unwrapped.content == null || unwrapped.content!.isEmpty) {
       return null;
     }

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -12,6 +12,7 @@ import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
+import 'package:mostro_mobile/services/dispute_chat_cursor_store.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
@@ -211,16 +212,26 @@ class SubscriptionManager {
       case SubscriptionType.disputeChat:
         // Kind 14 chat envelope: filter by the K_sign authors derived from
         // each admin shared key (never by #p — third-party flooding)
-        final signKeys = sessions
-            .where((s) => s.adminSharedKey != null)
+        final disputeSessions =
+            sessions.where((s) => s.adminSharedKey != null).toList();
+        if (disputeSessions.isEmpty) return null;
+        final signKeys = disputeSessions
             .map((s) => ChatKeys.fromSharedKey(s.adminSharedKey!).sign.public)
             .toList();
-        if (signKeys.isEmpty) return null;
+        // Shared filter across conversations: earliest persisted cursor,
+        // falling back to the default lookback (wider window; dedup absorbs)
+        final cursorStore = ref.read(disputeChatCursorStoreProvider);
+        final defaultSince = DateTime.now()
+            .subtract(NostrEventExtensions.chatDefaultLookback);
+        final since = disputeSessions
+            .map((s) => s.disputeId == null
+                ? defaultSince
+                : (cursorStore.cachedSinceFor(s.disputeId!) ?? defaultSince))
+            .reduce((a, b) => a.isBefore(b) ? a : b);
         return NostrFilter(
           kinds: [14],
           authors: signKeys,
-          since: DateTime.now()
-              .subtract(NostrEventExtensions.chatDefaultLookback),
+          since: since,
           limit: NostrEventExtensions.chatDefaultLimit,
         );
       case SubscriptionType.relayList:

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -14,6 +14,7 @@ import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
 
 /// Manages Nostr subscriptions across different parts of the application.
 ///
@@ -207,14 +208,16 @@ class SubscriptionManager {
               .toList(),
         );
       case SubscriptionType.disputeChat:
-        final adminKeys = sessions
-            .where((s) => s.adminSharedKey?.public != null)
-            .map((s) => s.adminSharedKey!.public)
+        // Kind 14 chat envelope: filter by the K_sign authors derived from
+        // each admin shared key (never by #p — third-party flooding)
+        final signKeys = sessions
+            .where((s) => s.adminSharedKey != null)
+            .map((s) => ChatKeys.fromSharedKey(s.adminSharedKey!).sign.public)
             .toList();
-        if (adminKeys.isEmpty) return null;
+        if (signKeys.isEmpty) return null;
         return NostrFilter(
-          kinds: [1059],
-          p: adminKeys,
+          kinds: [14],
+          authors: signKeys,
         );
       case SubscriptionType.relayList:
         // Relay list subscriptions are handled separately via subscribeToMostroRelayList

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -71,7 +71,7 @@ class SubscriptionManager {
           final sessions = ref.read(sessionNotifierProvider);
           if (sessions.isEmpty) return;
           logger.i('Orders transport changed to $newTransport, re-subscribing');
-          _updateSubscription(SubscriptionType.orders, sessions);
+          unawaited(_updateSubscription(SubscriptionType.orders, sessions));
         },
         onError: (error, stackTrace) {
           logger.e('Error in mostro instance listener',
@@ -140,7 +140,7 @@ class SubscriptionManager {
     }
 
     for (final type in SubscriptionType.values) {
-      _updateSubscription(type, sessions);
+      unawaited(_updateSubscription(type, sessions));
     }
   }
 
@@ -150,7 +150,8 @@ class SubscriptionManager {
     }
   }
 
-  void _updateSubscription(SubscriptionType type, List<Session> sessions) {
+  Future<void> _updateSubscription(
+      SubscriptionType type, List<Session> sessions) async {
     if (sessions.isEmpty) {
       logger.i('No sessions for $type subscription');
       unsubscribeByType(type);
@@ -158,6 +159,17 @@ class SubscriptionManager {
     }
 
     try {
+      // Pre-warm persisted cursors so the dispute chat filter — built
+      // synchronously and later persisted for the background service —
+      // sees durable state even on a cold start
+      if (type == SubscriptionType.disputeChat) {
+        final disputeIds = sessions
+            .where((s) => s.adminSharedKey != null)
+            .map((s) => s.disputeId)
+            .whereType<String>();
+        await ref.read(disputeChatCursorStoreProvider).warmUp(disputeIds);
+      }
+
       final filter = _createFilterForType(type, sessions);
       if (filter == null) {
         return;

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/core/models/relay_list_event.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/mostro/transport.dart';
@@ -218,6 +219,9 @@ class SubscriptionManager {
         return NostrFilter(
           kinds: [14],
           authors: signKeys,
+          since: DateTime.now()
+              .subtract(NostrEventExtensions.chatDefaultLookback),
+          limit: NostrEventExtensions.chatDefaultLimit,
         );
       case SubscriptionType.relayList:
         // Relay list subscriptions are handled separately via subscribeToMostroRelayList

--- a/lib/services/dispute_chat_cursor_store.dart
+++ b/lib/services/dispute_chat_cursor_store.dart
@@ -20,6 +20,10 @@ class DisputeChatCursorStore {
   final SharedPreferencesAsync _prefs;
   final Map<String, DateTime> _cache = {};
 
+  /// Per-dispute chain serializing advance() so concurrent calls cannot
+  /// interleave their read-compare-write and regress the cursor.
+  final Map<String, Future<void>> _advanceQueue = {};
+
   DisputeChatCursorStore(this._prefs);
 
   /// Clamp an accepted event timestamp to the local clock.
@@ -46,14 +50,35 @@ class DisputeChatCursorStore {
   }
 
   /// Synchronous variant for call sites that build filters synchronously.
-  /// Returns null when the cursor is not in memory yet — falling back to
-  /// the default lookback is wider, so no events are missed.
+  /// Returns null when the cursor is not in memory yet — call [warmUp]
+  /// first so persisted cursors are visible after a cold start.
   DateTime? cachedSinceFor(String disputeId) =>
       _cache[disputeId]?.subtract(cursorOverlap);
 
+  /// Load the persisted cursors for the given conversations into the
+  /// in-memory cache, so synchronous filter builders see durable state.
+  Future<void> warmUp(Iterable<String> disputeIds) async {
+    for (final disputeId in disputeIds) {
+      await cursorFor(disputeId);
+    }
+  }
+
   /// Advance the cursor after an accepted event. Monotonic (never moves
-  /// backward) and clamped to the local clock.
+  /// backward), clamped to the local clock, and serialized per dispute.
   Future<void> advance(
+    String disputeId,
+    DateTime accepted, {
+    DateTime? now,
+  }) {
+    final previous = _advanceQueue[disputeId] ?? Future.value();
+    final next = previous
+        .catchError((_) {})
+        .then((_) => _advanceSerialized(disputeId, accepted, now: now));
+    _advanceQueue[disputeId] = next;
+    return next;
+  }
+
+  Future<void> _advanceSerialized(
     String disputeId,
     DateTime accepted, {
     DateTime? now,

--- a/lib/services/dispute_chat_cursor_store.dart
+++ b/lib/services/dispute_chat_cursor_store.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists the per-conversation `since` cursor for dispute chat
+/// subscriptions, as the chat spec requires: "subscribe with `since` set to
+/// the last processed timestamp, persisted locally, together with a limit".
+///
+/// The cursor advances only after chatUnwrap accepts an event, clamped to
+/// min(accepted_timestamp, local_now) so a future-dated event cannot
+/// suppress later messages. Subscriptions subtract [cursorOverlap] so an
+/// event late-delivered by a slow relay is not filtered out forever;
+/// outer-id dedup absorbs the re-delivered tail.
+class DisputeChatCursorStore {
+  static const _keyPrefix = 'dispute_chat_since_';
+
+  /// Overlap window subtracted from the cursor when subscribing.
+  static const cursorOverlap = Duration(minutes: 10);
+
+  final SharedPreferencesAsync _prefs;
+  final Map<String, DateTime> _cache = {};
+
+  DisputeChatCursorStore(this._prefs);
+
+  /// Clamp an accepted event timestamp to the local clock.
+  static DateTime clamp(DateTime accepted, DateTime now) =>
+      accepted.isAfter(now) ? now : accepted;
+
+  /// Last processed timestamp for a conversation, or null if none stored.
+  Future<DateTime?> cursorFor(String disputeId) async {
+    final cached = _cache[disputeId];
+    if (cached != null) return cached;
+    final secs = await _prefs.getInt('$_keyPrefix$disputeId');
+    if (secs == null) return null;
+    final cursor = DateTime.fromMillisecondsSinceEpoch(secs * 1000);
+    _cache[disputeId] = cursor;
+    return cursor;
+  }
+
+  /// Subscription `since` for a conversation: the cursor minus the overlap
+  /// window, or null when no cursor is stored yet (callers fall back to the
+  /// default lookback).
+  Future<DateTime?> sinceFor(String disputeId) async {
+    final cursor = await cursorFor(disputeId);
+    return cursor?.subtract(cursorOverlap);
+  }
+
+  /// Synchronous variant for call sites that build filters synchronously.
+  /// Returns null when the cursor is not in memory yet — falling back to
+  /// the default lookback is wider, so no events are missed.
+  DateTime? cachedSinceFor(String disputeId) =>
+      _cache[disputeId]?.subtract(cursorOverlap);
+
+  /// Advance the cursor after an accepted event. Monotonic (never moves
+  /// backward) and clamped to the local clock.
+  Future<void> advance(
+    String disputeId,
+    DateTime accepted, {
+    DateTime? now,
+  }) async {
+    final clamped = clamp(accepted, now ?? DateTime.now());
+    final current = await cursorFor(disputeId);
+    if (current != null && !clamped.isAfter(current)) return;
+    _cache[disputeId] = clamped;
+    await _prefs.setInt(
+      '$_keyPrefix$disputeId',
+      clamped.millisecondsSinceEpoch ~/ 1000,
+    );
+  }
+}
+
+final disputeChatCursorStoreProvider = Provider<DisputeChatCursorStore>(
+  (ref) => DisputeChatCursorStore(ref.watch(sharedPreferencesProvider)),
+);

--- a/lib/shared/utils/chat_keys.dart
+++ b/lib/shared/utils/chat_keys.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:dart_nostr/dart_nostr.dart';
+
+/// Domain-separated key pair for the Mostro chat envelope (kind 14).
+///
+/// Derived from the 32-byte ECDH shared secret between the two chat parties
+/// (trade key <-> admin key for dispute chat, trade key <-> trade key for
+/// peer chat) via HKDF-SHA256:
+///
+/// - [conv] (`K_conv`): NIP-44 encryption key; its pubkey is the outer `p` tag
+/// - [sign] (`K_sign`): signs the outer kind 14 event; its pubkey is the
+///   relay `authors` subscription filter
+///
+/// Spec: https://mostro.network/protocol/chat.html#key-derivation
+class ChatKeys {
+  /// HKDF info for `K_conv`. Changing this value changes the wire format.
+  static const convInfo = 'mostro:chat:conv:v1';
+
+  /// HKDF info for `K_sign`. Changing this value changes the wire format.
+  static const signInfo = 'mostro:chat:sign:v1';
+
+  final NostrKeyPairs conv;
+  final NostrKeyPairs sign;
+
+  const ChatKeys({required this.conv, required this.sign});
+
+  /// Derive `(K_conv, K_sign)` from an ECDH shared key pair such as
+  /// `session.adminSharedKey`, whose private key is the hex-encoded
+  /// 32-byte ECDH output.
+  factory ChatKeys.fromSharedKey(NostrKeyPairs sharedKey) {
+    return ChatKeys.fromSharedSecret(
+      Uint8List.fromList(hex.decode(sharedKey.private)),
+    );
+  }
+
+  /// Derive `(K_conv, K_sign)` from the raw 32-byte ECDH shared secret.
+  factory ChatKeys.fromSharedSecret(Uint8List sharedSecret) {
+    if (sharedSecret.length != 32) {
+      throw ArgumentError(
+        'Chat shared secret must be 32 bytes, got ${sharedSecret.length}',
+      );
+    }
+
+    // HKDF-extract with an absent salt (RFC 5869: zero-filled, hash length)
+    final prk = Hmac(sha256, List.filled(32, 0)).convert(sharedSecret).bytes;
+
+    return ChatKeys(
+      conv: _deriveKey(prk, convInfo),
+      sign: _deriveKey(prk, signInfo),
+    );
+  }
+
+  /// HKDF-expand a single 32-byte block and interpret it as a secp256k1
+  /// secret key. On the negligible chance the output is not a valid key,
+  /// retry with a counter byte appended to the info (spec requirement).
+  static NostrKeyPairs _deriveKey(List<int> prk, String info) {
+    final base = utf8.encode(info);
+    for (var counter = 0; counter <= 255; counter++) {
+      final labelled = counter == 0 ? base : [...base, counter];
+      final okm = Hmac(sha256, prk).convert([...labelled, 0x01]).bytes;
+      try {
+        return NostrKeyPairs(private: hex.encode(okm));
+      } catch (_) {
+        continue;
+      }
+    }
+    throw StateError('HKDF failed to produce a valid secret key for $info');
+  }
+}

--- a/test/data/models/nostr_event_chat_test.dart
+++ b/test/data/models/nostr_event_chat_test.dart
@@ -236,6 +236,32 @@ void main() {
       );
     });
 
+    test('rejects an inner payload missing required fields as Exception',
+        () async {
+      final encrypted = await NostrUtils.encryptNIP44(
+        '{"kind": 1, "content": "no id, sig, pubkey or tags"}',
+        chatKeys.conv.private,
+        chatKeys.conv.public,
+      );
+      final wrapped = NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: chatKeys.sign,
+        tags: [
+          ["p", chatKeys.conv.public],
+        ],
+      );
+
+      await expectLater(
+        wrapped.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(
+          predicate((e) =>
+              e is Exception &&
+              e.toString().contains('Malformed inner chat event')),
+        ),
+      );
+    });
+
     test('rejects an inner event signed by a non-party key', () async {
       final inner = buildInner(stranger, 'not a party');
       final wrapped = await inner.chatWrap(chatKeys);

--- a/test/data/models/nostr_event_chat_test.dart
+++ b/test/data/models/nostr_event_chat_test.dart
@@ -1,0 +1,300 @@
+import 'dart:convert';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+void main() {
+  // Keys from the official chat test vector plus a stranger key
+  const alicePrivate =
+      '548f68890c49fa42f104c60352395e60ff030b0b407e955f1eed1400d6c0347a';
+  const bobPrivate =
+      'f258e73f07386d37133718b6127f873dd7c391b8f43b331ff8254034a13d2943';
+
+  final alice = NostrKeyPairs(private: alicePrivate);
+  final bob = NostrKeyPairs(private: bobPrivate);
+  final stranger = NostrUtils.generateKeyPair();
+
+  final chatKeys = ChatKeys.fromSharedKey(
+    NostrUtils.computeSharedKey(alicePrivate, bob.public),
+  );
+  final allowedSigners = [alice.public, bob.public];
+
+  NostrEvent buildInner(
+    NostrKeyPairs sender,
+    String text, {
+    DateTime? createdAt,
+    int kind = 1,
+  }) {
+    return NostrEvent.fromPartialData(
+      keyPairs: sender,
+      content: text,
+      kind: kind,
+      createdAt: createdAt,
+    );
+  }
+
+  group('chatWrap', () {
+    test('produces a kind 14 envelope with the expected shape', () async {
+      final inner = buildInner(alice, 'hello from the test');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      expect(wrapped.kind, equals(14));
+      expect(wrapped.pubkey, equals(chatKeys.sign.public));
+
+      final pTags = wrapped.tags!.where((t) => t[0] == 'p').toList();
+      expect(pTags.length, equals(1));
+      expect(pTags[0][1], equals(chatKeys.conv.public));
+
+      // Inner and outer must share the same timestamp (replay defense)
+      expect(
+        wrapped.createdAt!.millisecondsSinceEpoch ~/ 1000,
+        equals(inner.createdAt!.millisecondsSinceEpoch ~/ 1000),
+      );
+    });
+
+    test('rejects a non kind 1 inner event', () async {
+      final inner = buildInner(alice, 'wrong kind', kind: 5);
+      expect(() => inner.chatWrap(chatKeys), throwsArgumentError);
+    });
+  });
+
+  group('chatUnwrap round-trip', () {
+    test('preserves content, sender and inner event id', () async {
+      final inner = buildInner(alice, 'hello admin, I need help');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      final unwrapped = await wrapped.chatUnwrap(chatKeys, allowedSigners);
+
+      expect(unwrapped.content, equals('hello admin, I need help'));
+      expect(unwrapped.pubkey, equals(alice.public));
+      expect(unwrapped.kind, equals(1));
+      expect(unwrapped.id, equals(inner.id));
+    });
+
+    test('works in both directions with the same derived keys', () async {
+      final bobChatKeys = ChatKeys.fromSharedKey(
+        NostrUtils.computeSharedKey(bobPrivate, alice.public),
+      );
+      final inner = buildInner(bob, 'reply from the admin');
+      final wrapped = await inner.chatWrap(bobChatKeys);
+
+      final unwrapped = await wrapped.chatUnwrap(chatKeys, allowedSigners);
+
+      expect(unwrapped.content, equals('reply from the admin'));
+      expect(unwrapped.pubkey, equals(bob.public));
+    });
+  });
+
+  group('chatUnwrap rejections', () {
+    test('rejects an outer event not authored by K_sign', () async {
+      final inner = buildInner(alice, 'forged author');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      final forged = NostrEvent.fromPartialData(
+        kind: 14,
+        content: wrapped.content!,
+        keyPairs: stranger,
+        tags: wrapped.tags,
+        createdAt: wrapped.createdAt,
+      );
+
+      await expectLater(
+        forged.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('rejects a wrong outer kind', () async {
+      final inner = buildInner(alice, 'wrong outer kind');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      final wrongKind = NostrEvent.fromPartialData(
+        kind: 1059,
+        content: wrapped.content!,
+        keyPairs: chatKeys.sign,
+        tags: wrapped.tags,
+        createdAt: wrapped.createdAt,
+      );
+
+      await expectLater(
+        wrongKind.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('rejects an outer event with extra p tags', () async {
+      final inner = buildInner(alice, 'extra p tag');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      final extraTag = NostrEvent.fromPartialData(
+        kind: 14,
+        content: wrapped.content!,
+        keyPairs: chatKeys.sign,
+        tags: [
+          ["p", chatKeys.conv.public],
+          ["p", stranger.public],
+        ],
+        createdAt: wrapped.createdAt,
+      );
+
+      await expectLater(
+        extraTag.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('rejects an outer event dated too far in the future', () async {
+      final inner = buildInner(alice, 'from the future');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      await expectLater(
+        wrapped.chatUnwrap(
+          chatKeys,
+          allowedSigners,
+          now: wrapped.createdAt!.subtract(const Duration(seconds: 120)),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('rejects an oversized payload before decrypting', () async {
+      final oversized = NostrEvent.fromPartialData(
+        kind: 14,
+        content: 'x' * (NostrEventExtensions.chatMaxContentBytes + 1),
+        keyPairs: chatKeys.sign,
+        tags: [
+          ["p", chatKeys.conv.public],
+        ],
+      );
+
+      await expectLater(
+        oversized.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(
+          predicate((e) => e.toString().contains('exceeds the accepted size')),
+        ),
+      );
+    });
+
+    test('rejects a tampered outer event (id no longer matches)', () async {
+      final inner = buildInner(alice, 'tamper the outer');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      final reEncrypted = await NostrUtils.encryptNIP44(
+        jsonEncode(buildInner(alice, 'swapped payload').toMap()),
+        chatKeys.conv.private,
+        chatKeys.conv.public,
+      );
+      final tampered = NostrEvent(
+        id: wrapped.id,
+        kind: wrapped.kind,
+        content: reEncrypted,
+        sig: wrapped.sig,
+        pubkey: wrapped.pubkey,
+        createdAt: wrapped.createdAt,
+        tags: wrapped.tags,
+      );
+
+      await expectLater(
+        tampered.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(predicate((e) => e.toString().contains('does not match'))),
+      );
+    });
+
+    test('rejects a tampered inner event (id no longer matches)', () async {
+      final inner = buildInner(alice, 'original text');
+      final tamperedInner = NostrEvent(
+        id: inner.id,
+        kind: inner.kind,
+        content: 'tampered text',
+        sig: inner.sig,
+        pubkey: inner.pubkey,
+        createdAt: inner.createdAt,
+        tags: inner.tags,
+      );
+
+      final encrypted = await NostrUtils.encryptNIP44(
+        jsonEncode(tamperedInner.toMap()),
+        chatKeys.conv.private,
+        chatKeys.conv.public,
+      );
+      final wrapped = NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: chatKeys.sign,
+        tags: [
+          ["p", chatKeys.conv.public],
+        ],
+        createdAt: inner.createdAt,
+      );
+
+      await expectLater(
+        wrapped.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(predicate((e) => e.toString().contains('does not match'))),
+      );
+    });
+
+    test('rejects an inner event signed by a non-party key', () async {
+      final inner = buildInner(stranger, 'not a party');
+      final wrapped = await inner.chatWrap(chatKeys);
+
+      await expectLater(
+        wrapped.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(predicate((e) => e.toString().contains('not a party'))),
+      );
+    });
+
+    test('rejects a non kind 1 inner event', () async {
+      final inner = buildInner(alice, 'wrong inner kind', kind: 5);
+      final encrypted = await NostrUtils.encryptNIP44(
+        jsonEncode(inner.toMap()),
+        chatKeys.conv.private,
+        chatKeys.conv.public,
+      );
+      final wrapped = NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: chatKeys.sign,
+        tags: [
+          ["p", chatKeys.conv.public],
+        ],
+        createdAt: inner.createdAt,
+      );
+
+      await expectLater(
+        wrapped.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(predicate((e) => e.toString().contains('kind 1'))),
+      );
+    });
+
+    test('rejects a stale re-wrap (timestamps disagree)', () async {
+      final staleInner = buildInner(
+        alice,
+        'stale message',
+        createdAt: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      final encrypted = await NostrUtils.encryptNIP44(
+        jsonEncode(staleInner.toMap()),
+        chatKeys.conv.private,
+        chatKeys.conv.public,
+      );
+      final reWrapped = NostrEvent.fromPartialData(
+        kind: 14,
+        content: encrypted,
+        keyPairs: chatKeys.sign,
+        tags: [
+          ["p", chatKeys.conv.public],
+        ],
+      );
+
+      await expectLater(
+        reWrapped.chatUnwrap(chatKeys, allowedSigners),
+        throwsA(
+          predicate((e) => e.toString().contains('timestamps disagree')),
+        ),
+      );
+    });
+  });
+}

--- a/test/features/disputes/dispute_chat_cursor_store_test.dart
+++ b/test/features/disputes/dispute_chat_cursor_store_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/services/dispute_chat_cursor_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Minimal in-memory double for the two methods the store uses.
+class _FakeSharedPreferencesAsync implements SharedPreferencesAsync {
+  final Map<String, int> ints = {};
+
+  @override
+  Future<int?> getInt(String key) async => ints[key];
+
+  @override
+  Future<void> setInt(String key, int value) async {
+    ints[key] = value;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+void main() {
+  late _FakeSharedPreferencesAsync prefs;
+  late DisputeChatCursorStore store;
+
+  const disputeId = 'dispute-123';
+  final now = DateTime.fromMillisecondsSinceEpoch(1755000000 * 1000);
+
+  setUp(() {
+    prefs = _FakeSharedPreferencesAsync();
+    store = DisputeChatCursorStore(prefs);
+  });
+
+  group('DisputeChatCursorStore', () {
+    test('returns null cursor and since for an unknown conversation',
+        () async {
+      expect(await store.cursorFor(disputeId), isNull);
+      expect(await store.sinceFor(disputeId), isNull);
+      expect(store.cachedSinceFor(disputeId), isNull);
+    });
+
+    test('advance persists the accepted timestamp', () async {
+      final accepted = now.subtract(const Duration(minutes: 5));
+      await store.advance(disputeId, accepted, now: now);
+
+      expect(await store.cursorFor(disputeId), equals(accepted));
+      expect(
+        await store.sinceFor(disputeId),
+        equals(accepted.subtract(DisputeChatCursorStore.cursorOverlap)),
+      );
+      expect(prefs.ints, isNotEmpty);
+    });
+
+    test('advance clamps a future-dated timestamp to the local clock',
+        () async {
+      final farFuture = now.add(const Duration(days: 30));
+      await store.advance(disputeId, farFuture, now: now);
+
+      expect(await store.cursorFor(disputeId), equals(now));
+    });
+
+    test('advance is monotonic and never moves the cursor backward',
+        () async {
+      final newer = now.subtract(const Duration(minutes: 1));
+      final older = now.subtract(const Duration(hours: 2));
+
+      await store.advance(disputeId, newer, now: now);
+      await store.advance(disputeId, older, now: now);
+
+      expect(await store.cursorFor(disputeId), equals(newer));
+    });
+
+    test('cursor survives a new store instance (persistence)', () async {
+      final accepted = now.subtract(const Duration(minutes: 5));
+      await store.advance(disputeId, accepted, now: now);
+
+      final freshStore = DisputeChatCursorStore(prefs);
+      final restored = await freshStore.cursorFor(disputeId);
+
+      // Stored with second precision
+      expect(
+        restored!.millisecondsSinceEpoch ~/ 1000,
+        equals(accepted.millisecondsSinceEpoch ~/ 1000),
+      );
+    });
+
+    test('cachedSinceFor is available after loading or advancing', () async {
+      final accepted = now.subtract(const Duration(minutes: 5));
+      await store.advance(disputeId, accepted, now: now);
+
+      expect(
+        store.cachedSinceFor(disputeId),
+        equals(accepted.subtract(DisputeChatCursorStore.cursorOverlap)),
+      );
+    });
+
+    test('conversations track independent cursors', () async {
+      final a = now.subtract(const Duration(minutes: 5));
+      final b = now.subtract(const Duration(hours: 3));
+      await store.advance('dispute-a', a, now: now);
+      await store.advance('dispute-b', b, now: now);
+
+      expect(await store.cursorFor('dispute-a'), equals(a));
+      expect(await store.cursorFor('dispute-b'), equals(b));
+    });
+
+    test('clamp is a pure min against the local clock', () {
+      final past = now.subtract(const Duration(seconds: 1));
+      final future = now.add(const Duration(seconds: 1));
+      expect(DisputeChatCursorStore.clamp(past, now), equals(past));
+      expect(DisputeChatCursorStore.clamp(future, now), equals(now));
+      expect(DisputeChatCursorStore.clamp(now, now), equals(now));
+    });
+  });
+}

--- a/test/features/disputes/dispute_chat_cursor_store_test.dart
+++ b/test/features/disputes/dispute_chat_cursor_store_test.dart
@@ -94,6 +94,45 @@ void main() {
       );
     });
 
+    test('concurrent out-of-order advances keep the newer timestamp',
+        () async {
+      final newer = now.subtract(const Duration(minutes: 1));
+      final older = now.subtract(const Duration(hours: 2));
+
+      // Both calls start before either completes; serialization must
+      // prevent the older timestamp from overwriting the newer one
+      await Future.wait([
+        store.advance(disputeId, newer, now: now),
+        store.advance(disputeId, older, now: now),
+      ]);
+
+      expect(await store.cursorFor(disputeId), equals(newer));
+      expect(store.cachedSinceFor(disputeId),
+          equals(newer.subtract(DisputeChatCursorStore.cursorOverlap)));
+    });
+
+    test('warmUp loads persisted cursors into a cold cache', () async {
+      final accepted = now.subtract(const Duration(minutes: 5));
+      await store.advance(disputeId, accepted, now: now);
+
+      // Fresh instance simulates a cold start: cache empty, prefs populated
+      final coldStore = DisputeChatCursorStore(prefs);
+      expect(coldStore.cachedSinceFor(disputeId), isNull);
+
+      await coldStore.warmUp([disputeId, 'unknown-dispute']);
+
+      final since = coldStore.cachedSinceFor(disputeId);
+      expect(since, isNotNull);
+      expect(
+        since!.millisecondsSinceEpoch ~/ 1000,
+        equals(accepted
+            .subtract(DisputeChatCursorStore.cursorOverlap)
+            .millisecondsSinceEpoch ~/
+            1000),
+      );
+      expect(coldStore.cachedSinceFor('unknown-dispute'), isNull);
+    });
+
     test('conversations track independent cursors', () async {
       final a = now.subtract(const Duration(minutes: 5));
       final b = now.subtract(const Duration(hours: 3));

--- a/test/features/subscriptions/subscription_manager_initialization_test.dart
+++ b/test/features/subscriptions/subscription_manager_initialization_test.dart
@@ -81,7 +81,7 @@ void main() {
         reason: 'Comment explaining the relay preservation fix must exist');
       
       // Verify proper sequence: filter check happens before unsubscribe within the method
-      final updateMethodIndex = content.indexOf('void _updateSubscription(SubscriptionType type, List<Session> sessions)');
+      final updateMethodIndex = content.indexOf('Future<void> _updateSubscription(');
       final filterCheckIndex = content.indexOf('if (filter == null)', updateMethodIndex);
       final unsubscribeAfterCheckIndex = content.indexOf('unsubscribeByType(type);', filterCheckIndex);
       

--- a/test/shared/utils/chat_keys_test.dart
+++ b/test/shared/utils/chat_keys_test.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+void main() {
+  group('ChatKeys derivation', () {
+    // Official test vector: https://mostro.network/protocol/chat.html#test-vector
+    const alicePrivate =
+        '548f68890c49fa42f104c60352395e60ff030b0b407e955f1eed1400d6c0347a';
+    const bobPrivate =
+        'f258e73f07386d37133718b6127f873dd7c391b8f43b331ff8254034a13d2943';
+    const expectedAlicePublic =
+        '000053c3b4773182e7c4c1b72b272d34be01bf4414a6a25c998977c516a46a01';
+    const expectedBobPublic =
+        '000009ae5cff9f6ba9b05159ec5ed58c187f5882ea77c81ed5dd19163272a5d7';
+    const expectedSharedSecret =
+        'def6633a53d07d1e829484c4d4bdbbeed2f4b14c21743e63871c174338e39475';
+    const expectedConvPublic =
+        'bceb1cd2a8e98ee9729122a1693edcc39c3ace04582ff96a26705c5e4078a6f2';
+    const expectedSignPublic =
+        '1dba04571059183f76b148119cfa6f8004dad30cb4e810180a6df17386a7f0b4';
+
+    test('reproduces the official protocol test vector', () {
+      final alice = NostrKeyPairs(private: alicePrivate);
+      final bob = NostrKeyPairs(private: bobPrivate);
+      expect(alice.public, equals(expectedAlicePublic));
+      expect(bob.public, equals(expectedBobPublic));
+
+      final shared = NostrUtils.computeSharedKey(alicePrivate, bob.public);
+      expect(shared.private, equals(expectedSharedSecret));
+
+      final chatKeys = ChatKeys.fromSharedKey(shared);
+      expect(chatKeys.conv.public, equals(expectedConvPublic));
+      expect(chatKeys.sign.public, equals(expectedSignPublic));
+    });
+
+    test('both parties derive the same chat keys', () {
+      final alice = NostrUtils.generateKeyPair();
+      final bob = NostrUtils.generateKeyPair();
+
+      final aliceChatKeys = ChatKeys.fromSharedKey(
+        NostrUtils.computeSharedKey(alice.private, bob.public),
+      );
+      final bobChatKeys = ChatKeys.fromSharedKey(
+        NostrUtils.computeSharedKey(bob.private, alice.public),
+      );
+
+      expect(aliceChatKeys.conv.public, equals(bobChatKeys.conv.public));
+      expect(aliceChatKeys.sign.public, equals(bobChatKeys.sign.public));
+    });
+
+    test('K_conv and K_sign are distinct', () {
+      final alice = NostrUtils.generateKeyPair();
+      final bob = NostrUtils.generateKeyPair();
+
+      final chatKeys = ChatKeys.fromSharedKey(
+        NostrUtils.computeSharedKey(alice.private, bob.public),
+      );
+
+      expect(chatKeys.conv.private, isNot(equals(chatKeys.sign.private)));
+      expect(chatKeys.conv.public, isNot(equals(chatKeys.sign.public)));
+    });
+
+    test('different counterparties produce different chat keys', () {
+      final admin = NostrUtils.generateKeyPair();
+      final buyer = NostrUtils.generateKeyPair();
+      final seller = NostrUtils.generateKeyPair();
+
+      final buyerChatKeys = ChatKeys.fromSharedKey(
+        NostrUtils.computeSharedKey(admin.private, buyer.public),
+      );
+      final sellerChatKeys = ChatKeys.fromSharedKey(
+        NostrUtils.computeSharedKey(admin.private, seller.public),
+      );
+
+      expect(
+        buyerChatKeys.conv.public,
+        isNot(equals(sellerChatKeys.conv.public)),
+      );
+      expect(
+        buyerChatKeys.sign.public,
+        isNot(equals(sellerChatKeys.sign.public)),
+      );
+    });
+
+    test('rejects a shared secret that is not 32 bytes', () {
+      expect(
+        () => ChatKeys.fromSharedSecret(Uint8List(16)),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Migrates the user↔admin dispute chat from the legacy 1-layer gift wrap (kind 1059
addressed to the ECDH shared pubkey) to the Mostro chat kind-14 envelope defined in the
[protocol chat spec](https://mostro.network/protocol/chat.html).

This is required for interoperability: mostrix (the admin client) already sends dispute
chat messages **only** as kind-14 envelopes, so mobile users currently cannot receive
messages from admins during disputes. With this PR, both directions work again.

## What changed

**Envelope primitives** (`chat_keys.dart`, `nostr_event.dart`)
- `ChatKeys`: HKDF-SHA256 derivation of `(K_conv, K_sign)` from the existing ECDH shared
  secret (`session.adminSharedKey`, unchanged), with domain separation
  (`mostro:chat:conv:v1` / `mostro:chat:sign:v1`) and the spec's counter-byte retry.
- `chatWrap` / `chatUnwrap` extensions: inner kind 1 signed by the trade key → NIP-44
  self-encryption under `K_conv` → outer kind 14 signed by `K_sign` with a single `p` tag
  = `pub(K_conv)` and the same timestamp as the inner event. Unwrap runs the mandatory
  spec checks cheapest-first, recomputing event ids in addition to verifying BIP-340
  signatures.

**Consumers migrated atomically**
- `DisputeChatNotifier`: subscribes by `kinds:[14], authors:[pub(K_sign)]` (the spec
  forbids `#p` filtering — flood resistance), sends via `chatWrap`, authenticates incoming
  messages against the conversation allowlist (trade key + admin pubkey). Dispute history
  stored on disk before the migration (kind-1059 gift wraps) remains readable via a legacy
  branch in `_loadHistoricalMessages()`.
- `SubscriptionManager`: `disputeChat` filter now derives `pub(K_sign)` per session; the
  background service reuses these filters automatically.
- `BackgroundNotificationService`: kind-14 dispute chat events are routed by author ==
  `pub(K_sign)` before trade-key matching, so push notifications keep working. No
  collision with transport-v2 protocol messages (also kind 14): those are authored by the
  Mostro pubkey and matched separately.

**Out of scope (intentionally unchanged)**
- P2P buyer↔seller chat stays on the legacy gift wrap; its migration is future work and
  should reuse these same primitives.
- Multimedia attachments: encryption keys off the raw ECDH secret, not `K_conv`/`K_sign`,
  so Blossom attachments remain compatible.

## Documentation

- New `docs/architecture/DISPUTE_CHAT_KIND14.md`: key derivation, wire format,
  subscription and validation rules, implementation map, migration notes.
- Updated `NOSTR.md`, `DISPUTE_CHAT_RESTORE.md`, `DISPUTE_CHAT_MULTIMEDIA_PLAN.md` and
  `P2P_CHAT_SYSTEM.md` accordingly.

## Testing

- 19 new unit tests, including the [official protocol test vector](https://mostro.network/protocol/chat.html#test-vector)
  for the key derivation (proves byte-level interop with `mostro_core::chat`), both-way
  wrap/unwrap round-trips, and every envelope rejection path (forged author, extra `p`
  tags, future-dated events, oversized payloads, tampered inner/outer events, non-party
  signers, stale re-wraps).
- `flutter analyze` clean; full test suite passes (the only local failures are the known
  stale-mocks loading errors, regenerated in CI).
- Manual QA pending: live dispute against an admin running current mostrix, both
  directions, plus a background push notification check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a more secure dispute-chat protocol using encrypted, authenticated message envelopes.
  - Added key derivation for conversation encryption and message signing.
  - Added validation for authenticity, recipients, timestamps, size limits, and authorized senders.
  - Preserved compatibility with existing chat history and multimedia attachments.
  - Improved notifications, subscriptions, deduplication, and message restoration.

- **Documentation**
  - Updated architecture documentation covering encryption, migration, restore behavior, and chat compatibility.

- **Tests**
  - Added comprehensive coverage for encryption, key derivation, validation, tampering, authorization, persistence, and protocol vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->