### PR TITLE
Add BBVA and QR Santander payment methods for EUR

### DIFF
--- a/assets/data/payment_methods.json
+++ b/assets/data/payment_methods.json
@@ -9,7 +9,7 @@
   "CRC": ["Bank transfer (IBAN)", "SINPE Móvil", "Cash"],
   "COP": ["Nequi", "Daviplata", "PSE", "Llaves BRE-B", "Transferencia bancaria", "Efectivo"],
   "CUP": ["Transfermovil", "EnZona", "Tarjeta Clásica", "Saldo móvil", "MiTransfer", "Efectivo"],
-  "EUR": ["Revolut", "HalCash", "Bank Transfer", "Wise", "SEPA instant", "Bizum", "Payoneer", "Cash"],
+  "EUR": ["Revolut", "HalCash", "Bank Transfer", "Wise", "SEPA instant", "Bizum", "Payoneer", "Cash", "BBVA Efectivo Móvil", "QR Santander"],
   "GBP": ["Revolut", "Monzo", "Wise", "Any national bank", "Bank Transfer", "Cash"],
   "JPY": ["PayPay", "Bank Transfer", "Cash"],
   "KES": ["M-PESA", "Equity Bank", "NCBA Bank", "Airtel Money", "Co-operative Bank", "Standard Chartered", "Ecobank", "GTBank", "Pochi la Biashara", "Cash"],


### PR DESCRIPTION
## Summary
- Add BBVA Efectivo Móvil payment method for EUR
- Add QR Santander payment method for EUR

## Test plan
- Verify new payment methods appear in EUR payment method list
- Confirm order flow works with these new methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BBVA Efectivo Móvil and QR Santander as available EUR payment methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->