### PR TITLE
fix: add value equality to Order

### DIFF
--- a/lib/data/models/order.dart
+++ b/lib/data/models/order.dart
@@ -268,4 +268,48 @@ class Order implements Payload {
       createdAt: createdAt,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Order &&
+        other.id == id &&
+        other.kind == kind &&
+        other.status == status &&
+        other.amount == amount &&
+        other.fiatCode == fiatCode &&
+        other.minAmount == minAmount &&
+        other.maxAmount == maxAmount &&
+        other.fiatAmount == fiatAmount &&
+        other.paymentMethod == paymentMethod &&
+        other.premium == premium &&
+        other.masterBuyerPubkey == masterBuyerPubkey &&
+        other.masterSellerPubkey == masterSellerPubkey &&
+        other.buyerTradePubkey == buyerTradePubkey &&
+        other.sellerTradePubkey == sellerTradePubkey &&
+        other.buyerInvoice == buyerInvoice &&
+        other.createdAt == createdAt &&
+        other.expiresAt == expiresAt;
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        id,
+        kind,
+        status,
+        amount,
+        fiatCode,
+        minAmount,
+        maxAmount,
+        fiatAmount,
+        paymentMethod,
+        premium,
+        masterBuyerPubkey,
+        masterSellerPubkey,
+        buyerTradePubkey,
+        sellerTradePubkey,
+        buyerInvoice,
+        createdAt,
+        expiresAt,
+      ]);
 }

--- a/test/data/models/dispute_equality_test.dart
+++ b/test/data/models/dispute_equality_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/dispute.dart';
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/data/models/enums/status.dart';
+import 'package:mostro_mobile/data/models/order.dart';
+
+void main() {
+  Order order({Status status = Status.dispute}) => Order(
+        id: 'order-1',
+        kind: OrderType.sell,
+        status: status,
+        amount: 50000,
+        fiatCode: 'USD',
+        fiatAmount: 100,
+        paymentMethod: 'Wire transfer',
+        createdAt: 1700000000,
+        expiresAt: 1700003600,
+      );
+
+  Dispute dispute({Order? attached}) => Dispute(
+        disputeId: 'dispute-1',
+        orderId: 'order-1',
+        status: 'initiated',
+        order: attached,
+        adminPubkey: 'admin-pubkey',
+        adminTookAt: DateTime.utc(2026, 1, 1),
+        createdAt: DateTime.utc(2025, 12, 31),
+        action: 'dispute-initiated-by-you',
+      );
+
+  group('Dispute value equality with an attached order', () {
+    test('disputes holding equal-but-distinct orders are equal', () {
+      expect(dispute(attached: order()), equals(dispute(attached: order())));
+      expect(
+        dispute(attached: order()).hashCode,
+        equals(dispute(attached: order()).hashCode),
+      );
+    });
+
+    test('disputes holding different orders are not equal', () {
+      expect(
+        dispute(attached: order()),
+        isNot(equals(
+          dispute(attached: order(status: Status.settledHoldInvoice)),
+        )),
+      );
+    });
+
+    test('an attached order is not equal to no order at all', () {
+      expect(dispute(attached: order()), isNot(equals(dispute())));
+    });
+  });
+}

--- a/test/features/order/models/order_state_test.dart
+++ b/test/features/order/models/order_state_test.dart
@@ -108,12 +108,12 @@ void main() {
       expect(build().hashCode, build().hashCode);
     });
 
-    // `Order` declares no `==`/`hashCode`, so two structurally identical
-    // orders are different values and the surrounding states compare unequal.
-    // Tracked as a separate defect; pinned here so a fix shows up as a
-    // deliberate change rather than a silent behaviour shift.
-    test('states holding equal-but-distinct orders compare unequal today', () {
-      expect(baseState(), isNot(baseState()));
+    // `Order` defines value equality, so two structurally identical orders are
+    // the same value and the surrounding states compare equal. This is what
+    // keeps Riverpod from notifying listeners when nothing actually changed.
+    test('states holding equal-but-distinct orders are equal', () {
+      expect(baseState(), equals(baseState()));
+      expect(baseState().hashCode, equals(baseState().hashCode));
     });
 
     test('states differing in any field are not equal', () {

--- a/test/models/order_test.dart
+++ b/test/models/order_test.dart
@@ -74,4 +74,128 @@ void main() {
       expect(order.premium, equals(1));
     });
   });
+
+  group('Order value equality', () {
+    Order build({
+      String? id = 'order-1',
+      Status status = Status.pending,
+      int amount = 50000,
+      int? minAmount,
+      int? maxAmount,
+      int fiatAmount = 100,
+      String paymentMethod = 'Wire transfer',
+      int premium = 0,
+      String? masterBuyerPubkey,
+      String? masterSellerPubkey,
+      String? buyerTradePubkey,
+      String? sellerTradePubkey,
+      String? buyerInvoice,
+      int? createdAt = 1700000000,
+      int? expiresAt = 1700003600,
+    }) =>
+        Order(
+          id: id,
+          kind: OrderType.sell,
+          status: status,
+          amount: amount,
+          fiatCode: 'USD',
+          minAmount: minAmount,
+          maxAmount: maxAmount,
+          fiatAmount: fiatAmount,
+          paymentMethod: paymentMethod,
+          premium: premium,
+          masterBuyerPubkey: masterBuyerPubkey,
+          masterSellerPubkey: masterSellerPubkey,
+          buyerTradePubkey: buyerTradePubkey,
+          sellerTradePubkey: sellerTradePubkey,
+          buyerInvoice: buyerInvoice,
+          createdAt: createdAt,
+          expiresAt: expiresAt,
+        );
+
+    test('two distinct instances built from the same data are equal', () {
+      expect(build(), equals(build()));
+      expect(build().hashCode, equals(build().hashCode));
+    });
+
+    test('an instance equals itself', () {
+      final order = build();
+
+      expect(order, equals(order));
+    });
+
+    test('is not equal to a value of another type', () {
+      expect(build(), isNot(equals('not an order')));
+    });
+
+    test('differing in any compared field breaks equality', () {
+      expect(build(), isNot(equals(build(id: 'order-2'))));
+      expect(build(), isNot(equals(build(status: Status.active))));
+      expect(build(), isNot(equals(build(amount: 60000))));
+      expect(build(), isNot(equals(build(minAmount: 10))));
+      expect(build(), isNot(equals(build(maxAmount: 20))));
+      expect(build(), isNot(equals(build(fiatAmount: 200))));
+      expect(build(), isNot(equals(build(paymentMethod: 'Cash'))));
+      expect(build(), isNot(equals(build(premium: 5))));
+      expect(build(), isNot(equals(build(masterBuyerPubkey: 'mb'))));
+      expect(build(), isNot(equals(build(masterSellerPubkey: 'ms'))));
+      expect(build(), isNot(equals(build(buyerTradePubkey: 'bt'))));
+      expect(build(), isNot(equals(build(sellerTradePubkey: 'st'))));
+      expect(build(), isNot(equals(build(buyerInvoice: 'lnbc1'))));
+      expect(build(), isNot(equals(build(createdAt: 1))));
+      expect(build(), isNot(equals(build(expiresAt: 2))));
+    });
+
+    test('differing in kind breaks equality', () {
+      final sell = build();
+      final buy = Order(
+        id: sell.id,
+        kind: OrderType.buy,
+        status: sell.status,
+        amount: sell.amount,
+        fiatCode: sell.fiatCode,
+        fiatAmount: sell.fiatAmount,
+        paymentMethod: sell.paymentMethod,
+        premium: sell.premium,
+        createdAt: sell.createdAt,
+        expiresAt: sell.expiresAt,
+      );
+
+      expect(sell, isNot(equals(buy)));
+    });
+
+    test('differing in fiatCode breaks equality', () {
+      final usd = build();
+      final ves = Order(
+        id: usd.id,
+        kind: usd.kind,
+        status: usd.status,
+        amount: usd.amount,
+        fiatCode: 'VES',
+        fiatAmount: usd.fiatAmount,
+        paymentMethod: usd.paymentMethod,
+        premium: usd.premium,
+        createdAt: usd.createdAt,
+        expiresAt: usd.expiresAt,
+      );
+
+      expect(usd, isNot(equals(ves)));
+    });
+
+    test('copyWith result equals an order built with the same values', () {
+      final updated = build().copyWith(
+        status: Status.active,
+        buyerInvoice: 'lnbc1',
+      );
+
+      expect(
+        updated,
+        equals(build(status: Status.active, buyerInvoice: 'lnbc1')),
+      );
+    });
+
+    test('equal orders collapse in a set', () {
+      expect({build(), build()}, hasLength(1));
+    });
+  });
 }


### PR DESCRIPTION
Closes #652

## Problem

`lib/data/models/order.dart` declared no `operator ==` and no `hashCode`, so `Order` fell back to identity comparison — while every sibling payload model (`PaymentRequest`, `Dispute`, `Peer`, `CantDo`, `Amount`, `RatingUser`, `TextMessage`, `RangeAmount`, `Currency`) defines value equality.

`OrderState.==` and `OrderState.hashCode` both include `order`. Since two structurally identical `Order` instances were never equal, **any** `OrderState` carrying an order compared unequal to itself. `OrderState` is Riverpod state, and Riverpod skips notifying listeners only when the new state `==` the old one — so every rebuild notified every listener and re-rendered the trade UI even when nothing had changed.

`Dispute.==`/`Dispute.hashCode` also include `order`, so two otherwise-identical disputes never compared equal once an order was attached.

## Change

- `Order` gains `operator ==` and `hashCode` over all 17 fields (`id`, `kind`, `status`, `amount`, `fiatCode`, `minAmount`, `maxAmount`, `fiatAmount`, `paymentMethod`, `premium`, `masterBuyerPubkey`, `masterSellerPubkey`, `buyerTradePubkey`, `sellerTradePubkey`, `buyerInvoice`, `createdAt`, `expiresAt`), matching the style already used by `PaymentRequest` and `Dispute`. `Order` is immutable with a `const` constructor, so this is safe.

No other production code changed.

## Tests

- `test/models/order_test.dart` — new `Order value equality` group: distinct instances from the same data are equal and share a `hashCode`, reflexivity, inequality against another type, one case per compared field (including `kind` and `fiatCode`), `copyWith` result equality, and collapsing in a `Set`. Written first and confirmed failing before the fix.
- `test/data/models/dispute_equality_test.dart` (new) — regression coverage for the second symptom: disputes holding equal-but-distinct orders now compare equal; different orders and order-vs-null stay unequal.
- `test/features/order/models/order_state_test.dart` — the pinned test flipped from `isNot(baseState())` to an equality assertion plus a `hashCode` comparison, with its comment updated.

## Rebuild-notification audit

Per the issue's "Watch out for" note, I reviewed every `state = ` in `lib/features/order/notifiers/` (`add_order_notifier.dart`, `order_notifier.dart`, `abstract_mostro_notifier.dart`). All of them assign through `updateWith`/`copyWith` on fields that participate in `OrderState.==`; none mutated something outside the compared set while relying on the identity-forced notification. No notifier changes were needed.

## Test plan

- [x] `flutter analyze` on the four touched files — no issues
- [x] `flutter test test/models/order_test.dart` — 11 passing (3 failing before the fix)
- [x] `flutter test test/data/models/dispute_equality_test.dart` — passing
- [x] `flutter test test/features/order/models/` — passing
- [x] Full `flutter test` — 960 passing, 1 pre-existing failure (see below)
- [x] CodeRabbit review on the diff — 0 findings
- [ ] CI green

### Pre-existing failure, unrelated to this PR

`test/notifiers/session_notifier_test.dart` fails to load locally because `test/mocks.mocks.dart` is stale and lacks `MockPushNotificationService`. It cannot be regenerated locally right now: `pub get` resolves `analyzer 8.4.1`, and `build_runner`'s build script fails to compile against it (`DartObjectImpl.getInvocation()` no longer exists). Verified with `git stash` that this failure reproduces on a clean tree at `main`, so it is out of scope here — CI regenerates mocks itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Order objects now compare by their values, including all order details.
  * Related order and dispute states now behave consistently when equivalent data is represented by separate objects.
  * Collections correctly recognize duplicate orders based on matching values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->