### PR TITLE
feat: show the taker's reputation to the maker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,19 +247,17 @@ When orders are canceled, Mostro sends `Action.canceled` gift wrap:
 ## Internationalization (i18n)
 
 ### Current Localization Setup
-- **Primary languages**: English (en), Spanish (es), Italian (it)
-- **ARB files location**: `lib/l10n/`
-  - `intl_en.arb` - English (base language)
-  - `intl_es.arb` - Spanish translations
-  - `intl_it.arb` - Italian translations
+- **Supported languages**: English (en, base), Spanish (es), Italian (it), German (de), French (fr), Portuguese (pt)
+- **ALWAYS verify the actual locale set before adding keys**: list `lib/l10n/` (one `intl_<locale>.arb` per language) — new languages get added over time and this list can be outdated. A key missing in any ARB shows up as "N untranslated message(s)" when running `flutter gen-l10n`.
+- **ARB files location**: `lib/l10n/` (`intl_en.arb` is the base language)
 - **Generated files**: `lib/generated/l10n.dart` and language-specific files
 - **Usage**: Import `import 'package:mostro_mobile/generated/l10n.dart';` and use `S.of(context)!.keyName`
 
 ### Localization Best Practices
 - **Always use localized strings**: Replace hardcoded text with `S.of(context)!.keyName`
-- **ARB file structure**: Add new keys to all three ARB files (en, es, it)
+- **ARB file structure**: Add new keys to EVERY `intl_*.arb` file in `lib/l10n/` (verify the current set first), matching each file's existing style/capitalization
 - **Parameterized strings**: Use proper ARB metadata for strings with parameters
-- **Regenerate after changes**: Run `dart run build_runner build -d` after ARB modifications
+- **Regenerate after changes**: Run `flutter gen-l10n` after ARB modifications and check its output for untranslated-message warnings
 - **Context usage**: Pass BuildContext to methods that need localization
 
 ### TimeAgo Localization

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -9,6 +9,7 @@ export 'package:mostro_mobile/data/models/order.dart';
 export 'package:mostro_mobile/data/models/payload.dart';
 export 'package:mostro_mobile/data/models/payment_request.dart';
 export 'package:mostro_mobile/data/models/peer.dart';
+export 'package:mostro_mobile/data/models/user_info.dart';
 export 'package:mostro_mobile/data/models/rating_user.dart';
 export 'package:mostro_mobile/data/models/rating.dart';
 export 'package:mostro_mobile/data/models/session.dart';

--- a/lib/data/models/mostro_message.dart
+++ b/lib/data/models/mostro_message.dart
@@ -5,6 +5,7 @@ import 'package:dart_nostr/nostr/core/key_pairs.dart';
 import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
 import 'package:mostro_mobile/data/models/payload.dart';
+import 'package:mostro_mobile/data/models/peer.dart';
 import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
@@ -99,6 +100,15 @@ class MostroMessage<T extends Payload> {
       return payload as R;
     }
     return null;
+  }
+
+  /// True for the daemon's taker-reputation notice: a [Peer] payload whose
+  /// pubkey is empty on purpose, sent to the maker riding the same flow action
+  /// (`pay-invoice` / `add-invoice`) as the real message. It carries no order
+  /// state, only the counterpart's reputation snapshot.
+  bool get isTakerReputationNotice {
+    final peer = getPayload<Peer>();
+    return peer != null && peer.publicKey.isEmpty;
   }
 
   /// Wrapper key for the message envelope: 'restore' for restore and

--- a/lib/data/models/peer.dart
+++ b/lib/data/models/peer.dart
@@ -1,15 +1,22 @@
 import 'package:mostro_mobile/data/models/payload.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
 
 class Peer implements Payload {
   final String publicKey;
 
-  Peer({required this.publicKey}) {
-    if (publicKey.isEmpty) {
-      throw ArgumentError('Public key cannot be empty');
-    }
+  /// Reputation snapshot forwarded by the daemon. An empty [publicKey] with a
+  /// non-null [reputation] is the taker-reputation notice sent to the maker
+  /// before the counterpart's trade key is revealed.
+  final UserInfo? reputation;
+
+  Peer({required this.publicKey, this.reputation}) {
+    // Empty is allowed: reputation-only notices carry no pubkey on purpose.
     // Basic validation for hex string format (64 characters for secp256k1)
-    if (publicKey.length != 64 || !RegExp(r'^[0-9a-fA-F]+$').hasMatch(publicKey)) {
-      throw ArgumentError('Invalid public key format: must be 64-character hex string');
+    if (publicKey.isNotEmpty &&
+        (publicKey.length != 64 ||
+            !RegExp(r'^[0-9a-fA-F]+$').hasMatch(publicKey))) {
+      throw ArgumentError(
+          'Invalid public key format: must be 64-character hex string');
     }
   }
 
@@ -20,13 +27,17 @@ class Peer implements Payload {
         throw FormatException('Missing required field: pubkey');
       }
       if (pubkey is! String) {
-        throw FormatException('Invalid pubkey type: expected String, got ${pubkey.runtimeType}');
+        throw FormatException(
+            'Invalid pubkey type: expected String, got ${pubkey.runtimeType}');
       }
-      if (pubkey.isEmpty) {
-        throw FormatException('Public key cannot be empty');
-      }
-      
-      return Peer(publicKey: pubkey);
+
+      final reputationJson = json['reputation'];
+      return Peer(
+        publicKey: pubkey,
+        reputation: reputationJson is Map<String, dynamic>
+            ? UserInfo.fromJson(reputationJson)
+            : null,
+      );
     } catch (e) {
       throw FormatException('Failed to parse Peer from JSON: $e');
     }
@@ -37,22 +48,25 @@ class Peer implements Payload {
     return {
       type: {
         'pubkey': publicKey,
+        if (reputation != null) 'reputation': reputation!.toJson(),
       }
     };
   }
 
   @override
   String get type => 'peer';
-  
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is Peer && other.publicKey == publicKey;
+    return other is Peer &&
+        other.publicKey == publicKey &&
+        other.reputation == reputation;
   }
-  
+
   @override
-  int get hashCode => publicKey.hashCode;
-  
+  int get hashCode => Object.hash(publicKey, reputation);
+
   @override
-  String toString() => 'Peer(publicKey: $publicKey)';
+  String toString() => 'Peer(publicKey: $publicKey, reputation: $reputation)';
 }

--- a/lib/data/models/user_info.dart
+++ b/lib/data/models/user_info.dart
@@ -26,9 +26,6 @@ class UserInfo {
         'operating_days': operatingDays,
       };
 
-  /// True when the snapshot carries no history (new user or full privacy).
-  bool get hasNoHistory => rating == 0.0 && reviews == 0 && operatingDays == 0;
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/data/models/user_info.dart
+++ b/lib/data/models/user_info.dart
@@ -1,0 +1,46 @@
+/// Reputation snapshot of a counterpart, as forwarded by the Mostro daemon
+/// inside a Peer payload (mostro-core `UserInfo`). Zeroed values mean either
+/// a brand-new user or a full-privacy taker — indistinguishable on the wire.
+class UserInfo {
+  final double rating;
+  final int reviews;
+  final int operatingDays;
+
+  const UserInfo({
+    required this.rating,
+    required this.reviews,
+    required this.operatingDays,
+  });
+
+  factory UserInfo.fromJson(Map<String, dynamic> json) {
+    return UserInfo(
+      rating: (json['rating'] as num?)?.toDouble() ?? 0.0,
+      reviews: (json['reviews'] as num?)?.toInt() ?? 0,
+      operatingDays: (json['operating_days'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'rating': rating,
+        'reviews': reviews,
+        'operating_days': operatingDays,
+      };
+
+  /// True when the snapshot carries no history (new user or full privacy).
+  bool get hasNoHistory => rating == 0.0 && reviews == 0 && operatingDays == 0;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserInfo &&
+          other.rating == rating &&
+          other.reviews == reviews &&
+          other.operatingDays == operatingDays;
+
+  @override
+  int get hashCode => Object.hash(rating, reviews, operatingDays);
+
+  @override
+  String toString() =>
+      'UserInfo(rating: $rating, reviews: $reviews, operatingDays: $operatingDays)';
+}

--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -12,6 +12,11 @@ class NotificationDataExtractor {
   /// Extract notification data from MostroMessage
   /// If ref is null, will use fallback methods for nickname resolution
   static Future<NotificationData?> extractFromMostroMessage(MostroMessage event, Ref? ref, {Session? session, Status? previousStatus, bool wasUserInitiatedCancel = false}) async {
+    // The taker-reputation notice reuses the flow action, so the real message
+    // already notifies for it. Suppressed here rather than at the call sites so
+    // the background service stays silent too.
+    if (event.isTakerReputationNotice) return null;
+
     Map<String, dynamic> values = {};
     bool isTemporary = false;
     

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -114,6 +114,13 @@ class OrderState {
       return copyWith(cantDo: message.getPayload<CantDo>());
     }
 
+    // The taker-reputation notice is informational too: it reuses a flow
+    // action but carries no order state, and it can arrive out of order.
+    // Take only the snapshot so it can never move the order backwards.
+    if (message.isTakerReputationNotice) {
+      return copyWith(peerReputation: message.getPayload<Peer>()?.reputation);
+    }
+
     // Track whether fiat was sent at any point in this order's lifecycle
     final bool newFiatWasSent = fiatWasSent ||
         message.action == Action.fiatSent ||

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -91,6 +91,7 @@ class OrderState {
     PaymentFailed? paymentFailed,
     bool? fiatWasSent,
     UserInfo? peerReputation,
+    bool clearPeerReputation = false,
   }) {
     return OrderState(
       status: status ?? this.status,
@@ -102,7 +103,9 @@ class OrderState {
       peer: peer ?? this.peer,
       paymentFailed: paymentFailed ?? this.paymentFailed,
       fiatWasSent: fiatWasSent ?? this.fiatWasSent,
-      peerReputation: peerReputation ?? this.peerReputation,
+      peerReputation: clearPeerReputation
+          ? null
+          : peerReputation ?? this.peerReputation,
     );
   }
 
@@ -147,6 +150,14 @@ class OrderState {
 
     // DEBUG: Log status mapping
     logger.i('Status mapping: $effectiveAction → $newStatus');
+
+    // A pending order has no counterpart: when Mostro republishes it after the
+    // taker times out, the previous taker's snapshot must not be carried into
+    // the next take and shown as if it belonged to whoever takes it next.
+    final bool orderReactivated = newStatus == Status.pending;
+    if (orderReactivated && peerReputation != null) {
+      logger.i('Order returned to pending: dropping the taker reputation');
+    }
 
     // Preserve PaymentRequest correctly
     PaymentRequest? newPaymentRequest;
@@ -284,6 +295,7 @@ class OrderState {
       // Preserve the last non-null snapshot: later Peers (e.g. fiat-sent-ok)
       // carry reputation: null and must not clear it
       peerReputation: message.getPayload<Peer>()?.reputation ?? peerReputation,
+      clearPeerReputation: orderReactivated,
     );
 
     logger.i('New state: ${newState.status} - ${newState.action}');

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -13,6 +13,10 @@ class OrderState {
   final PaymentFailed? paymentFailed;
   final bool fiatWasSent;
 
+  /// Counterpart reputation snapshot, from the daemon's taker-reputation
+  /// notice (a Peer payload with empty pubkey riding the flow action).
+  final UserInfo? peerReputation;
+
   OrderState({
     required this.status,
     required this.action,
@@ -23,6 +27,7 @@ class OrderState {
     this.peer,
     this.paymentFailed,
     this.fiatWasSent = false,
+    this.peerReputation,
   });
 
   factory OrderState.fromMostroMessage(MostroMessage message) {
@@ -33,14 +38,18 @@ class OrderState {
       paymentRequest: message.getPayload<PaymentRequest>(),
       cantDo: message.getPayload<CantDo>(),
       dispute: message.getPayload<Dispute>(),
-      peer: message.getPayload<Peer>(),
+      // Reputation-only Peers carry an empty pubkey and are not a counterpart
+      peer: message.getPayload<Peer>()?.publicKey.isNotEmpty == true
+          ? message.getPayload<Peer>()
+          : null,
       paymentFailed: message.getPayload<PaymentFailed>(),
+      peerReputation: message.getPayload<Peer>()?.reputation,
     );
   }
 
   @override
   String toString() =>
-      'OrderState(status: $status, action: $action, order: $order, paymentRequest: $paymentRequest, cantDo: $cantDo, dispute: $dispute, peer: $peer, paymentFailed: $paymentFailed, fiatWasSent: $fiatWasSent)';
+      'OrderState(status: $status, action: $action, order: $order, paymentRequest: $paymentRequest, cantDo: $cantDo, dispute: $dispute, peer: $peer, paymentFailed: $paymentFailed, fiatWasSent: $fiatWasSent, peerReputation: $peerReputation)';
 
   @override
   bool operator ==(Object other) =>
@@ -54,7 +63,8 @@ class OrderState {
           other.dispute == dispute &&
           other.paymentFailed == paymentFailed &&
           other.peer == peer &&
-          other.fiatWasSent == fiatWasSent;
+          other.fiatWasSent == fiatWasSent &&
+          other.peerReputation == peerReputation;
 
   @override
   int get hashCode => Object.hash(
@@ -67,6 +77,7 @@ class OrderState {
         peer,
         paymentFailed,
         fiatWasSent,
+        peerReputation,
       );
 
   OrderState copyWith({
@@ -79,6 +90,7 @@ class OrderState {
     Peer? peer,
     PaymentFailed? paymentFailed,
     bool? fiatWasSent,
+    UserInfo? peerReputation,
   }) {
     return OrderState(
       status: status ?? this.status,
@@ -90,6 +102,7 @@ class OrderState {
       peer: peer ?? this.peer,
       paymentFailed: paymentFailed ?? this.paymentFailed,
       fiatWasSent: fiatWasSent ?? this.fiatWasSent,
+      peerReputation: peerReputation ?? this.peerReputation,
     );
   }
 
@@ -261,6 +274,9 @@ class OrderState {
       peer: newPeer,
       paymentFailed: message.getPayload<PaymentFailed>() ?? paymentFailed,
       fiatWasSent: newFiatWasSent,
+      // Preserve the last non-null snapshot: later Peers (e.g. fiat-sent-ok)
+      // carry reputation: null and must not clear it
+      peerReputation: message.getPayload<Peer>()?.reputation ?? peerReputation,
     );
 
     logger.i('New state: ${newState.status} - ${newState.action}');

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -186,18 +186,10 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
                 .subtract(const Duration(seconds: 60))
                 .millisecondsSinceEpoch;
 
-    // Taker-reputation notice: the daemon reuses the flow action (payInvoice /
-    // addInvoice) with a Peer payload carrying only reputation. The state
-    // update (peerReputation) already happened in updateWith; skip the
-    // duplicate notification and the action's navigation side effects.
-    final isTakerReputationNotice = event.payload is Peer &&
-        (event.action == Action.payInvoice ||
-            event.action == Action.addInvoice);
-
-    // Extract notification data using the centralized extractor
-    final notificationData = isTakerReputationNotice
-        ? null
-        : await NotificationDataExtractor.extractFromMostroMessage(event, ref,
+    // Extract notification data using the centralized extractor, which also
+    // filters out the taker-reputation notice
+    final notificationData =
+        await NotificationDataExtractor.extractFromMostroMessage(event, ref,
             session: session,
             previousStatus: previousStatus,
             wasUserInitiatedCancel: wasUserInitiatedCancel);
@@ -364,7 +356,7 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
         final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
         sessionNotifier.saveSession(session);
         // The reputation notice must not (re-)navigate to the invoice screen
-        if (!isTakerReputationNotice) {
+        if (!event.isTakerReputationNotice) {
           await _handleAddInvoiceWithAutoLightningAddress(event);
         }
         break;

--- a/lib/features/order/notifiers/abstract_mostro_notifier.dart
+++ b/lib/features/order/notifiers/abstract_mostro_notifier.dart
@@ -186,9 +186,18 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
                 .subtract(const Duration(seconds: 60))
                 .millisecondsSinceEpoch;
 
+    // Taker-reputation notice: the daemon reuses the flow action (payInvoice /
+    // addInvoice) with a Peer payload carrying only reputation. The state
+    // update (peerReputation) already happened in updateWith; skip the
+    // duplicate notification and the action's navigation side effects.
+    final isTakerReputationNotice = event.payload is Peer &&
+        (event.action == Action.payInvoice ||
+            event.action == Action.addInvoice);
+
     // Extract notification data using the centralized extractor
-    final notificationData =
-        await NotificationDataExtractor.extractFromMostroMessage(event, ref,
+    final notificationData = isTakerReputationNotice
+        ? null
+        : await NotificationDataExtractor.extractFromMostroMessage(event, ref,
             session: session,
             previousStatus: previousStatus,
             wasUserInitiatedCancel: wasUserInitiatedCancel);
@@ -354,7 +363,10 @@ class AbstractMostroNotifier extends StateNotifier<OrderState> {
       case Action.addInvoice:
         final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
         sessionNotifier.saveSession(session);
-        await _handleAddInvoiceWithAutoLightningAddress(event);
+        // The reputation notice must not (re-)navigate to the invoice screen
+        if (!isTakerReputationNotice) {
+          await _handleAddInvoiceWithAutoLightningAddress(event);
+        }
         break;
 
       case Action.addBondInvoice:

--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -61,15 +61,23 @@ class _AddLightningInvoiceScreenState
         final orderIdValue = orderPayload?.id ?? orderId;
         // Trade summary shown by every flow: trade type, who took the order,
         // amounts, order id and the counterpart reputation (when received).
-        // Adding an invoice always means the user is the buyer.
+        // Adding an invoice always means the user is the buyer, but not always
+        // the maker: taking a sell order and retrying after a failed payout
+        // land here too.
         final session = ref.watch(sessionProvider(orderId));
+        final orderState = ref.watch(orderNotifierProvider(orderId));
         final header = InvoiceHeader(
           userIsSeller: session?.role == Role.seller,
           sats: amount ?? 0,
           fiatAmount: fiatAmount,
           fiatCode: fiatCode,
           orderId: orderIdValue,
-          reputation: ref.watch(orderNotifierProvider(orderId)).peerReputation,
+          takenByCounterpart: counterpartTookYourOrder(
+            kind: orderState.order?.kind ?? orderPayload?.kind,
+            role: session?.role,
+            status: orderState.status,
+          ),
+          reputation: orderState.peerReputation,
         );
 
         final nwcState = ref.watch(nwcProvider);

--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -7,8 +7,11 @@ import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/features/wallet/providers/nwc_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/data/models/order.dart';
+import 'package:mostro_mobile/data/models/enums/role.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/shared/widgets/add_lightning_invoice_widget.dart';
 import 'package:mostro_mobile/shared/widgets/nwc_invoice_widget.dart';
+import 'package:mostro_mobile/shared/widgets/invoice_header.dart';
 import 'package:mostro_mobile/shared/widgets/ln_address_confirmation_widget.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
@@ -56,6 +59,18 @@ class _AddLightningInvoiceScreenState
         final fiatAmount = orderPayload?.fiatAmount.toString() ?? '0';
         final fiatCode = orderPayload?.fiatCode ?? '';
         final orderIdValue = orderPayload?.id ?? orderId;
+        // Trade summary shown by every flow: trade type, who took the order,
+        // amounts, order id and the counterpart reputation (when received).
+        // Adding an invoice always means the user is the buyer.
+        final session = ref.watch(sessionProvider(orderId));
+        final header = InvoiceHeader(
+          userIsSeller: session?.role == Role.seller,
+          sats: amount ?? 0,
+          fiatAmount: fiatAmount,
+          fiatCode: fiatCode,
+          orderId: orderIdValue,
+          reputation: ref.watch(orderNotifierProvider(orderId)).peerReputation,
+        );
 
         final nwcState = ref.watch(nwcProvider);
         final isNwcConnected = nwcState.status == NwcStatus.connected;
@@ -77,16 +92,9 @@ class _AddLightningInvoiceScreenState
               16 + MediaQuery.of(context).viewPadding.bottom,
             ),
             child: showLnAddressConfirmation
-                ? _buildLnAddressConfirmation(
-                    orderIdValue: orderIdValue,
-                  )
+                ? _buildLnAddressConfirmation(header: header)
                 : showNwcInvoice
-                    ? _buildNwcInvoiceFlow(
-                        amount: amount ?? 0,
-                        fiatAmount: fiatAmount,
-                        fiatCode: fiatCode,
-                        orderIdValue: orderIdValue,
-                      )
+                    ? _buildNwcInvoiceFlow(header: header)
                     : AddLightningInvoiceWidget(
                         controller: invoiceController,
                         onSubmit: () async {
@@ -102,6 +110,7 @@ class _AddLightningInvoiceScreenState
                         fiatAmount: fiatAmount,
                         fiatCode: fiatCode,
                         orderId: orderIdValue,
+                        header: header,
                       ),
           ),
         );
@@ -111,20 +120,11 @@ class _AddLightningInvoiceScreenState
     );
   }
 
-  Widget _buildLnAddressConfirmation({
-    required String orderIdValue,
-  }) {
+  Widget _buildLnAddressConfirmation({required Widget header}) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          S.of(context)!.lnAddressConfirmHeader(orderIdValue),
-          style: const TextStyle(
-            color: AppTheme.textPrimary,
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
+        header,
         const SizedBox(height: 24),
         LnAddressConfirmationWidget(
           lightningAddress: widget.lnAddress!,
@@ -160,28 +160,13 @@ class _AddLightningInvoiceScreenState
     }
   }
 
-  Widget _buildNwcInvoiceFlow({
-    required int amount,
-    required String fiatAmount,
-    required String fiatCode,
-    required String orderIdValue,
-  }) {
+  Widget _buildNwcInvoiceFlow({required InvoiceHeader header}) {
+    final amount = header.sats;
+    final orderIdValue = header.orderId;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          S.of(context)!.pleaseEnterLightningInvoiceFor(
-                amount.toString(),
-                fiatCode,
-                fiatAmount,
-                orderIdValue,
-              ),
-          style: const TextStyle(
-            color: AppTheme.textPrimary,
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
+        header,
         const SizedBox(height: 24),
         NwcInvoiceWidget(
           sats: amount,

--- a/lib/features/order/screens/pay_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/pay_lightning_invoice_screen.dart
@@ -46,7 +46,8 @@ class _PayLightningInvoiceScreenState
 
     // Trade summary shown by every flow: trade type, who took the order,
     // amounts, order id and the counterpart reputation (when received).
-    // Paying the hold invoice always means the user is the seller.
+    // Paying the hold invoice always means the user is the seller, but not
+    // always the maker: taking a buy order lands here too.
     final session = ref.watch(sessionProvider(widget.orderId));
     final header = InvoiceHeader(
       userIsSeller: session?.role == null || session!.role == Role.seller,
@@ -54,6 +55,11 @@ class _PayLightningInvoiceScreenState
       fiatAmount: fiatAmount,
       fiatCode: fiatCode,
       orderId: widget.orderId,
+      takenByCounterpart: counterpartTookYourOrder(
+        kind: orderState.order?.kind,
+        role: session?.role,
+        status: orderState.status,
+      ),
       reputation: orderState.peerReputation,
     );
 

--- a/lib/features/order/screens/pay_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/pay_lightning_invoice_screen.dart
@@ -7,6 +7,9 @@ import 'package:mostro_mobile/core/automation/automation_ids.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/features/wallet/providers/nwc_provider.dart';
+import 'package:mostro_mobile/data/models/enums/role.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/shared/widgets/invoice_header.dart';
 import 'package:mostro_mobile/shared/widgets/nwc_payment_widget.dart';
 import 'package:mostro_mobile/shared/widgets/pay_lightning_invoice_widget.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
@@ -41,10 +44,23 @@ class _PayLightningInvoiceScreenState
     final showNwcPayment =
         isNwcConnected && !_manualMode && lnInvoice.isNotEmpty;
 
+    // Trade summary shown by every flow: trade type, who took the order,
+    // amounts, order id and the counterpart reputation (when received).
+    // Paying the hold invoice always means the user is the seller.
+    final session = ref.watch(sessionProvider(widget.orderId));
+    final header = InvoiceHeader(
+      userIsSeller: session?.role == null || session!.role == Role.seller,
+      sats: sats,
+      fiatAmount: fiatAmount,
+      fiatCode: fiatCode,
+      orderId: widget.orderId,
+      reputation: orderState.peerReputation,
+    );
+
     return Scaffold(
       backgroundColor: AppTheme.dark1,
       appBar: OrderAppBar(title: S.of(context)!.payLightningInvoice),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: EdgeInsets.fromLTRB(
           16,
           16,
@@ -56,16 +72,7 @@ class _PayLightningInvoiceScreenState
           children: [
             if (showNwcPayment) ...[
               // NWC auto-payment flow
-              Text(
-                S.of(context)!.payInvoiceToContinue(
-                      sats.toString(),
-                      fiatCode,
-                      fiatAmount,
-                      widget.orderId,
-                    ),
-                style: const TextStyle(color: AppTheme.cream1, fontSize: 18),
-                textAlign: TextAlign.center,
-              ),
+              header,
               const SizedBox(height: 24),
               // Automation readout: the invoice being paid, so a black-box
               // driver can correlate the payment by hash without reading the
@@ -118,6 +125,7 @@ class _PayLightningInvoiceScreenState
                 fiatAmount: fiatAmount,
                 fiatCode: fiatCode,
                 orderId: widget.orderId,
+                header: header,
               ),
             ],
           ],

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -88,8 +88,11 @@ class TradeDetailScreen extends ConsumerWidget {
                   MostroMessageDetail(orderId: orderId),
                 ],
                 // Counterpart reputation, from the daemon's taker notice
-                // (only ever received by the maker)
-                if (tradeState.peerReputation != null) ...[
+                // (only ever received by the maker). A pending order has no
+                // counterpart, so a notice that outlived its take cycle and
+                // landed late is never shown as the next taker's.
+                if (tradeState.peerReputation != null &&
+                    tradeState.status != Status.pending) ...[
                   const SizedBox(height: 16),
                   PeerReputationCard(
                     reputation: tradeState.peerReputation!,

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -87,6 +87,15 @@ class TradeDetailScreen extends ConsumerWidget {
                   // Detailed info: includes the last Mostro message action text
                   MostroMessageDetail(orderId: orderId),
                 ],
+                // Counterpart reputation, from the daemon's taker notice
+                // (only ever received by the maker)
+                if (tradeState.peerReputation != null) ...[
+                  const SizedBox(height: 16),
+                  PeerReputationCard(
+                    reputation: tradeState.peerReputation!,
+                    counterpartIsBuyer: session?.role == Role.seller,
+                  ),
+                ],
                 const SizedBox(height: 24),
                 // Show countdown timer only for specific statuses
                 _CountdownWidget(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -305,6 +305,55 @@
     "createdOnLabel": "Erstellt am",
     "orderIdLabel": "Order-ID",
     "creatorReputationLabel": "Reputation des Erstellers",
+    "buyerReputationLabel": "Reputation des Käufers",
+    "sellerReputationLabel": "Reputation des Verkäufers",
+    "noReputationHistory": "Noch kein Reputationsverlauf",
+    "buyerTookYourSellOrder": "Ein Käufer hat deine Verkaufsorder angenommen.",
+    "sellerTookYourBuyOrder": "Ein Verkäufer hat deine Kauforder angenommen.",
+    "payInvoiceExchangeInstruction": "Wenn du mit dem Austausch fortfahren möchtest, bezahle diese Lightning-Rechnung über {sats} Sats, entsprechend {fiat_amount} {fiat_code}.",
+    "@payInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "addInvoiceExchangeInstruction": "Wenn du mit dem Austausch fortfahren möchtest, füge eine Lightning-Rechnung über {sats} Sats hinzu, entsprechend {fiat_amount} {fiat_code}.",
+    "@addInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "reputationReviewsCount": "{count, plural, =1{1 Bewertung} other{{count} Bewertungen}}",
+    "@reputationReviewsCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "reputationDaysCount": "{count, plural, =1{1 Tag} other{{count} Tage}}",
+    "@reputationDaysCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "ratingTitleLabel": "Bewertung",
     "reviewsLabel": "Bewertungen",
     "daysLabel": "Tage",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -307,7 +307,6 @@
     "creatorReputationLabel": "Reputation des Erstellers",
     "buyerReputationLabel": "Reputation des Käufers",
     "sellerReputationLabel": "Reputation des Verkäufers",
-    "noReputationHistory": "Noch kein Reputationsverlauf",
     "buyerTookYourSellOrder": "Ein Käufer hat deine Verkaufsorder angenommen.",
     "sellerTookYourBuyOrder": "Ein Verkäufer hat deine Kauforder angenommen.",
     "payInvoiceExchangeInstruction": "Wenn du mit dem Austausch fortfahren möchtest, bezahle diese Lightning-Rechnung über {sats} Sats, entsprechend {fiat_amount} {fiat_code}.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -305,6 +305,55 @@
     "createdOnLabel": "Created On",
     "orderIdLabel": "Order ID",
     "creatorReputationLabel": "Creator's Reputation",
+    "buyerReputationLabel": "Buyer's Reputation",
+    "sellerReputationLabel": "Seller's Reputation",
+    "noReputationHistory": "No reputation history yet",
+    "buyerTookYourSellOrder": "A buyer has taken your sell order.",
+    "sellerTookYourBuyOrder": "A seller has taken your buy order.",
+    "payInvoiceExchangeInstruction": "If you want to continue with the exchange, pay this Lightning invoice for {sats} sats, equivalent to {fiat_amount} {fiat_code}.",
+    "@payInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "addInvoiceExchangeInstruction": "If you want to continue with the exchange, add a Lightning invoice for {sats} sats, equivalent to {fiat_amount} {fiat_code}.",
+    "@addInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "reputationReviewsCount": "{count, plural, =1{1 review} other{{count} reviews}}",
+    "@reputationReviewsCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "reputationDaysCount": "{count, plural, =1{1 day} other{{count} days}}",
+    "@reputationDaysCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "ratingTitleLabel": "Rating",
     "reviewsLabel": "Reviews",
     "daysLabel": "Days",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -307,7 +307,6 @@
     "creatorReputationLabel": "Creator's Reputation",
     "buyerReputationLabel": "Buyer's Reputation",
     "sellerReputationLabel": "Seller's Reputation",
-    "noReputationHistory": "No reputation history yet",
     "buyerTookYourSellOrder": "A buyer has taken your sell order.",
     "sellerTookYourBuyOrder": "A seller has taken your buy order.",
     "payInvoiceExchangeInstruction": "If you want to continue with the exchange, pay this Lightning invoice for {sats} sats, equivalent to {fiat_amount} {fiat_code}.",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -739,8 +739,57 @@
     "fiatSentButton": "FIAT ENVIADO",
     "paymentMethodLabel": "Método de Pago",
     "createdOnLabel": "Creado el",
-    "orderIdLabel": "ID de Orden",
+    "orderIdLabel": "ID de la orden",
     "creatorReputationLabel": "Reputación del Creador",
+    "buyerReputationLabel": "Reputación del Comprador",
+    "sellerReputationLabel": "Reputación del Vendedor",
+    "noReputationHistory": "Aún sin historial de reputación",
+    "buyerTookYourSellOrder": "Un comprador ha tomado tu orden de venta.",
+    "sellerTookYourBuyOrder": "Un vendedor ha tomado tu orden de compra.",
+    "payInvoiceExchangeInstruction": "Si deseas continuar con el intercambio, paga esta factura Lightning de {sats} sats, equivalentes a {fiat_amount} {fiat_code}.",
+    "@payInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "addInvoiceExchangeInstruction": "Si deseas continuar con el intercambio, agrega una factura Lightning de {sats} sats, equivalentes a {fiat_amount} {fiat_code}.",
+    "@addInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "reputationReviewsCount": "{count, plural, =1{1 reseña} other{{count} reseñas}}",
+    "@reputationReviewsCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "reputationDaysCount": "{count, plural, =1{1 día} other{{count} días}}",
+    "@reputationDaysCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "ratingTitleLabel": "Calificación",
     "reviewsLabel": "Reseñas",
     "daysLabel": "Días",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -743,7 +743,6 @@
     "creatorReputationLabel": "Reputación del Creador",
     "buyerReputationLabel": "Reputación del Comprador",
     "sellerReputationLabel": "Reputación del Vendedor",
-    "noReputationHistory": "Aún sin historial de reputación",
     "buyerTookYourSellOrder": "Un comprador ha tomado tu orden de venta.",
     "sellerTookYourBuyOrder": "Un vendedor ha tomado tu orden de compra.",
     "payInvoiceExchangeInstruction": "Si deseas continuar con el intercambio, paga esta factura Lightning de {sats} sats, equivalentes a {fiat_amount} {fiat_code}.",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -307,7 +307,6 @@
     "creatorReputationLabel": "Réputation du créateur",
     "buyerReputationLabel": "Réputation de l'acheteur",
     "sellerReputationLabel": "Réputation du vendeur",
-    "noReputationHistory": "Pas encore d'historique de réputation",
     "buyerTookYourSellOrder": "Un acheteur a pris votre ordre de vente.",
     "sellerTookYourBuyOrder": "Un vendeur a pris votre ordre d'achat.",
     "payInvoiceExchangeInstruction": "Si vous souhaitez poursuivre l'échange, payez cette facture Lightning de {sats} sats, équivalant à {fiat_amount} {fiat_code}.",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -305,6 +305,55 @@
     "createdOnLabel": "Créé le",
     "orderIdLabel": "ID de commande",
     "creatorReputationLabel": "Réputation du créateur",
+    "buyerReputationLabel": "Réputation de l'acheteur",
+    "sellerReputationLabel": "Réputation du vendeur",
+    "noReputationHistory": "Pas encore d'historique de réputation",
+    "buyerTookYourSellOrder": "Un acheteur a pris votre ordre de vente.",
+    "sellerTookYourBuyOrder": "Un vendeur a pris votre ordre d'achat.",
+    "payInvoiceExchangeInstruction": "Si vous souhaitez poursuivre l'échange, payez cette facture Lightning de {sats} sats, équivalant à {fiat_amount} {fiat_code}.",
+    "@payInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "addInvoiceExchangeInstruction": "Si vous souhaitez poursuivre l'échange, ajoutez une facture Lightning de {sats} sats, équivalant à {fiat_amount} {fiat_code}.",
+    "@addInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "reputationReviewsCount": "{count, plural, =1{1 avis} other{{count} avis}}",
+    "@reputationReviewsCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "reputationDaysCount": "{count, plural, =1{1 jour} other{{count} jours}}",
+    "@reputationDaysCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "ratingTitleLabel": "Évaluation",
     "reviewsLabel": "Avis",
     "daysLabel": "Jours",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -814,6 +814,55 @@
     "createdOnLabel": "Creato il",
     "orderIdLabel": "ID Ordine",
     "creatorReputationLabel": "Reputazione del Creatore",
+    "buyerReputationLabel": "Reputazione dell'Acquirente",
+    "sellerReputationLabel": "Reputazione del Venditore",
+    "noReputationHistory": "Ancora nessuna cronologia di reputazione",
+    "buyerTookYourSellOrder": "Un acquirente ha preso il tuo ordine di vendita.",
+    "sellerTookYourBuyOrder": "Un venditore ha preso il tuo ordine di acquisto.",
+    "payInvoiceExchangeInstruction": "Se vuoi continuare con lo scambio, paga questa fattura Lightning di {sats} sats, equivalenti a {fiat_amount} {fiat_code}.",
+    "@payInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "addInvoiceExchangeInstruction": "Se vuoi continuare con lo scambio, aggiungi una fattura Lightning di {sats} sats, equivalenti a {fiat_amount} {fiat_code}.",
+    "@addInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "reputationReviewsCount": "{count, plural, =1{1 recensione} other{{count} recensioni}}",
+    "@reputationReviewsCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "reputationDaysCount": "{count, plural, =1{1 giorno} other{{count} giorni}}",
+    "@reputationDaysCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "ratingTitleLabel": "Valutazione",
     "reviewsLabel": "Recensioni",
     "daysLabel": "Giorni",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -816,7 +816,6 @@
     "creatorReputationLabel": "Reputazione del Creatore",
     "buyerReputationLabel": "Reputazione dell'Acquirente",
     "sellerReputationLabel": "Reputazione del Venditore",
-    "noReputationHistory": "Ancora nessuna cronologia di reputazione",
     "buyerTookYourSellOrder": "Un acquirente ha preso il tuo ordine di vendita.",
     "sellerTookYourBuyOrder": "Un venditore ha preso il tuo ordine di acquisto.",
     "payInvoiceExchangeInstruction": "Se vuoi continuare con lo scambio, paga questa fattura Lightning di {sats} sats, equivalenti a {fiat_amount} {fiat_code}.",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -307,7 +307,6 @@
     "creatorReputationLabel": "Reputação do Criador",
     "buyerReputationLabel": "Reputação do Comprador",
     "sellerReputationLabel": "Reputação do Vendedor",
-    "noReputationHistory": "Ainda sem histórico de reputação",
     "buyerTookYourSellOrder": "Um comprador aceitou a sua ordem de venda.",
     "sellerTookYourBuyOrder": "Um vendedor aceitou a sua ordem de compra.",
     "payInvoiceExchangeInstruction": "Se deseja continuar com a troca, pague esta fatura Lightning de {sats} sats, equivalente a {fiat_amount} {fiat_code}.",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -305,6 +305,55 @@
     "createdOnLabel": "Criada Em",
     "orderIdLabel": "ID da Ordem",
     "creatorReputationLabel": "Reputação do Criador",
+    "buyerReputationLabel": "Reputação do Comprador",
+    "sellerReputationLabel": "Reputação do Vendedor",
+    "noReputationHistory": "Ainda sem histórico de reputação",
+    "buyerTookYourSellOrder": "Um comprador aceitou a sua ordem de venda.",
+    "sellerTookYourBuyOrder": "Um vendedor aceitou a sua ordem de compra.",
+    "payInvoiceExchangeInstruction": "Se deseja continuar com a troca, pague esta fatura Lightning de {sats} sats, equivalente a {fiat_amount} {fiat_code}.",
+    "@payInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "addInvoiceExchangeInstruction": "Se deseja continuar com a troca, adicione uma fatura Lightning de {sats} sats, equivalente a {fiat_amount} {fiat_code}.",
+    "@addInvoiceExchangeInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "reputationReviewsCount": "{count, plural, =1{1 avaliação} other{{count} avaliações}}",
+    "@reputationReviewsCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "reputationDaysCount": "{count, plural, =1{1 dia} other{{count} dias}}",
+    "@reputationDaysCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "ratingTitleLabel": "Avaliação",
     "reviewsLabel": "Avaliações",
     "daysLabel": "Dias",

--- a/lib/shared/widgets/add_lightning_invoice_widget.dart
+++ b/lib/shared/widgets/add_lightning_invoice_widget.dart
@@ -13,6 +13,9 @@ class AddLightningInvoiceWidget extends StatefulWidget {
   final String fiatCode;
   final String orderId;
 
+  /// Replaces the built-in heading text when provided (see [InvoiceHeader]).
+  final Widget? header;
+
   const AddLightningInvoiceWidget({
     super.key,
     required this.controller,
@@ -22,6 +25,7 @@ class AddLightningInvoiceWidget extends StatefulWidget {
     required this.fiatAmount,
     required this.fiatCode,
     required this.orderId,
+    this.header,
   });
 
   @override
@@ -36,19 +40,20 @@ class _AddLightningInvoiceWidgetState extends State<AddLightningInvoiceWidget> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            S.of(context)!.pleaseEnterLightningInvoiceFor(
-                  widget.amount.toString(),
-                  widget.fiatCode,
-                  widget.fiatAmount,
-                  widget.orderId,
+          widget.header ??
+              Text(
+                S.of(context)!.pleaseEnterLightningInvoiceFor(
+                      widget.amount.toString(),
+                      widget.fiatCode,
+                      widget.fiatAmount,
+                      widget.orderId,
+                    ),
+                style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
                 ),
-            style: const TextStyle(
-              color: AppTheme.textPrimary,
-              fontSize: 16,
-              fontWeight: FontWeight.w500,
-            ),
-          ),
+              ),
           const SizedBox(height: 16),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),

--- a/lib/shared/widgets/invoice_header.dart
+++ b/lib/shared/widgets/invoice_header.dart
@@ -1,8 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/data/models/enums/role.dart';
+import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/user_info.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/widgets/order_cards.dart';
+
+/// Whether the "someone took your order" line is true for this user.
+///
+/// It only ever is for the maker, at the handoff right after a take. Both
+/// invoice screens are also reached by takers — taking a buy order means
+/// paying the hold invoice, taking a sell one means adding an invoice — and
+/// by the buyer asked for a fresh invoice after a failed payout, and for
+/// them nobody took anything.
+///
+/// A sell order is published by its seller and a buy order by its buyer, so
+/// matching the order kind against the user's role identifies the maker.
+bool counterpartTookYourOrder({
+  required OrderType? kind,
+  required Role? role,
+  required Status status,
+}) {
+  if (kind == null || role == null) return false;
+
+  final userIsMaker = (kind == OrderType.sell) == (role == Role.seller);
+  final justTaken = status == Status.waitingPayment ||
+      status == Status.waitingBuyerInvoice;
+
+  return userIsMaker && justTaken;
+}
 
 /// Header shown on the add/pay invoice screens: who took the order, the
 /// amounts to pay or invoice, the order id and the counterpart's reputation.
@@ -19,6 +46,11 @@ class InvoiceHeader extends StatelessWidget {
   final String orderId;
   final UserInfo? reputation;
 
+  /// Whether to open with the "someone took your order" line. False for
+  /// takers and for the post-payment-failure retry — see
+  /// [counterpartTookYourOrder].
+  final bool takenByCounterpart;
+
   const InvoiceHeader({
     super.key,
     required this.userIsSeller,
@@ -26,6 +58,7 @@ class InvoiceHeader extends StatelessWidget {
     required this.fiatAmount,
     required this.fiatCode,
     required this.orderId,
+    required this.takenByCounterpart,
     this.reputation,
   });
 
@@ -39,11 +72,13 @@ class InvoiceHeader extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(
-          userIsSeller ? s.buyerTookYourSellOrder : s.sellerTookYourBuyOrder,
-          style: boldStyle,
-        ),
-        const SizedBox(height: 8),
+        if (takenByCounterpart) ...[
+          Text(
+            userIsSeller ? s.buyerTookYourSellOrder : s.sellerTookYourBuyOrder,
+            style: boldStyle,
+          ),
+          const SizedBox(height: 8),
+        ],
         Text(
           userIsSeller
               ? s.payInvoiceExchangeInstruction(

--- a/lib/shared/widgets/invoice_header.dart
+++ b/lib/shared/widgets/invoice_header.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/widgets/order_cards.dart';
+
+/// Header shown on the add/pay invoice screens: who took the order, the
+/// amounts to pay or invoice, the order id and the counterpart's reputation.
+/// Everything is left aligned and shares one text size and weight scale.
+///
+/// The two flows are mirror images: paying the hold invoice means the user is
+/// the seller and the taker is the buyer; adding an invoice means the user is
+/// the buyer and the taker is the seller.
+class InvoiceHeader extends StatelessWidget {
+  final bool userIsSeller;
+  final int sats;
+  final String fiatAmount;
+  final String fiatCode;
+  final String orderId;
+  final UserInfo? reputation;
+
+  const InvoiceHeader({
+    super.key,
+    required this.userIsSeller,
+    required this.sats,
+    required this.fiatAmount,
+    required this.fiatCode,
+    required this.orderId,
+    this.reputation,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    const bodyStyle = TextStyle(color: AppTheme.textPrimary, fontSize: 16);
+    final boldStyle = bodyStyle.copyWith(fontWeight: FontWeight.w600);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          userIsSeller ? s.buyerTookYourSellOrder : s.sellerTookYourBuyOrder,
+          style: boldStyle,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          userIsSeller
+              ? s.payInvoiceExchangeInstruction(
+                  sats.toString(), fiatAmount, fiatCode)
+              : s.addInvoiceExchangeInstruction(
+                  sats.toString(), fiatAmount, fiatCode),
+          style: bodyStyle,
+        ),
+        const SizedBox(height: 12),
+        // Text.rich (not RichText) so the line inherits the theme font
+        Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: '${s.orderIdLabel}: ', style: boldStyle),
+              TextSpan(text: orderId),
+            ],
+          ),
+          style: bodyStyle,
+        ),
+        if (reputation != null) ...[
+          const SizedBox(height: 12),
+          PeerReputationInline(
+            reputation: reputation!,
+            counterpartIsBuyer: userIsSeller,
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/shared/widgets/order_cards.dart
+++ b/lib/shared/widgets/order_cards.dart
@@ -288,8 +288,8 @@ class CreatorReputationCard extends StatelessWidget {
 }
 
 /// Card that displays the counterpart's reputation, from the daemon's
-/// taker-reputation notice. Zeroed data (new user or full-privacy taker)
-/// renders as "no history" instead of a misleading 0-star rating.
+/// taker-reputation notice. Keeps the same shape when there is no history
+/// (new user or full-privacy taker), showing zeros in every metric.
 class PeerReputationCard extends StatelessWidget {
   final UserInfo reputation;
   final bool counterpartIsBuyer;
@@ -318,20 +318,11 @@ class PeerReputationCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            if (reputation.hasNoHistory)
-              Text(
-                S.of(context)!.noReputationHistory,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 14,
-                ),
-              )
-            else
-              _ReputationMetricsRow(
-                rating: reputation.rating,
-                reviews: reputation.reviews,
-                days: reputation.operatingDays,
-              ),
+            _ReputationMetricsRow(
+              rating: reputation.rating,
+              reviews: reputation.reviews,
+              days: reputation.operatingDays,
+            ),
           ],
         ),
       ),
@@ -340,8 +331,8 @@ class PeerReputationCard extends StatelessWidget {
 }
 
 /// Compact, cardless counterpart reputation for dense layouts (invoice
-/// screens): a title line plus "★ 4.4 / 5 · 4 reviews · 64 days".
-/// Zeroed data renders as "no history", same as [PeerReputationCard].
+/// screens): a title line plus "★ 4.4 / 5 · 4 reviews · 64 days". A
+/// counterpart with no history reads as zeros, same as [PeerReputationCard].
 class PeerReputationInline extends StatelessWidget {
   final UserInfo reputation;
   final bool counterpartIsBuyer;
@@ -369,37 +360,28 @@ class PeerReputationInline extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 4),
-        if (reputation.hasNoHistory)
-          Text(
-            S.of(context)!.noReputationHistory,
-            style: const TextStyle(
-              color: AppTheme.textPrimary,
-              fontSize: 16,
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.star,
+              color: AppTheme.mostroGreen,
+              size: 18,
             ),
-          )
-        else
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.star,
-                color: AppTheme.mostroGreen,
-                size: 18,
-              ),
-              const SizedBox(width: 6),
-              Flexible(
-                child: Text(
-                  '${reputation.rating.toStringAsFixed(1)} / 5 · '
-                  '${S.of(context)!.reputationReviewsCount(reputation.reviews)} · '
-                  '${S.of(context)!.reputationDaysCount(reputation.operatingDays)}',
-                  style: const TextStyle(
-                    color: AppTheme.textPrimary,
-                    fontSize: 16,
-                  ),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                '${reputation.rating.toStringAsFixed(1)} / 5 · '
+                '${S.of(context)!.reputationReviewsCount(reputation.reviews)} · '
+                '${S.of(context)!.reputationDaysCount(reputation.operatingDays)}',
+                style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 16,
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/lib/shared/widgets/order_cards.dart
+++ b/lib/shared/widgets/order_cards.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/core/automation/automation_id.dart';
 import 'package:mostro_mobile/core/automation/automation_ids.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
 import 'package:mostro_mobile/shared/widgets/custom_card.dart';
 
 import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
@@ -274,116 +275,256 @@ class CreatorReputationCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                // Rating section
-                Expanded(
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(
-                            Icons.star,
-                            color: AppTheme.mostroGreen,
-                            size: 16,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            rating.toStringAsFixed(1),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        S.of(context)!.ratingTitleLabel,
-                        style: TextStyle(
-                          color: Colors.white70,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                // Reviews section
-                Expanded(
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const Icon(
-                            Icons.person_outline,
-                            color: Colors.white70,
-                            size: 16,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            reviews.toString(),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        S.of(context)!.reviewsLabel,
-                        style: TextStyle(
-                          color: Colors.white70,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                // Days section
-                Expanded(
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const Icon(
-                            Icons.calendar_today_outlined,
-                            color: Colors.white70,
-                            size: 16,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            days.toString(),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        S.of(context)!.daysLabel,
-                        style: TextStyle(
-                          color: Colors.white70,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+            _ReputationMetricsRow(
+              rating: rating,
+              reviews: reviews,
+              days: days,
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Card that displays the counterpart's reputation, from the daemon's
+/// taker-reputation notice. Zeroed data (new user or full-privacy taker)
+/// renders as "no history" instead of a misleading 0-star rating.
+class PeerReputationCard extends StatelessWidget {
+  final UserInfo reputation;
+  final bool counterpartIsBuyer;
+
+  const PeerReputationCard({
+    super.key,
+    required this.reputation,
+    required this.counterpartIsBuyer,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomCard(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              counterpartIsBuyer
+                  ? S.of(context)!.buyerReputationLabel
+                  : S.of(context)!.sellerReputationLabel,
+              style: TextStyle(
+                color: Colors.white70,
+                fontSize: 12,
+              ),
+            ),
+            const SizedBox(height: 12),
+            if (reputation.hasNoHistory)
+              Text(
+                S.of(context)!.noReputationHistory,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                ),
+              )
+            else
+              _ReputationMetricsRow(
+                rating: reputation.rating,
+                reviews: reputation.reviews,
+                days: reputation.operatingDays,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Compact, cardless counterpart reputation for dense layouts (invoice
+/// screens): a title line plus "★ 4.4 / 5 · 4 reviews · 64 days".
+/// Zeroed data renders as "no history", same as [PeerReputationCard].
+class PeerReputationInline extends StatelessWidget {
+  final UserInfo reputation;
+  final bool counterpartIsBuyer;
+
+  const PeerReputationInline({
+    super.key,
+    required this.reputation,
+    required this.counterpartIsBuyer,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          counterpartIsBuyer
+              ? S.of(context)!.buyerReputationLabel
+              : S.of(context)!.sellerReputationLabel,
+          style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 4),
+        if (reputation.hasNoHistory)
+          Text(
+            S.of(context)!.noReputationHistory,
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 16,
+            ),
+          )
+        else
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.star,
+                color: AppTheme.mostroGreen,
+                size: 18,
+              ),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  '${reputation.rating.toStringAsFixed(1)} / 5 · '
+                  '${S.of(context)!.reputationReviewsCount(reputation.reviews)} · '
+                  '${S.of(context)!.reputationDaysCount(reputation.operatingDays)}',
+                  style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 16,
+                  ),
+                ),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+}
+
+/// Shared rating / reviews / days row used by the reputation cards
+class _ReputationMetricsRow extends StatelessWidget {
+  final double rating;
+  final int reviews;
+  final int days;
+
+  const _ReputationMetricsRow({
+    required this.rating,
+    required this.reviews,
+    required this.days,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: [
+        // Rating section
+        Expanded(
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.star,
+                    color: AppTheme.mostroGreen,
+                    size: 16,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    rating.toStringAsFixed(1),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                S.of(context)!.ratingTitleLabel,
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Reviews section
+        Expanded(
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.person_outline,
+                    color: Colors.white70,
+                    size: 16,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    reviews.toString(),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                S.of(context)!.reviewsLabel,
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Days section
+        Expanded(
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.calendar_today_outlined,
+                    color: Colors.white70,
+                    size: 16,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    days.toString(),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                S.of(context)!.daysLabel,
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/shared/widgets/pay_lightning_invoice_widget.dart
+++ b/lib/shared/widgets/pay_lightning_invoice_widget.dart
@@ -17,6 +17,9 @@ class PayLightningInvoiceWidget extends StatefulWidget {
   final String fiatCode;
   final String orderId;
 
+  /// Replaces the built-in heading text when provided (see [InvoiceHeader]).
+  final Widget? header;
+
   const PayLightningInvoiceWidget({
     super.key,
     required this.onSubmit,
@@ -26,6 +29,7 @@ class PayLightningInvoiceWidget extends StatefulWidget {
     required this.fiatAmount,
     required this.fiatCode,
     required this.orderId,
+    this.header,
   });
 
   @override
@@ -39,16 +43,19 @@ class _PayLightningInvoiceWidgetState extends State<PayLightningInvoiceWidget> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Text(
-          S.of(context)!.payInvoiceToContinue(
-            widget.sats.toString(),
-            widget.fiatCode,
-            widget.fiatAmount,
-            widget.orderId,
+        if (widget.header != null)
+          SizedBox(width: double.infinity, child: widget.header!)
+        else
+          Text(
+            S.of(context)!.payInvoiceToContinue(
+                  widget.sats.toString(),
+                  widget.fiatCode,
+                  widget.fiatAmount,
+                  widget.orderId,
+                ),
+            style: const TextStyle(color: AppTheme.cream1, fontSize: 18),
+            textAlign: TextAlign.center,
           ),
-          style: const TextStyle(color: AppTheme.cream1, fontSize: 18),
-          textAlign: TextAlign.center,
-        ),
         const SizedBox(height: 20),
         Container(
           padding: const EdgeInsets.all(8.0),
@@ -100,12 +107,14 @@ class _PayLightningInvoiceWidgetState extends State<PayLightningInvoiceWidget> {
                   final uri = Uri.parse('lightning:${widget.lnInvoice}');
                   if (await canLaunchUrl(uri)) {
                     await launchUrl(uri);
-                    logger.i('Launched Lightning wallet with invoice: ${widget.lnInvoice}');
+                    logger.i(
+                        'Launched Lightning wallet with invoice: ${widget.lnInvoice}');
                   } else {
                     // Fallback to generic share if no Lightning apps available
                     // lightning: URL scheme is not necessary then
                     await Share.share(widget.lnInvoice);
-                    logger.i('Shared LN Invoice via share sheet: ${widget.lnInvoice}');
+                    logger.i(
+                        'Shared LN Invoice via share sheet: ${widget.lnInvoice}');
                   }
                 } catch (e) {
                   logger.e('Failed to share LN Invoice: $e');

--- a/test/data/models/protocol_payloads_test.dart
+++ b/test/data/models/protocol_payloads_test.dart
@@ -505,6 +505,32 @@ void main() {
       );
     });
 
+    // Empty pubkey is mostrod's only marker for this notice: notify_taker_
+    // reputation is the sole emitter, so unknown shapes stay informational
+    test('an empty pubkey is the notice even without a reputation', () {
+      expect(
+        peerMessage(Action.addInvoice, Peer(publicKey: ''))
+            .isTakerReputationNotice,
+        isTrue,
+      );
+    });
+
+    // Requiring the action instead would send a future third call site into
+    // the status machine, which is what keying on the pubkey prevents
+    test('an empty pubkey is the notice on any other action', () {
+      expect(
+        peerMessage(
+          Action.fiatSentOk,
+          Peer(
+            publicKey: '',
+            reputation:
+                const UserInfo(rating: 5.0, reviews: 9, operatingDays: 30),
+          ),
+        ).isTakerReputationNotice,
+        isTrue,
+      );
+    });
+
     test('a message without a Peer payload is never the notice', () {
       expect(
         MostroMessage(action: Action.payInvoice, id: 'order-1')

--- a/test/data/models/protocol_payloads_test.dart
+++ b/test/data/models/protocol_payloads_test.dart
@@ -8,6 +8,7 @@ import 'package:mostro_mobile/data/models/orders_response.dart';
 import 'package:mostro_mobile/data/models/payload.dart';
 import 'package:mostro_mobile/data/models/payment_failed.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
 import 'package:mostro_mobile/data/models/rating_user.dart';
 import 'package:mostro_mobile/data/models/text_message.dart';
 
@@ -263,8 +264,58 @@ void main() {
       expect(Peer.fromJson(const {'pubkey': _pubkey}).publicKey, _pubkey);
     });
 
-    test('rejects a pubkey that is not 64 hex characters', () {
-      expect(() => Peer(publicKey: ''), throwsArgumentError);
+    test('parses the daemon taker-reputation notice (empty pubkey)', () {
+      // Exact wire shape from mostrod's notify_taker_reputation()
+      final peer = Peer.fromJson(const {
+        'pubkey': '',
+        'reputation': {
+          'rating': 4.375,
+          'reviews': 4,
+          'operating_days': 64,
+        },
+      });
+
+      expect(peer.publicKey, isEmpty);
+      expect(peer.reputation, isNotNull);
+      expect(peer.reputation!.rating, 4.375);
+      expect(peer.reputation!.reviews, 4);
+      expect(peer.reputation!.operatingDays, 64);
+      expect(peer.reputation!.hasNoHistory, isFalse);
+    });
+
+    test('parses a zeroed reputation (new user or full privacy)', () {
+      final peer = Peer.fromJson(const {
+        'pubkey': '',
+        'reputation': {'rating': 0.0, 'reviews': 0, 'operating_days': 0},
+      });
+
+      expect(peer.reputation!.hasNoHistory, isTrue);
+    });
+
+    test('parses a real pubkey with reputation absent (fiat-sent-ok shape)',
+        () {
+      final peer = Peer.fromJson(const {'pubkey': _pubkey});
+
+      expect(peer.publicKey, _pubkey);
+      expect(peer.reputation, isNull);
+    });
+
+    test('round-trips the reputation through toJson', () {
+      final peer = Peer.fromJson(const {
+        'pubkey': '',
+        'reputation': {'rating': 4.375, 'reviews': 4, 'operating_days': 64},
+      });
+
+      expect(peer.toJson(), {
+        'peer': {
+          'pubkey': '',
+          'reputation': {'rating': 4.375, 'reviews': 4, 'operating_days': 64},
+        }
+      });
+      expect(Peer.fromJson(peer.toJson()['peer']), equals(peer));
+    });
+
+    test('rejects a non-empty pubkey that is not 64 hex characters', () {
       expect(() => Peer(publicKey: 'abc'), throwsArgumentError);
       expect(() => Peer(publicKey: 'z' * 64), throwsArgumentError);
     });
@@ -272,15 +323,24 @@ void main() {
     test('throws FormatException for malformed JSON', () {
       expect(() => Peer.fromJson(const {}), throwsFormatException);
       expect(() => Peer.fromJson(const {'pubkey': 42}), throwsFormatException);
-      expect(() => Peer.fromJson(const {'pubkey': ''}), throwsFormatException);
       expect(() => Peer.fromJson(const {'pubkey': 'short'}),
           throwsFormatException);
     });
 
-    test('compares by pubkey', () {
+    test('compares by pubkey and reputation', () {
       expect(Peer(publicKey: _pubkey), Peer(publicKey: _pubkey));
-      expect(Peer(publicKey: _pubkey).hashCode, _pubkey.hashCode);
-      expect(Peer(publicKey: _pubkey).toString(), 'Peer(publicKey: $_pubkey)');
+      expect(
+        Peer(publicKey: _pubkey).hashCode,
+        Peer(publicKey: _pubkey).hashCode,
+      );
+      expect(
+        Peer(publicKey: _pubkey),
+        isNot(equals(Peer(
+          publicKey: _pubkey,
+          reputation:
+              const UserInfo(rating: 5.0, reviews: 1, operatingDays: 1),
+        ))),
+      );
     });
   });
 

--- a/test/data/models/protocol_payloads_test.dart
+++ b/test/data/models/protocol_payloads_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
 import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/data/models/last_trade_index_response.dart';
 import 'package:mostro_mobile/data/models/next_trade.dart';
 import 'package:mostro_mobile/data/models/nostr_filter.dart';
@@ -470,6 +472,45 @@ void main() {
 
     test('SecureStorageKeys rejects an unknown key', () {
       expect(() => SecureStorageKeys.fromString('nope'), throwsArgumentError);
+    });
+  });
+
+  group('MostroMessage.isTakerReputationNotice', () {
+    MostroMessage<Peer> peerMessage(Action action, Peer peer) =>
+        MostroMessage<Peer>(action: action, id: 'order-1', payload: peer);
+
+    test('recognises the empty-pubkey notice on either flow action', () {
+      final peer = Peer(
+        publicKey: '',
+        reputation:
+            const UserInfo(rating: 4.375, reviews: 4, operatingDays: 64),
+      );
+
+      expect(peerMessage(Action.payInvoice, peer).isTakerReputationNotice,
+          isTrue);
+      expect(peerMessage(Action.addInvoice, peer).isTakerReputationNotice,
+          isTrue);
+    });
+
+    test('a Peer carrying a real pubkey is a normal flow message', () {
+      expect(
+        peerMessage(Action.fiatSentOk, Peer(publicKey: _pubkey))
+            .isTakerReputationNotice,
+        isFalse,
+      );
+      expect(
+        peerMessage(Action.addInvoice, Peer(publicKey: _pubkey))
+            .isTakerReputationNotice,
+        isFalse,
+      );
+    });
+
+    test('a message without a Peer payload is never the notice', () {
+      expect(
+        MostroMessage(action: Action.payInvoice, id: 'order-1')
+            .isTakerReputationNotice,
+        isFalse,
+      );
     });
   });
 }

--- a/test/data/models/protocol_payloads_test.dart
+++ b/test/data/models/protocol_payloads_test.dart
@@ -280,7 +280,6 @@ void main() {
       expect(peer.reputation!.rating, 4.375);
       expect(peer.reputation!.reviews, 4);
       expect(peer.reputation!.operatingDays, 64);
-      expect(peer.reputation!.hasNoHistory, isFalse);
     });
 
     test('parses a zeroed reputation (new user or full privacy)', () {
@@ -289,7 +288,9 @@ void main() {
         'reputation': {'rating': 0.0, 'reviews': 0, 'operating_days': 0},
       });
 
-      expect(peer.reputation!.hasNoHistory, isTrue);
+      expect(peer.reputation!.rating, 0.0);
+      expect(peer.reputation!.reviews, 0);
+      expect(peer.reputation!.operatingDays, 0);
     });
 
     test('parses a real pubkey with reputation absent (fiat-sent-ok shape)',
@@ -337,8 +338,7 @@ void main() {
         Peer(publicKey: _pubkey),
         isNot(equals(Peer(
           publicKey: _pubkey,
-          reputation:
-              const UserInfo(rating: 5.0, reviews: 1, operatingDays: 1),
+          reputation: const UserInfo(rating: 5.0, reviews: 1, operatingDays: 1),
         ))),
       );
     });

--- a/test/features/notifications/utils/notification_data_extractor_test.dart
+++ b/test/features/notifications/utils/notification_data_extractor_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/peer.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
+import 'package:mostro_mobile/features/notifications/utils/notification_data_extractor.dart';
+
+MostroMessage<Peer> reputationNotice(Action action) => MostroMessage<Peer>(
+      action: action,
+      id: 'order-1',
+      payload: Peer(
+        publicKey: '',
+        reputation:
+            const UserInfo(rating: 4.375, reviews: 4, operatingDays: 64),
+      ),
+    );
+
+void main() {
+  group('NotificationDataExtractor', () {
+    test('the taker-reputation notice produces no notification', () async {
+      // Filtered inside the extractor so the background service, which calls
+      // it directly, cannot fire a second notification for the same action
+      for (final action in [Action.payInvoice, Action.addInvoice]) {
+        expect(
+          await NotificationDataExtractor.extractFromMostroMessage(
+              reputationNotice(action), null),
+          isNull,
+          reason: '$action notice must stay silent',
+        );
+      }
+    });
+
+    test('the real flow message still notifies', () async {
+      final data = await NotificationDataExtractor.extractFromMostroMessage(
+        MostroMessage(action: Action.addInvoice, id: 'order-1'),
+        null,
+      );
+
+      expect(data, isNotNull);
+      expect(data!.action, Action.addInvoice);
+      expect(data.orderId, 'order-1');
+    });
+  });
+}

--- a/test/features/order/models/order_state_test.dart
+++ b/test/features/order/models/order_state_test.dart
@@ -196,6 +196,58 @@ void main() {
       expect(state.peerReputation, reputation);
     });
 
+    test('the notice never moves the order it rides on', () {
+      final state = baseState(
+        status: Status.waitingTakerBond,
+        action: Action.payBondInvoice,
+      ).updateWith(
+        message<Peer>(
+          Action.addInvoice,
+          payload: Peer(publicKey: '', reputation: reputation),
+        ),
+      );
+
+      // addInvoice would normally map to waiting-buyer-invoice
+      expect(state.status, Status.waitingTakerBond);
+      expect(state.action, Action.payBondInvoice);
+      expect(state.peerReputation, reputation);
+    });
+
+    test('a late notice cannot roll back an order that already advanced', () {
+      var state = baseState()
+          .updateWith(
+            message<Peer>(
+              Action.payInvoice,
+              payload: Peer(publicKey: '', reputation: reputation),
+            ),
+          )
+          .updateWith(
+            message<Order>(
+              Action.fiatSentOk,
+              payload: order(
+                status: Status.fiatSent,
+                buyerTradePubkey: _buyerPubkey,
+              ),
+            ),
+          );
+      expect(state.status, Status.fiatSent);
+
+      // Redelivered by a slow relay long after the trade moved on
+      final afterLateNotice = state.updateWith(
+        message<Peer>(
+          Action.payInvoice,
+          payload: Peer(publicKey: '', reputation: reputation),
+        ),
+      );
+
+      expect(afterLateNotice.status, Status.fiatSent);
+      expect(afterLateNotice.action, Action.fiatSentOk);
+      expect(afterLateNotice.order, state.order);
+      expect(afterLateNotice.peer?.publicKey, _buyerPubkey);
+      expect(afterLateNotice.fiatWasSent, isTrue);
+      expect(afterLateNotice.peerReputation, reputation);
+    });
+
     test('fromMostroMessage picks the snapshot up without setting a peer', () {
       final state = OrderState.fromMostroMessage(
         message<Peer>(

--- a/test/features/order/models/order_state_test.dart
+++ b/test/features/order/models/order_state_test.dart
@@ -6,6 +6,7 @@ import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/data/models/payload.dart';
 import 'package:mostro_mobile/data/models/payment_failed.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 
 const _buyerPubkey =
@@ -154,6 +155,57 @@ void main() {
       expect(updated.cantDo?.cantDoReason, CantDoReason.notFound);
       expect(updated.peer?.publicKey, _buyerPubkey);
       expect(updated.paymentFailed?.paymentAttempts, 1);
+    });
+  });
+
+  group('OrderState peerReputation', () {
+    const reputation = UserInfo(rating: 4.375, reviews: 4, operatingDays: 64);
+
+    test('updateWith stores the snapshot from a reputation-only Peer', () {
+      final state = baseState().updateWith(
+        message<Peer>(
+          Action.payInvoice,
+          payload: Peer(publicKey: '', reputation: reputation),
+        ),
+      );
+
+      expect(state.peerReputation, reputation);
+      // An empty pubkey must never become the tracked counterpart
+      expect(state.peer, isNull);
+    });
+
+    test('is preserved across later messages without reputation', () {
+      var state = baseState().updateWith(
+        message<Peer>(
+          Action.addInvoice,
+          payload: Peer(publicKey: '', reputation: reputation),
+        ),
+      );
+
+      // fiat-sent-ok shape: real pubkey, reputation absent
+      state = state.updateWith(
+        message<Peer>(
+          Action.fiatSentOk,
+          payload: Peer(publicKey: _buyerPubkey),
+        ),
+      );
+      expect(state.peerReputation, reputation);
+      expect(state.peer?.publicKey, _buyerPubkey);
+
+      state = state.updateWith(message(Action.rate));
+      expect(state.peerReputation, reputation);
+    });
+
+    test('fromMostroMessage picks the snapshot up without setting a peer', () {
+      final state = OrderState.fromMostroMessage(
+        message<Peer>(
+          Action.addInvoice,
+          payload: Peer(publicKey: '', reputation: reputation),
+        ),
+      );
+
+      expect(state.peerReputation, reputation);
+      expect(state.peer, isNull);
     });
   });
 

--- a/test/features/order/models/order_state_test.dart
+++ b/test/features/order/models/order_state_test.dart
@@ -248,6 +248,73 @@ void main() {
       expect(afterLateNotice.peerReputation, reputation);
     });
 
+    test('a republish after the taker times out drops the snapshot', () {
+      var state = baseState()
+          .updateWith(
+            message<Peer>(
+              Action.payInvoice,
+              payload: Peer(publicKey: '', reputation: reputation),
+            ),
+          )
+          .updateWith(
+            message<Order>(
+              Action.waitingBuyerInvoice,
+              payload: order(status: Status.waitingBuyerInvoice),
+            ),
+          );
+      expect(state.peerReputation, reputation);
+
+      // Mostro returns the maker's order to the book: there is no taker now
+      state = state.updateWith(
+        message<Order>(Action.newOrder, payload: order(status: Status.pending)),
+      );
+
+      expect(state.status, Status.pending);
+      expect(state.peerReputation, isNull);
+    });
+
+    test('the next taker snapshot replaces the one that was dropped', () {
+      const nextTaker = UserInfo(rating: 2.0, reviews: 1, operatingDays: 3);
+
+      var state = baseState()
+          .updateWith(
+            message<Peer>(
+              Action.payInvoice,
+              payload: Peer(publicKey: '', reputation: reputation),
+            ),
+          )
+          .updateWith(
+            message<Order>(
+              Action.waitingBuyerInvoice,
+              payload: order(status: Status.waitingBuyerInvoice),
+            ),
+          )
+          .updateWith(
+            message<Order>(
+              Action.newOrder,
+              payload: order(status: Status.pending),
+            ),
+          );
+      expect(state.peerReputation, isNull);
+
+      state = state.updateWith(
+        message<Peer>(
+          Action.payInvoice,
+          payload: Peer(publicKey: '', reputation: nextTaker),
+        ),
+      );
+
+      expect(state.peerReputation, nextTaker);
+    });
+
+    test('copyWith clears the snapshot only when asked to', () {
+      final state = baseState().copyWith(peerReputation: reputation);
+
+      // A bare null preserves, like every other copyWith field
+      expect(state.copyWith(peerReputation: null).peerReputation, reputation);
+      expect(state.copyWith(clearPeerReputation: true).peerReputation, isNull);
+    });
+
     test('fromMostroMessage picks the snapshot up without setting a peer', () {
       final state = OrderState.fromMostroMessage(
         message<Peer>(

--- a/test/shared/widgets/invoice_header_test.dart
+++ b/test/shared/widgets/invoice_header_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models/user_info.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/widgets/invoice_header.dart';
@@ -8,6 +9,7 @@ Future<void> pumpHeader(
   WidgetTester tester, {
   required bool userIsSeller,
   UserInfo? reputation,
+  bool takenByCounterpart = true,
 }) {
   return tester.pumpWidget(
     MaterialApp(
@@ -20,6 +22,7 @@ Future<void> pumpHeader(
           fiatAmount: '235',
           fiatCode: 'CUP',
           orderId: '20a5d3c2-e69d-4f63-b57c-c97beffbd939',
+          takenByCounterpart: takenByCounterpart,
           reputation: reputation,
         ),
       ),
@@ -105,5 +108,99 @@ void main() {
           .first,
     );
     expect(column.crossAxisAlignment, CrossAxisAlignment.start);
+  });
+
+  testWidgets('a taker gets the instruction without the took-your-order line',
+      (tester) async {
+    await pumpHeader(tester, userIsSeller: true, takenByCounterpart: false);
+
+    expect(find.text('A buyer has taken your sell order.'), findsNothing);
+    expect(
+      find.text('If you want to continue with the exchange, pay this '
+          'Lightning invoice for 550 sats, equivalent to 235 CUP.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Order ID: 20a5d3c2-e69d-4f63-b57c-c97beffbd939',
+          findRichText: true),
+      findsOneWidget,
+    );
+  });
+
+  group('counterpartTookYourOrder', () {
+    test('is true for the maker at the handoff', () {
+      // Sell order: the maker is the seller, waiting to pay the hold invoice
+      expect(
+        counterpartTookYourOrder(
+          kind: OrderType.sell,
+          role: Role.seller,
+          status: Status.waitingPayment,
+        ),
+        isTrue,
+      );
+      // Buy order: the maker is the buyer, waiting to hand over an invoice
+      expect(
+        counterpartTookYourOrder(
+          kind: OrderType.buy,
+          role: Role.buyer,
+          status: Status.waitingBuyerInvoice,
+        ),
+        isTrue,
+      );
+    });
+
+    test('is false for a taker reaching the same screens', () {
+      // Took a buy order, so pays the hold invoice as the seller
+      expect(
+        counterpartTookYourOrder(
+          kind: OrderType.buy,
+          role: Role.seller,
+          status: Status.waitingPayment,
+        ),
+        isFalse,
+      );
+      // Took a sell order, so adds an invoice as the buyer
+      expect(
+        counterpartTookYourOrder(
+          kind: OrderType.sell,
+          role: Role.buyer,
+          status: Status.waitingBuyerInvoice,
+        ),
+        isFalse,
+      );
+    });
+
+    test('is false for the maker retrying after a failed payout', () {
+      for (final status in [Status.paymentFailed, Status.settledHoldInvoice]) {
+        expect(
+          counterpartTookYourOrder(
+            kind: OrderType.buy,
+            role: Role.buyer,
+            status: status,
+          ),
+          isFalse,
+          reason: 'nobody took anything at $status',
+        );
+      }
+    });
+
+    test('is false while the role or the order is still unknown', () {
+      expect(
+        counterpartTookYourOrder(
+          kind: OrderType.sell,
+          role: null,
+          status: Status.waitingPayment,
+        ),
+        isFalse,
+      );
+      expect(
+        counterpartTookYourOrder(
+          kind: null,
+          role: Role.seller,
+          status: Status.waitingPayment,
+        ),
+        isFalse,
+      );
+    });
   });
 }

--- a/test/shared/widgets/invoice_header_test.dart
+++ b/test/shared/widgets/invoice_header_test.dart
@@ -68,7 +68,6 @@ void main() {
 
     expect(find.text('A buyer has taken your sell order.'), findsOneWidget);
     expect(find.text("Buyer's Reputation"), findsNothing);
-    expect(find.text('No reputation history yet'), findsNothing);
   });
 
   testWidgets('every line shares one size and inherits the theme font',

--- a/test/shared/widgets/invoice_header_test.dart
+++ b/test/shared/widgets/invoice_header_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/widgets/invoice_header.dart';
+
+Future<void> pumpHeader(
+  WidgetTester tester, {
+  required bool userIsSeller,
+  UserInfo? reputation,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: S.localizationsDelegates,
+      supportedLocales: S.supportedLocales,
+      home: Scaffold(
+        body: InvoiceHeader(
+          userIsSeller: userIsSeller,
+          sats: 550,
+          fiatAmount: '235',
+          fiatCode: 'CUP',
+          orderId: '20a5d3c2-e69d-4f63-b57c-c97beffbd939',
+          reputation: reputation,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  const reputation = UserInfo(rating: 2.5, reviews: 1, operatingDays: 4);
+
+  testWidgets('seller flow: pay instruction and buyer reputation',
+      (tester) async {
+    await pumpHeader(tester, userIsSeller: true, reputation: reputation);
+
+    expect(find.text('A buyer has taken your sell order.'), findsOneWidget);
+    expect(
+      find.text('If you want to continue with the exchange, pay this '
+          'Lightning invoice for 550 sats, equivalent to 235 CUP.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Order ID: 20a5d3c2-e69d-4f63-b57c-c97beffbd939',
+          findRichText: true),
+      findsOneWidget,
+    );
+    expect(find.text("Buyer's Reputation"), findsOneWidget);
+    expect(find.text('2.5 / 5 · 1 review · 4 days'), findsOneWidget);
+  });
+
+  testWidgets('buyer flow: add instruction and seller reputation',
+      (tester) async {
+    await pumpHeader(tester, userIsSeller: false, reputation: reputation);
+
+    expect(find.text('A seller has taken your buy order.'), findsOneWidget);
+    expect(
+      find.text('If you want to continue with the exchange, add a '
+          'Lightning invoice for 550 sats, equivalent to 235 CUP.'),
+      findsOneWidget,
+    );
+    expect(find.text("Seller's Reputation"), findsOneWidget);
+  });
+
+  testWidgets('omits the reputation block when none was received',
+      (tester) async {
+    await pumpHeader(tester, userIsSeller: true);
+
+    expect(find.text('A buyer has taken your sell order.'), findsOneWidget);
+    expect(find.text("Buyer's Reputation"), findsNothing);
+    expect(find.text('No reputation history yet'), findsNothing);
+  });
+
+  testWidgets('every line shares one size and inherits the theme font',
+      (tester) async {
+    await pumpHeader(tester, userIsSeller: true, reputation: reputation);
+
+    final texts = tester.widgetList<Text>(
+      find.descendant(
+        of: find.byType(InvoiceHeader),
+        matching: find.byType(Text),
+      ),
+    );
+
+    expect(texts, isNotEmpty);
+    for (final text in texts) {
+      expect(text.style?.fontSize, 16, reason: 'mixed text sizes: $text');
+      // No hardcoded family: the theme font must come through
+      expect(text.style?.fontFamily, isNull);
+    }
+    // The order id line must be a Text.rich: a bare RichText would bypass
+    // DefaultTextStyle and render in a different font
+    final richLine = texts.firstWhere((t) => t.textSpan != null);
+    expect(richLine.textSpan!.toPlainText(), startsWith('Order ID: '));
+  });
+
+  testWidgets('every line is left aligned', (tester) async {
+    await pumpHeader(tester, userIsSeller: true, reputation: reputation);
+
+    final column = tester.widget<Column>(
+      find
+          .descendant(
+            of: find.byType(InvoiceHeader),
+            matching: find.byType(Column),
+          )
+          .first,
+    );
+    expect(column.crossAxisAlignment, CrossAxisAlignment.start);
+  });
+}

--- a/test/shared/widgets/peer_reputation_card_test.dart
+++ b/test/shared/widgets/peer_reputation_card_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(find.text("Seller's Reputation"), findsOneWidget);
   });
 
-  testWidgets('zeroed reputation renders as no history, not 0 stars',
+  testWidgets('zeroed reputation keeps the same card with every metric at 0',
       (tester) async {
     await pumpCard(
       tester,
@@ -50,8 +50,13 @@ void main() {
       counterpartIsBuyer: true,
     );
 
-    expect(find.text('No reputation history yet'), findsOneWidget);
-    expect(find.text('0.0'), findsNothing);
+    expect(find.text("Buyer's Reputation"), findsOneWidget);
+    expect(find.text('0.0'), findsOneWidget);
+    expect(find.text('0'), findsNWidgets(2));
+    // The three metric captions stay in place
+    expect(find.text('Rating'), findsOneWidget);
+    expect(find.text('Reviews'), findsOneWidget);
+    expect(find.text('Days'), findsOneWidget);
   });
 
   group('PeerReputationInline', () {
@@ -96,14 +101,16 @@ void main() {
       expect(find.text('4.4 / 5 · 4 reviews · 64 days'), findsOneWidget);
     });
 
-    testWidgets('zeroed reputation renders as no history', (tester) async {
+    testWidgets('zeroed reputation keeps the line with every metric at 0',
+        (tester) async {
       await pumpInline(
         tester,
         reputation: const UserInfo(rating: 0.0, reviews: 0, operatingDays: 0),
         counterpartIsBuyer: true,
       );
 
-      expect(find.text('No reputation history yet'), findsOneWidget);
+      expect(find.text("Buyer's Reputation"), findsOneWidget);
+      expect(find.text('0.0 / 5 · 0 reviews · 0 days'), findsOneWidget);
     });
   });
 }

--- a/test/shared/widgets/peer_reputation_card_test.dart
+++ b/test/shared/widgets/peer_reputation_card_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/user_info.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/widgets/order_cards.dart';
+
+Future<void> pumpCard(
+  WidgetTester tester, {
+  required UserInfo reputation,
+  required bool counterpartIsBuyer,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: S.localizationsDelegates,
+      supportedLocales: S.supportedLocales,
+      home: Scaffold(
+        body: PeerReputationCard(
+          reputation: reputation,
+          counterpartIsBuyer: counterpartIsBuyer,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  const reputation = UserInfo(rating: 4.375, reviews: 4, operatingDays: 64);
+
+  testWidgets('renders the buyer title and the three metrics', (tester) async {
+    await pumpCard(tester, reputation: reputation, counterpartIsBuyer: true);
+
+    expect(find.text("Buyer's Reputation"), findsOneWidget);
+    expect(find.text('4.4'), findsOneWidget);
+    expect(find.text('4'), findsOneWidget);
+    expect(find.text('64'), findsOneWidget);
+    expect(find.text('No reputation history yet'), findsNothing);
+  });
+
+  testWidgets('renders the seller title', (tester) async {
+    await pumpCard(tester, reputation: reputation, counterpartIsBuyer: false);
+
+    expect(find.text("Seller's Reputation"), findsOneWidget);
+  });
+
+  testWidgets('zeroed reputation renders as no history, not 0 stars',
+      (tester) async {
+    await pumpCard(
+      tester,
+      reputation: const UserInfo(rating: 0.0, reviews: 0, operatingDays: 0),
+      counterpartIsBuyer: true,
+    );
+
+    expect(find.text('No reputation history yet'), findsOneWidget);
+    expect(find.text('0.0'), findsNothing);
+  });
+
+  group('PeerReputationInline', () {
+    Future<void> pumpInline(
+      WidgetTester tester, {
+      required UserInfo reputation,
+      required bool counterpartIsBuyer,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: Scaffold(
+            body: PeerReputationInline(
+              reputation: reputation,
+              counterpartIsBuyer: counterpartIsBuyer,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the compact single-line summary', (tester) async {
+      await pumpInline(
+        tester,
+        reputation: const UserInfo(rating: 2.5, reviews: 1, operatingDays: 4),
+        counterpartIsBuyer: true,
+      );
+
+      expect(find.text("Buyer's Reputation"), findsOneWidget);
+      expect(find.text('2.5 / 5 · 1 review · 4 days'), findsOneWidget);
+    });
+
+    testWidgets('pluralizes reviews and days', (tester) async {
+      await pumpInline(
+        tester,
+        reputation: reputation,
+        counterpartIsBuyer: false,
+      );
+
+      expect(find.text("Seller's Reputation"), findsOneWidget);
+      expect(find.text('4.4 / 5 · 4 reviews · 64 days'), findsOneWidget);
+    });
+
+    testWidgets('zeroed reputation renders as no history', (tester) async {
+      await pumpInline(
+        tester,
+        reputation: const UserInfo(rating: 0.0, reviews: 0, operatingDays: 0),
+        counterpartIsBuyer: true,
+      );
+
+      expect(find.text('No reputation history yet'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
The daemon sends the maker an extra DM carrying the
taker's reputation: a `Peer` payload with an empty pubkey riding the same
`pay-invoice` / `add-invoice` action as the flow message. Mobile threw while
parsing that empty pubkey and dropped the whole DM before storage, so the
data never reached the app.

- Parse it: new `UserInfo` model, optional `Peer.reputation`, and an empty
  pubkey is now accepted (non-empty ones keep the 64-hex validation).
- Track it in `OrderState.peerReputation`, preserved across later messages
  (the `fiat-sent-ok` Peer carries no reputation and must not clear it) and
  never promoted to the tracked counterpart.
- Show it in the order details and on the two invoice screens, together with
  who took the order. Every screen watches order state, so it renders whenever
  the notice arrives — before or after the screen opened — and simply never
  appears on older daemons.
- Zeroed data renders as zeros in every metric: a brand-new user and a
  full-privacy taker are indistinguishable on the wire, so the card keeps its
  shape instead of claiming there is no history.
- New localization keys in the six supported languages.

#### The notice is informational only

It reuses a flow action but carries no order state, and message timestamps are
assigned on arrival rather than by the daemon, so a notice delayed by a slow
relay lands last and would roll an advanced order back to waiting-payment —
and the replay would reapply it on every restart.

- Detect it by payload shape (empty-pubkey Peer) in one shared getter, not by
  action, which would also have caught a real counterpart Peer and swallowed
  its navigation.
- Return early from `updateWith` with the snapshot alone, next to the `cantDo`
  guard, so it can never move the order.
- Suppress its notification in `NotificationDataExtractor` rather than in the
  notifier, so the background service stops firing a second push.

#### The snapshot belongs to one take cycle

Mostro republishes the maker's order when the taker times out, but the snapshot
survived every later message, so the next taker could be shown the previous
one's numbers.

- Clear `peerReputation` whenever the new status is pending: an order with no
  counterpart cannot have a counterpart reputation.
- Hide the card on a pending order as well. The notice carries no taker
  identity, so a very late one can repopulate the field after the republish.

#### Who took the order

The header opened with "a buyer/seller has taken your order" for everyone, but
both invoice screens are also reached by takers — taking a buy order means
paying the hold invoice, taking a sell one means adding an invoice — and by the
buyer asked for a fresh invoice after a failed payout. The maker is derived
from data already at hand: a sell order is published by its seller and a buy
order by its buyer, so the order kind matched against the session role
identifies who created it. When the line does not apply the header opens with
the exchange instruction, which was already role-correct, so no new keys.

#### Testing

`flutter analyze` is clean and there are unit tests covering the exact wire
from data already at hand: a sell order is published by its seller and a buy
order by its buyer, so the order kind matched against the session role
identifies who created it. When the line does not apply the header opens with
the exchange instruction, which was already role-correct, so no new keys.

#### Testing

`flutter analyze` is clean and there are unit tests covering the exact wire
shape, the state preservation and clearing rules, the notice detection, the
notification suppression and every header variant.

#### Note

Also corrects the CLAUDE.md i18n section, which listed three locales when the
repo has six.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buyer and seller reputation details, including ratings, reviews, and operating history.
  * Displayed counterpart reputation on trade details and invoice payment screens.
  * Added clearer invoice headers with order status, amounts, order IDs, and payment instructions.
  * Added notifications and handling for reputation-only order updates.
* **Localization**
  * Added reputation and invoice-related translations in English, German, Spanish, French, Italian, and Portuguese.
* **Bug Fixes**
  * Improved handling of reputation data when public key information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->