### PR TITLE
fix: anchor transport resolution and authenticate v1 message senders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,15 +125,28 @@ The app follows a specific initialization order in `appInitializerProvider`:
 
 1. **NostrService Initialization**: Establishes WebSocket connections to configured relays
 2. **KeyManager Initialization**: Loads cryptographic keys from secure storage  
-3. **SessionNotifier Initialization**: Loads active trading sessions from Sembast database
-4. **SubscriptionManager Creation**: Registers session listeners with `fireImmediately: false`
-5. **Background Services Setup**: Configures notification and sync services
-6. **Order Notifier Initialization**: Creates individual order managers for active sessions
+3. **ProtocolVersionStore Initialization**: Loads the persisted transport anchor from SharedPreferences
+4. **SessionNotifier Initialization**: Loads active trading sessions from Sembast database
+5. **SubscriptionManager Creation**: Registers session listeners with `fireImmediately: false`
+6. **Background Services Setup**: Configures notification and sync services
+7. **Order Notifier Initialization**: Creates individual order managers for active sessions
 
 ### Critical Timing Requirements
 - SessionNotifier must complete initialization before SubscriptionManager setup
 - SubscriptionManager uses `fireImmediately: false` to prevent premature execution
+- `ProtocolVersionStore.init()` must complete before SubscriptionManager builds its first orders filter, since that filter's kind depends on the resolved transport
 - Proper sequence ensures orders appear consistently in UI across app restarts
+
+## Transport Resolution (Protocol v1/v2)
+
+Mostro nodes speak one of two wire transports, advertised in the kind-38385 info event via a `protocol_version` tag: v1 (NIP-59 gift wrap, kind 1059) or v2 (NIP-44 direct message, kind 14). Detection is automatic; there is no setting.
+
+- **Single resolution point**: every caller reads `anchoredProtocolVersionFor(ref)` (`features/mostro/protocol_version_store.dart`), never `MostroInstance.protocolVersion` directly. The send path and the receive subscription must not disagree about the transport — a client publishing kind 1059 while listening on kind 14 is partitioned from the node.
+- **Three tag states**: `NostrEvent.assertedProtocolVersion` reads a parseable value as that version, an absent tag on a *verified* event as v1 (a pre-0.18.0 daemon asserting by omission), and a present-but-unusable value as null. The last two are different facts and must not collapse.
+- **Unknown degrades upwards**: no info event, an unreadable value, or a version this client does not speak resolves to `kDefaultTransport` (v2), not v1. Any relay can produce "unknown" by withholding the info event, and v1's intake authenticates nothing, so resolving unknown to v1 would make omission a downgrade primitive.
+- **Persisted anchor**: `ProtocolVersionStore` remembers, per node pubkey, the last verified version *and* the asserting event's signed `created_at`. The more recent assertion wins, with ties and undatable assertions falling back to the higher version. A relay can replay a signed event but cannot re-date one, so a replayed pre-migration v1 event loses against a recorded v2 — while an operator genuinely rolling a node back to v1 is followed.
+- **Never recorded**: a version this client cannot resolve, and an absent tag. Persisting the latter would let a relay resolve v1 from remembered state alone by simply withholding the info event.
+- **Full detail**: `docs/architecture/TRANSPORT_V2_MIGRATION.md` §4.1, referenced from the code comments.
 
 ## Timeout Detection & Orphan Session Prevention
 

--- a/docs/architecture/TRANSPORT_V2_MIGRATION.md
+++ b/docs/architecture/TRANSPORT_V2_MIGRATION.md
@@ -69,7 +69,8 @@ manual override: detection is automatic (decision below).
 ### Decisions (fixed)
 
 1. **Transport selection: auto-detection only.** Read `protocol_version` from
-   the node's kind-`38385` event. `"2"` → v2; `"1"` or absent → v1. No settings
+   the node's kind-`38385` event. `"2"` → v2; `"1"` or an absent tag on a
+   verified event → v1; anything else → the safe default (§4.1). No settings
    toggle.
 2. **`version` field tied to transport.** Send `version: 1` on the gift-wrap
    path (preserves today's exact wire for already-deployed daemons) and
@@ -86,7 +87,12 @@ A node advertises its transport in its kind-`38385` info event via a
 ["protocol_version", "1"]   → NIP-59 gift wrap (kind 1059), DEPRECATED
 ["protocol_version", "2"]   → NIP-44 direct (kind 14)
 (tag absent)                → legacy daemon → treat as v1
+["protocol_version", "abc"] → asserts nothing → safe default (§4.1)
+(no info event at all)      → no evidence    → safe default (§4.1)
 ```
+
+The last two are not the same as an absent tag, and §4.1 covers why the
+difference is load-bearing.
 
 The client already parses this event into `MostroInstance`
 (`lib/features/mostro/mostro_instance.dart`). Today the extension reads tags
@@ -224,16 +230,76 @@ of the chosen transport:
 enum Transport { giftWrap, nip44 } // v1 / v2
 ```
 
-One small resolver maps the node (via `MostroInstance.protocolVersion`, §2) to a
+One small resolver maps the node's advertised `protocol_version` (§2) to a
 `Transport`, and that single value is consumed by **both** the send path and the
-receive subscription filters. No UI, no persisted setting, no per-message
-override.
+receive subscription filters. No UI, no per-message override. Every caller reads
+`anchoredProtocolVersionFor(ref)` rather than reaching for
+`MostroInstance.protocolVersion` directly, so the two halves cannot disagree
+about which transport is in play.
 
-Degrade safely: when the `protocol_version` tag is absent or the node is
-unreachable, resolve to **`Transport.giftWrap` (v1)** rather than mis-pairing —
-this is the version-skew guard. The downgrade must be **logged explicitly** (at
-`warn`) so a misconfigured or unreachable node cannot silently leave the app in
-a degraded transport without anyone noticing.
+**The tag has three states, not two.** Collapsing them is a partition either
+way, so `NostrEvent.assertedProtocolVersion` keeps them apart:
+
+| Tag | Reads as | Why |
+|---|---|---|
+| Present, parseable | that version | `resolveTransport` decides what to do with one we do not speak |
+| Absent entirely | `kLegacyProtocolVersion` (v1) | on a *verified* event, silence is a pre-0.18.0 daemon asserting v1 by omission |
+| Present, unusable | `null` (no evidence) | the node meant to state a version and the value says nothing; reading `protocol_version=abc` as v1 would pair us with gift wrap against a node that may well speak NIP-44 |
+
+**Degrade upwards, not to v1.** When nothing is known — no info event yet, the
+node unreachable, a relay withholding the event, or a version this client does
+not speak — resolve to **`kDefaultTransport` = `Transport.nip44` (v2)**, and log
+an unsupported value at `warn`.
+
+The direction is a security property, not a guess about what most nodes run.
+"Unknown" is a state any relay can create for free by simply not serving the
+info event, and v1's intake authenticates nothing — so resolving unknown to v1
+made *omission* a downgrade primitive. Defaulting the other way makes the
+failure mode a brief deafness against a genuine v1 node, self-healing the moment
+its signed info event arrives, instead of a silent downgrade. It also matches
+mostrod's own default: since v0.18.0 the daemon picks nip44 unless an operator
+opts into gift-wrap explicitly, and v0.19.0 removes the choice.
+
+#### The persisted anchor
+
+Signature verification and the NIP-01 replacement rule both guard the info
+event, but neither survives a restart: `OpenOrdersRepository` holds the event in
+memory only, so on a cold start the first one to arrive is accepted with nothing
+to compare it against. A relay that withholds the current event and replays a
+genuinely signed pre-migration one downgrades the client for the whole session.
+
+`ProtocolVersionStore` (`lib/features/mostro/protocol_version_store.dart`) is
+what persists across that gap. Per node pubkey it remembers the last version
+that node was **verified** to assert, together with the asserting event's signed
+`created_at`, and `anchoredProtocolVersion` resolves the two against each other:
+
+- **The more recent assertion wins.** A relay picks which signed events it
+  serves, but it cannot mint one and cannot re-date one without breaking the
+  signature — so "newer than anything this client has verified" is exactly the
+  evidence it cannot manufacture. A replayed pre-migration v1 event loses
+  against a recorded v2.
+- **In both directions.** mostrod 0.18.x still ships `transport = "gift-wrap"`,
+  so an operator undoing a bad v2 rollout signs a *newer* v1 assertion. A purely
+  monotonic ratchet would refuse it and partition every client that had ever
+  seen v2 — silently, with no recovery short of reinstalling. Anchoring on
+  freshness follows the node instead.
+- **Ties resolve upwards.** Same `created_at`, or an assertion that cannot be
+  dated, falls back to the higher version. NIP-01's id tie-break runs upstream
+  on events, so a tie here is between an event in hand and one recalled from an
+  earlier session.
+
+Two things are deliberately never recorded: a version this client cannot resolve
+(the store would anchor to a number no resolver understands), and an *absent*
+tag. Resolution reads an absent tag as v1 because it can see the info event is
+in hand; the store outlives it, and persisting 1 would let a relay resolve v1
+off remembered state alone by simply withholding the event — turning the anchor
+into the durable downgrade primitive it exists to prevent.
+
+`ProtocolVersionStore.init()` must complete before the first transport is
+resolved. `appInitializerProvider` awaits it before `SubscriptionManager` is
+built; `init()` merges rather than replaces, because `RelaysNotifier` builds a
+`SubscriptionManager` of its own during bootstrap and info events can reach
+`record()` before the load finishes.
 
 ### 4.2 `version` field is derived from the transport
 
@@ -270,10 +336,11 @@ behaviourally unchanged.
 
 ### Phase A — Dual receive (with receive-side auto-detection)
 
-- Parse `protocol_version` into `MostroInstance.protocolVersion` (default v1 when
-  absent or unparseable) — `lib/features/mostro/mostro_instance.dart`. Resolve a
-  per-node `Transport` from it (`lib/features/mostro/transport.dart`), degrading
-  to v1 on an unsupported value and logging it (version-skew guard, §4.1).
+- Parse `protocol_version` into `MostroInstance.protocolVersion` —
+  `lib/features/mostro/mostro_instance.dart`. Resolve a per-node `Transport`
+  from it (`lib/features/mostro/transport.dart`). Originally this read an absent
+  *or* unparseable tag as v1 and degraded unsupported values to v1; both were
+  reversed later — see §4.1 for the three-state reading and the upward degrade.
   > Receive-side detection lives here (not Phase C) so the dual-receive path is
   > actually reachable and reviewable; Phase C only threads the resolved
   > transport into the **send** path.
@@ -339,8 +406,8 @@ behaviourally unchanged.
   from the transport (§4.2).
 - Extracted the transport → orders-filter mapping into the testable top-level
   `buildOrdersFilter` (`subscription_manager.dart`).
-- The version-skew guard (`resolveTransport`) degrades to v1 on an unsupported
-  protocol version and logs it (§4.1).
+- The version-skew guard (`resolveTransport`) handles an unsupported protocol
+  version and logs it (§4.1; it degrades to `kDefaultTransport`, not to v1).
 
 ### Phase D — Tests ✅
 
@@ -350,9 +417,14 @@ behaviourally unchanged.
   verifies the trade signature and the identity proof, including the exact domain
   string `mostro-transport-v2-identity:<tradePubkey>:<messageJSON>` (`null` in
   full-privacy).
-- `protocol_version` tag parse → transport mapping, including absent → v1
+- `protocol_version` tag parse → transport mapping, across all three tag states
   (`test/features/mostro/transport_test.dart`,
   `test/features/mostro/mostro_instance_test.dart`).
+- The persisted anchor: freshness ordering in both directions, unsupported and
+  undatable assertions, write serialisation and records racing `init()`
+  (`test/features/mostro/protocol_version_store_test.dart`), and the same rules
+  end-to-end through the repository
+  (`test/features/mostro/anchored_transport_resolution_test.dart`).
 - Orders subscription filter is transport-aware
   (`test/features/subscriptions/orders_filter_test.dart`).
 - Restore decode handles both transports and yields identical results
@@ -364,9 +436,16 @@ behaviourally unchanged.
 
 ## 6. Backward compatibility and edge cases
 
-- **Legacy node (no `protocol_version` tag)** → resolve to v1; behaviour
-  identical to today. The resolver logs this downgrade at `warn` (§4.1) so a
-  misconfigured node is not silently left on the degraded transport.
+- **Legacy node (no `protocol_version` tag)** → resolve to v1, but only off a
+  *verified* info event: an absent tag on one is the node asserting v1 by
+  omission (§4.1). Having no info event at all is the opposite case and resolves
+  to `kDefaultTransport`.
+- **Malformed `protocol_version`** → no evidence; resolve to `kDefaultTransport`
+  and log at `warn`. The About screen shows "unknown" rather than a version the
+  node never claimed.
+- **Operator rolls a node back to v1** → followed, because the rollback event is
+  signed later than the v2 one the client remembers (§4.1, the persisted
+  anchor). A replayed pre-migration v1 event is not, because it is not.
 - **`version` field** → v1 keeps `version: 1` on the wire (decision #2), so
   already-deployed pre-0.13 daemons are unaffected. (A 0.13+ daemon dispatches
   on event **kind**, not on `version`, and `verify()` checks action↔payload

--- a/lib/data/models/enums/storage_keys.dart
+++ b/lib/data/models/enums/storage_keys.dart
@@ -6,7 +6,8 @@ enum SharedPreferencesKeys {
   mostroCustomNodes('mostro_custom_nodes'),
   trustedNodeMetadata('trusted_node_metadata'),
   backgroundFilters('background_filters'),
-  communitySelected('community_selected');
+  communitySelected('community_selected'),
+  nodeProtocolVersions('node_protocol_versions');
 
   final String value;
 

--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -146,20 +146,10 @@ extension NostrEventExtensions on NostrEvent {
           throw Exception('SEAL content is empty');
         }
 
-        // STEP 2b: Authenticate the sender. The seal is the only signed
-        // layer that names them: the outer wrap is signed by a throwaway
-        // ephemeral key, and the rumor is unsigned by design, so its pubkey
-        // field is a claim. Pin the author and verify the signature before
-        // trusting anything inside.
-        if (sealEvent.pubkey != expectedAuthor) {
-          throw Exception(
-            'Unexpected seal author: expected $expectedAuthor, '
-            'got ${sealEvent.pubkey}',
-          );
-        }
-        if (!NostrUtils.isValidEventSignature(sealEvent)) {
-          throw Exception('Invalid seal signature');
-        }
+        // STEP 2b: Authenticate the sender before trusting anything inside.
+        // See NostrUtils.authenticateSeal for why the seal is the layer that
+        // carries this evidence.
+        NostrUtils.authenticateSeal(sealEvent, expectedAuthor);
 
         // STEP 3: Decrypt SEAL with sender's pubkey (from SEAL)
         // The SEAL pubkey identifies the actual sender (admin or user)

--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -68,10 +68,14 @@ extension NostrEventExtensions on NostrEvent {
     return timeago.format(createdAt!, allowFromNow: true, locale: locale);
   }
 
-  Future<NostrEvent> unWrap(String privateKey) async {
+  Future<NostrEvent> unWrap(
+    String privateKey, {
+    required String expectedAuthor,
+  }) async {
     return await NostrUtils.decryptNIP59Event(
       this,
       privateKey,
+      expectedAuthor: expectedAuthor,
     );
   }
 
@@ -104,7 +108,10 @@ extension NostrEventExtensions on NostrEvent {
     }
   }
 
-  Future<NostrEvent> mostroUnWrap(NostrKeyPairs receiver) async {
+  Future<NostrEvent> mostroUnWrap(
+    NostrKeyPairs receiver, {
+    required String expectedAuthor,
+  }) async {
     if (kind != 1059) {
       throw ArgumentError('Expected kind 1059 (Gift Wrap), got: $kind');
     }
@@ -137,6 +144,21 @@ extension NostrEventExtensions on NostrEvent {
 
         if (sealEvent.content == null || sealEvent.content!.isEmpty) {
           throw Exception('SEAL content is empty');
+        }
+
+        // STEP 2b: Authenticate the sender. The seal is the only signed
+        // layer that names them: the outer wrap is signed by a throwaway
+        // ephemeral key, and the rumor is unsigned by design, so its pubkey
+        // field is a claim. Pin the author and verify the signature before
+        // trusting anything inside.
+        if (sealEvent.pubkey != expectedAuthor) {
+          throw Exception(
+            'Unexpected seal author: expected $expectedAuthor, '
+            'got ${sealEvent.pubkey}',
+          );
+        }
+        if (!NostrUtils.isValidEventSignature(sealEvent)) {
+          throw Exception('Invalid seal signature');
         }
 
         // STEP 3: Decrypt SEAL with sender's pubkey (from SEAL)

--- a/lib/data/repositories/dispute_repository.dart
+++ b/lib/data/repositories/dispute_repository.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
 import 'package:mostro_mobile/data/models/dispute.dart';
 import 'package:mostro_mobile/data/models/mostro_message.dart';
 import 'package:mostro_mobile/data/models/enums/action.dart';
@@ -56,7 +57,7 @@ class DisputeRepository {
       }
       final mostroPow = mostroInstance?.pow ?? 0;
       final event = await disputeMessage.wrapForTransport(
-        protocolVersion: mostroInstance?.protocolVersion,
+        protocolVersion: anchoredProtocolVersionFor(_ref),
         tradeKey: session.tradeKey,
         recipientPubKey: _mostroPubkey,
         masterKey: session.fullPrivacy ? null : session.masterKey,

--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -94,6 +94,26 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
           );
           return;
         }
+        // A valid signature says the node authored this event, not that it
+        // still reflects the node's configuration. Relays pick which events
+        // they serve and in what order, so without a monotonicity check the
+        // last one to arrive wins — letting a relay replay a genuinely signed
+        // but superseded info event to roll the advertised config back (most
+        // importantly `protocol_version` 2 -> 1). Only move forward in time.
+        //
+        // Reset to null on instance switch (see updateSettings), so this never
+        // blocks the newly selected node's own info event.
+        final currentCreatedAt = _mostroInstance?.createdAt;
+        final incomingCreatedAt = event.createdAt;
+        if (currentCreatedAt != null &&
+            (incomingCreatedAt == null ||
+                !incomingCreatedAt.isAfter(currentCreatedAt))) {
+          logger.d(
+            'Ignoring kind-$infoEventKind info event from ${event.pubkey} '
+            'dated $incomingCreatedAt: not newer than $currentCreatedAt',
+          );
+          return;
+        }
         logger.i('Mostro instance info loaded: $event');
         _mostroInstance = event;
         if (!_mostroInstanceController.isClosed) {

--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -67,14 +67,28 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
     final filterTime =
         DateTime.now().subtract(Duration(hours: orderFilterDurationHours));
 
-    final filter = NostrFilter(
-      kinds: [orderEventKind, infoEventKind],
-      since: filterTime,
-      authors: [_settings.mostroPublicKey],
-    );
-
+    // Two filters, not one. The order history is deliberately bounded to a
+    // recent window, but the info event must not inherit that bound: kind
+    // 38385 is addressable, so the node publishes it once at startup and the
+    // relay keeps only that copy. A node that has been up longer than the
+    // window has an info event older than `since`, and a combined filter would
+    // make the relay withhold it — leaving `protocol_version` unknown for the
+    // whole session. That used to be harmless because unknown meant v1; now
+    // that unknown resolves to v2 it would strand the client on kind 14
+    // against a node that only listens on kind 1059.
     final request = NostrRequest(
-      filters: [filter],
+      filters: [
+        NostrFilter(
+          kinds: [orderEventKind],
+          since: filterTime,
+          authors: [_settings.mostroPublicKey],
+        ),
+        NostrFilter(
+          kinds: [infoEventKind],
+          authors: [_settings.mostroPublicKey],
+          limit: 1,
+        ),
+      ],
     );
 
     _subscription = _nostrService.subscribeToEvents(request).listen((event) {

--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -7,6 +7,7 @@ import 'package:mostro_mobile/data/repositories/order_repository_interface.dart'
 import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/services/nostr_service.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 const orderEventKind = 38383;
 const infoEventKind = 38385;
@@ -82,6 +83,17 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
         _eventStreamController.add(_events.values.toList());
       } else if (event.kind == infoEventKind &&
           event.pubkey == _settings.mostroPublicKey) {
+        // The author field alone proves nothing: any relay can hand us an
+        // event that merely *claims* the node's pubkey. The info event
+        // configures the wire transport (`protocol_version`), the bond policy
+        // and the PoW target, so an unsigned forgery is a downgrade primitive.
+        if (!NostrUtils.isValidEventSignature(event)) {
+          logger.w(
+            'Rejecting kind-$infoEventKind info event claiming to be from '
+            '${event.pubkey}: signature verification failed',
+          );
+          return;
+        }
         logger.i('Mostro instance info loaded: $event');
         _mostroInstance = event;
         if (!_mostroInstanceController.isClosed) {

--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -110,21 +110,18 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
         }
         // A valid signature says the node authored this event, not that it
         // still reflects the node's configuration. Relays pick which events
-        // they serve and in what order, so without a monotonicity check the
-        // last one to arrive wins — letting a relay replay a genuinely signed
-        // but superseded info event to roll the advertised config back (most
-        // importantly `protocol_version` 2 -> 1). Only move forward in time.
+        // they serve and in what order, so without a replacement rule the last
+        // one to arrive wins — letting a relay replay a genuinely signed but
+        // superseded info event to roll the advertised config back (most
+        // importantly `protocol_version` 2 -> 1).
         //
         // Reset to null on instance switch (see updateSettings), so this never
         // blocks the newly selected node's own info event.
-        final currentCreatedAt = _mostroInstance?.createdAt;
-        final incomingCreatedAt = event.createdAt;
-        if (currentCreatedAt != null &&
-            (incomingCreatedAt == null ||
-                !incomingCreatedAt.isAfter(currentCreatedAt))) {
+        if (!_supersedesCurrentInfo(event)) {
           logger.d(
-            'Ignoring kind-$infoEventKind info event from ${event.pubkey} '
-            'dated $incomingCreatedAt: not newer than $currentCreatedAt',
+            'Ignoring kind-$infoEventKind info event ${event.id} from '
+            '${event.pubkey} dated ${event.createdAt}: does not supersede '
+            '${_mostroInstance?.id} dated ${_mostroInstance?.createdAt}',
           );
           return;
         }
@@ -162,6 +159,35 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
         );
       }
     });
+  }
+
+  /// Whether [candidate] replaces the info event currently in use, under
+  /// NIP-01's ordering for addressable events: the higher `created_at` wins,
+  /// and a tie goes to the lower id.
+  ///
+  /// The tie-break is what makes this converge. Two events sharing a second
+  /// are both genuinely the node's — they cleared the signature check — but
+  /// only one of them is the copy every other client will settle on, and a
+  /// pure "strictly newer" rule silently keeps whichever the fastest relay
+  /// happened to deliver. An exact re-delivery compares equal on both fields
+  /// and is still rejected, so this does not reopen the replay window the
+  /// check exists to close.
+  bool _supersedesCurrentInfo(NostrEvent candidate) {
+    final current = _mostroInstance;
+    if (current == null) return true;
+
+    final candidateAt = candidate.createdAt;
+    if (candidateAt == null) return false;
+    final currentAt = current.createdAt;
+    if (currentAt == null) return true;
+
+    if (candidateAt.isAfter(currentAt)) return true;
+    if (currentAt.isAfter(candidateAt)) return false;
+
+    final candidateId = candidate.id;
+    final currentId = current.id;
+    if (candidateId == null || currentId == null) return false;
+    return candidateId.compareTo(currentId) < 0;
   }
 
   void _emitEvents() {

--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -76,6 +76,12 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
     // whole session. That used to be harmless because unknown meant v1; now
     // that unknown resolves to v2 it would strand the client on kind 14
     // against a node that only listens on kind 1059.
+    //
+    // `limit: 1` bounds each relay, not the subscription, so N relays can each
+    // answer with their own idea of the latest info event. Picking among them
+    // is _supersedesCurrentInfo's job — the NIP-01 replacement order it applies
+    // is what makes multi-relay delivery converge on one event rather than on
+    // whichever relay replied last.
     final request = NostrRequest(
       filters: [
         NostrFilter(

--- a/lib/features/mostro/mostro_instance.dart
+++ b/lib/features/mostro/mostro_instance.dart
@@ -179,14 +179,25 @@ extension MostroInstanceExtensions on NostrEvent {
 
   /// Parses the wire transport version from the `protocol_version` tag (§2).
   ///
-  /// Returns `null` when the tag is absent or unparseable. Callers treat
-  /// `null` as legacy v1 (NIP-59 gift wrap); the nullable form is preserved so
-  /// the transport resolver can distinguish "not advertised" from an explicit
-  /// version when deciding whether to log a version-skew downgrade.
+  /// Returns `null` when the tag is absent, empty or unparseable. Those are
+  /// not the same fact, and callers deciding a transport must not treat them
+  /// alike — pair this with [advertisesProtocolVersion] to tell them apart.
   int? get protocolVersion {
     final raw = _getOptionalTagValue('protocol_version');
     return raw == null ? null : int.tryParse(raw);
   }
+
+  /// Whether the event carries a `protocol_version` tag at all, regardless of
+  /// whether its value parses.
+  ///
+  /// This is the half of the story [protocolVersion] cannot tell. A daemon
+  /// before v0.18.0 emits no tag, and on a verified event that silence *is* an
+  /// assertion of v1. A tag holding `""` or `abc` asserts nothing: the node
+  /// meant to state a version and the value is unusable, so the client has no
+  /// evidence and must fall back to its safe default rather than read the
+  /// malformed value as legacy and pair itself with gift wrap.
+  bool get advertisesProtocolVersion =>
+      tags?.any((t) => t.isNotEmpty && t[0] == 'protocol_version') ?? false;
 
   /// Parses the anti-abuse bond policy from the `bond_enabled` tag.
   ///

--- a/lib/features/mostro/mostro_instance.dart
+++ b/lib/features/mostro/mostro_instance.dart
@@ -1,4 +1,5 @@
 import 'package:dart_nostr/nostr/model/event/event.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
 
 /// Anti-abuse bond policy advertised by a Mostro daemon via the kind-38385
 /// info event.
@@ -39,9 +40,16 @@ class MostroInstance {
   final int maxOrdersPerResponse;
 
   /// Wire transport advertised via the `protocol_version` tag (§2 of the
-  /// transport v2 migration). Defaults to `1` (NIP-59 gift wrap) when the tag
-  /// is absent or unparseable, matching the legacy-daemon behaviour.
-  final int protocolVersion;
+  /// transport v2 migration), in the three states the tag can be in: the
+  /// version it names, [kLegacyProtocolVersion] when the tag is absent, and
+  /// null when it is present but unusable.
+  ///
+  /// Nullable because those last two are different facts. Reading a malformed
+  /// value as v1 is the conflation [advertisesProtocolVersion] exists to avoid,
+  /// and it would show a node whose transport actually resolved to v2 as
+  /// speaking v1. This field is display state — the transport itself comes from
+  /// [anchoredProtocolVersionFor], never from here.
+  final int? protocolVersion;
 
   /// Bond policy state. See [BondPolicy] for the three-state semantics.
   final BondPolicy bondPolicy;
@@ -78,7 +86,7 @@ class MostroInstance {
     this.lndNodeUri,
     this.fiatCurrenciesAccepted,
     this.maxOrdersPerResponse, {
-    this.protocolVersion = 1,
+    this.protocolVersion,
     this.bondPolicy = BondPolicy.unsupported,
     this.bondApplyTo,
     this.bondSlashOnWaitingTimeout,
@@ -111,7 +119,7 @@ class MostroInstance {
       event.lndNodeUri,
       event.fiatCurrenciesAccepted,
       event.maxOrdersPerResponse,
-      protocolVersion: event.protocolVersion ?? 1,
+      protocolVersion: event.assertedProtocolVersion,
       bondPolicy: event.bondPolicy,
       bondApplyTo: event.bondApplyTo,
       bondSlashOnWaitingTimeout: event.bondSlashOnWaitingTimeout,
@@ -198,6 +206,24 @@ extension MostroInstanceExtensions on NostrEvent {
   /// malformed value as legacy and pair itself with gift wrap.
   bool get advertisesProtocolVersion =>
       tags?.any((t) => t.isNotEmpty && t[0] == 'protocol_version') ?? false;
+
+  /// What this event asserts about its transport, resolving the three states
+  /// [protocolVersion] and [advertisesProtocolVersion] describe between them:
+  ///
+  /// - Tag present and parseable → that version, whatever it is. What to do
+  ///   with one this client does not speak is `resolveTransport`'s call.
+  /// - Tag absent entirely → [kLegacyProtocolVersion]. Silence from a verified
+  ///   event is a pre-v0.18.0 daemon asserting v1 by omission.
+  /// - Tag present but unusable → null. The node meant to state a version and
+  ///   the value says nothing, so there is no evidence to act on.
+  ///
+  /// The single reading of the tag, so display and transport resolution cannot
+  /// disagree about what a node claims.
+  int? get assertedProtocolVersion {
+    final parsed = protocolVersion;
+    if (parsed != null) return parsed;
+    return advertisesProtocolVersion ? null : kLegacyProtocolVersion;
+  }
 
   /// Parses the anti-abuse bond policy from the `bond_enabled` tag.
   ///

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -12,9 +12,9 @@ import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/storage_providers.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Remembers the highest `protocol_version` each Mostro node has ever been
-/// *verified* to advertise, so a relay cannot walk a client back to an older
-/// wire transport.
+/// Remembers the most recent `protocol_version` each Mostro node has been
+/// *verified* to assert, so a relay cannot walk a client back to an older wire
+/// transport by serving an older event.
 ///
 /// The client learns a node's transport from its kind-38385 info event. Two
 /// guards already sit in front of that event: the signature must verify, and
@@ -25,18 +25,23 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// genuinely signed one from before the operator migrated to v2, downgrades
 /// the client for that whole session.
 ///
-/// This store is the part that persists. It is deliberately monotonic: a
-/// recorded version is never lowered, so once a node has been seen speaking
-/// v2 no later event can make this client speak v1 to it again.
+/// This store is the part that persists, and what it persists is the *signed
+/// timestamp* alongside the version. A relay picks which events it serves but
+/// cannot mint one or re-date one, so "newer than anything this client has
+/// verified" is precisely the property it cannot forge. A replayed
+/// pre-migration v1 event loses against a recorded v2; a genuinely newer signed
+/// v1 event — an operator rolling back, which mostrod 0.18.x still supports —
+/// wins, and the client follows the node instead of being partitioned from it.
+/// See [anchoredProtocolVersion] for the comparison itself.
 ///
 /// Keyed by node pubkey, so switching between Mostro instances keeps each
 /// node's history separate.
 class ProtocolVersionStore {
   final SharedPreferencesAsync _prefs;
 
-  /// Node pubkey -> highest verified `protocol_version`. Authoritative once
-  /// [init] has run; persistence is a write-behind mirror of it.
-  Map<String, int> _versions = {};
+  /// Node pubkey -> most recent verified assertion. Authoritative once [init]
+  /// has run; persistence is a write-behind mirror of it.
+  Map<String, VersionAssertion> _versions = {};
 
   bool _initialized = false;
 
@@ -47,8 +52,8 @@ class ProtocolVersionStore {
   /// straight to platform storage and concurrent calls complete in whatever
   /// order the platform picks. Without this chain a `setString` issued before
   /// a `clear()` could land after it and resurrect the cleared map, or an
-  /// older snapshot could overwrite a newer one — the ratchet is monotonic in
-  /// memory, but its disk mirror would not be.
+  /// older snapshot could overwrite a newer one — the anchor only ever moves
+  /// forward in memory, but its disk mirror would not.
   Future<void> _writes = Future<void>.value();
 
   ProtocolVersionStore(this._prefs);
@@ -78,9 +83,9 @@ class ProtocolVersionStore {
   /// Merges rather than replaces. A `SubscriptionManager` can exist before this
   /// runs — `RelaysNotifier` builds one of its own during bootstrap, and every
   /// instance feeds the info-event stream into [record] — so entries may
-  /// already have been ratcheted into memory. Overwriting them would drop the
-  /// higher version, and the next snapshot would carry that loss to disk: a
-  /// ratchet that forgets is the one thing this store must not be.
+  /// already have been anchored in memory. Overwriting them would drop that
+  /// evidence, and the next snapshot would carry the loss to disk: an anchor
+  /// that forgets is the one thing this store must not be.
   Future<void> init() async {
     final loaded = await _load();
     final early = _versions;
@@ -88,10 +93,10 @@ class ProtocolVersionStore {
     _initialized = true;
 
     var merged = false;
-    early.forEach((pubkey, version) {
+    early.forEach((pubkey, assertion) {
       final current = _versions[pubkey];
-      if (current == null || version > current) {
-        _versions[pubkey] = version;
+      if (current == null || _supersedes(assertion, current)) {
+        _versions[pubkey] = assertion;
         merged = true;
       }
     });
@@ -104,39 +109,55 @@ class ProtocolVersionStore {
 
   bool get isInitialized => _initialized;
 
-  /// Highest verified protocol version seen for [pubkey], or null if this
-  /// client has never verified an info event from that node.
-  int? versionFor(String pubkey) => _versions[pubkey];
+  /// The most recent verified assertion for [pubkey], or null if this client
+  /// has never verified an info event from that node.
+  VersionAssertion? assertionFor(String pubkey) => _versions[pubkey];
 
-  /// Records [version] for [pubkey], keeping the higher of the two.
+  /// The version of [assertionFor], for callers that do not need its date.
+  int? versionFor(String pubkey) => _versions[pubkey]?.version;
+
+  /// Records [version] for [pubkey] as asserted at [createdAt], keeping
+  /// whichever assertion is the more recent evidence.
+  ///
+  /// [createdAt] must be the `created_at` of the info event that carried the
+  /// version, not the time of the call: the point of storing it is that it is
+  /// signed, and a wall-clock stamp would let a relay advance the anchor just
+  /// by delivering an old event late.
   ///
   /// Call this only for a version parsed from an info event whose signature
   /// has been verified — an unverified event is a relay's claim, not the
-  /// node's, and recording it would poison the ratchet permanently.
+  /// node's, and recording it would poison the anchor.
   ///
-  /// Returns true when the stored value changed.
-  bool record(String pubkey, int version) {
+  /// Returns true when the stored assertion changed. That includes a same
+  /// version re-asserted more recently: the date is what later replays are
+  /// measured against, so it has to move forward too.
+  bool record(String pubkey, int version, DateTime? createdAt) {
     if (pubkey.isEmpty) return false;
-    // Guard against a malformed tag ratcheting the store to a value no
-    // resolver would honour anyway.
+    // Guard against a malformed tag anchoring the store to a value no resolver
+    // would honour anyway.
     if (version < 1) {
       logger.w('Ignoring non-positive protocol_version $version for $pubkey');
       return false;
     }
 
+    final incoming = VersionAssertion(version, createdAt);
     final current = _versions[pubkey];
-    if (current != null && current >= version) {
-      if (current > version) {
+    if (current != null && !_supersedes(incoming, current)) {
+      if (current.version != version) {
         logger.w(
-          'Node $pubkey advertised protocol_version $version but has been '
-          'verified at $current before; keeping $current',
+          'Node $pubkey asserted protocol_version $version at $createdAt, '
+          'which does not postdate the verified assertion of ${current.version} '
+          'at ${current.createdAt}; keeping ${current.version}',
         );
       }
       return false;
     }
 
-    _versions[pubkey] = version;
-    logger.i('Recorded protocol_version $version for node $pubkey');
+    _versions[pubkey] = incoming;
+    logger.i(
+      'Recorded protocol_version $version for node $pubkey '
+      'asserted at $createdAt',
+    );
     // Nothing reaches disk before [init] has merged what is already there.
     // A snapshot taken now would be of a map that has not seen storage yet,
     // and writing it would erase every node this device had verified in an
@@ -145,9 +166,23 @@ class ProtocolVersionStore {
     return true;
   }
 
+  /// Whether [incoming] is the better evidence of what a node speaks than
+  /// [current], using the same rule [anchoredProtocolVersion] resolves with:
+  /// the more recent signed assertion wins, and a tie — or an assertion that
+  /// cannot be dated — falls back to the higher version.
+  bool _supersedes(VersionAssertion incoming, VersionAssertion current) {
+    final incomingAt = incoming.createdAt;
+    final currentAt = current.createdAt;
+    if (incomingAt != null && currentAt != null) {
+      if (incomingAt.isAfter(currentAt)) return true;
+      if (currentAt.isAfter(incomingAt)) return false;
+    }
+    return incoming.version > current.version;
+  }
+
   /// Drops everything this store knows. Intended for an explicit "forget this
   /// device's history" action, not for routine flows — clearing it reopens the
-  /// downgrade window the ratchet exists to close.
+  /// downgrade window the anchor exists to close.
   Future<void> clear() {
     _versions = {};
     return _enqueueWrite(
@@ -156,14 +191,16 @@ class ProtocolVersionStore {
     );
   }
 
-  /// Memory is authoritative, so a failed write costs at most the ratchet's
-  /// memory of this node across a restart — never a wrong value.
+  /// Memory is authoritative, so a failed write costs at most this node's
+  /// anchor across a restart — never a wrong value.
   ///
   /// The snapshot is encoded here, at call time, and the write is queued: what
   /// reaches disk is the map as it stood when the caller asked, applied in the
   /// order the callers asked.
   void _persist() {
-    final snapshot = jsonEncode(_versions);
+    final snapshot = jsonEncode(
+      _versions.map((pubkey, assertion) => MapEntry(pubkey, _encode(assertion))),
+    );
     unawaited(
       _enqueueWrite(
         () => _prefs.setString(
@@ -175,7 +212,47 @@ class ProtocolVersionStore {
     );
   }
 
-  Future<Map<String, int>> _load() async {
+  /// `{"v": version, "t": secondsSinceEpoch}`, with `t` omitted for an
+  /// assertion that carried no usable date. Seconds rather than milliseconds
+  /// to match the `created_at` this came from.
+  Map<String, Object> _encode(VersionAssertion assertion) {
+    final createdAt = assertion.createdAt;
+    return {
+      'v': assertion.version,
+      if (createdAt != null)
+        't': createdAt.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond,
+    };
+  }
+
+  /// The inverse of [_encode], or null for anything that is not a usable
+  /// entry. Entries are dropped rather than repaired: an assertion whose shape
+  /// this build does not recognise cannot be dated, and something that cannot
+  /// be dated is not evidence.
+  VersionAssertion? _decode(Object? value) {
+    if (value is! Map) return null;
+
+    final version = _asInt(value['v']);
+    if (version == null || version < 1) return null;
+
+    final seconds = _asInt(value['t']);
+    return VersionAssertion(
+      version,
+      seconds == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(
+              seconds * Duration.millisecondsPerSecond,
+              isUtc: true,
+            ),
+    );
+  }
+
+  int? _asInt(Object? value) => value is int
+      ? value
+      : value is String
+          ? int.tryParse(value)
+          : null;
+
+  Future<Map<String, VersionAssertion>> _load() async {
     try {
       final json = await _prefs.getString(
         SharedPreferencesKeys.nodeProtocolVersions.value,
@@ -185,20 +262,14 @@ class ProtocolVersionStore {
       final decoded = jsonDecode(json);
       if (decoded is! Map) return {};
 
-      final result = <String, int>{};
+      final result = <String, VersionAssertion>{};
       decoded.forEach((key, value) {
         if (key is! String || key.isEmpty) return;
         // Tolerate anything a previous version (or a corrupted write) left
         // behind: a malformed entry is dropped, never allowed to throw and
-        // take the whole ratchet down with it.
-        final version = value is int
-            ? value
-            : value is String
-                ? int.tryParse(value)
-                : null;
-        if (version != null && version >= 1) {
-          result[key] = version;
-        }
+        // take the whole anchor down with it.
+        final assertion = _decode(value);
+        if (assertion != null) result[key] = assertion;
       });
       return result;
     } catch (e) {
@@ -213,8 +284,8 @@ final protocolVersionStoreProvider = Provider<ProtocolVersionStore>((ref) {
 });
 
 /// The protocol version to use when talking to the currently connected node:
-/// what it advertises now, anchored against the highest version it has ever
-/// been verified to advertise.
+/// what it advertises now, anchored against the most recent assertion it has
+/// been verified to make.
 ///
 /// Single resolution point on purpose. The send path and the receive
 /// subscription must never disagree about which transport is in play — a
@@ -234,7 +305,7 @@ int? anchoredProtocolVersionFor(Ref ref) {
     final infoEvent = ref.read(orderRepositoryProvider).mostroInstance;
     final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
     final remembered =
-        ref.read(protocolVersionStoreProvider).versionFor(mostroPubkey);
+        ref.read(protocolVersionStoreProvider).assertionFor(mostroPubkey);
     return anchoredProtocolVersion(_advertisedBy(infoEvent), remembered);
   } catch (e) {
     // Null resolves to the safe default rather than to v1, so failing to read
@@ -244,8 +315,8 @@ int? anchoredProtocolVersionFor(Ref ref) {
   }
 }
 
-/// What [infoEvent] actually asserts about its transport, in the three states
-/// the tag can be in.
+/// What [infoEvent] actually asserts about its transport, and when, in the
+/// three states the tag can be in.
 ///
 /// - No info event, or a tag that is present but unusable → null. Both are an
 ///   absence of evidence, and [resolveTransport] maps null to the safe
@@ -256,11 +327,14 @@ int? anchoredProtocolVersionFor(Ref ref) {
 ///   event is a legacy daemon asserting v1.
 /// - Tag present and parseable → that version, whatever it is;
 ///   [resolveTransport] decides what to do with one it does not speak.
-int? _advertisedBy(NostrEvent? infoEvent) {
+///
+/// The assertion carries the event's signed `created_at`, which is what
+/// [anchoredProtocolVersion] weighs it against the remembered one with.
+VersionAssertion? _advertisedBy(NostrEvent? infoEvent) {
   if (infoEvent == null) return null;
 
   final parsed = infoEvent.protocolVersion;
-  if (parsed != null) return parsed;
+  if (parsed != null) return VersionAssertion(parsed, infoEvent.createdAt);
 
   if (infoEvent.advertisesProtocolVersion) {
     logger.w(
@@ -269,5 +343,5 @@ int? _advertisedBy(NostrEvent? infoEvent) {
     );
     return null;
   }
-  return kLegacyProtocolVersion;
+  return VersionAssertion(kLegacyProtocolVersion, infoEvent.createdAt);
 }

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -2,7 +2,11 @@ import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
+import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
+import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/storage_providers.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -144,3 +148,31 @@ class ProtocolVersionStore {
 final protocolVersionStoreProvider = Provider<ProtocolVersionStore>((ref) {
   return ProtocolVersionStore(ref.watch(sharedPreferencesProvider));
 });
+
+/// The protocol version to use when talking to the currently connected node:
+/// what it advertises now, anchored against the highest version it has ever
+/// been verified to advertise.
+///
+/// Single resolution point on purpose. The send path and the receive
+/// subscription must never disagree about which transport is in play — a
+/// client listening on kind 14 while publishing kind 1059 is partitioned from
+/// the node, and the attacker-controlled half of that split is the forgeable
+/// one. Every caller reads this instead of reaching for
+/// `mostroInstance?.protocolVersion` directly.
+///
+/// Returns null only when the node has never been heard from and nothing is
+/// remembered; [resolveTransport] maps that to [kDefaultTransport].
+int? anchoredProtocolVersionFor(Ref ref) {
+  try {
+    final infoEvent = ref.read(orderRepositoryProvider).mostroInstance;
+    final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
+    final remembered =
+        ref.read(protocolVersionStoreProvider).versionFor(mostroPubkey);
+    return anchoredProtocolVersion(infoEvent?.protocolVersion, remembered);
+  } catch (e) {
+    // Null resolves to the safe default rather than to v1, so failing to read
+    // the node's state cannot be turned into a downgrade.
+    logger.w('Failed to resolve anchored protocol version: $e');
+    return null;
+  }
+}

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -343,18 +343,20 @@ int? anchoredProtocolVersionFor(Ref ref) {
 ///
 /// The assertion carries the event's signed `created_at`, which is what
 /// [anchoredProtocolVersion] weighs it against the remembered one with.
+///
+/// The reading itself is [MostroInstanceExtensions.assertedProtocolVersion], so
+/// what the About screen displays and what the transport resolves from are the
+/// same judgement about the same tag.
 VersionAssertion? _advertisedBy(NostrEvent? infoEvent) {
   if (infoEvent == null) return null;
 
-  final parsed = infoEvent.protocolVersion;
-  if (parsed != null) return VersionAssertion(parsed, infoEvent.createdAt);
-
-  if (infoEvent.advertisesProtocolVersion) {
+  final asserted = infoEvent.assertedProtocolVersion;
+  if (asserted == null) {
     logger.w(
       'Node ${infoEvent.pubkey} advertises an unparseable protocol_version; '
       'treating the transport as unknown rather than legacy',
     );
     return null;
   }
-  return VersionAssertion(kLegacyProtocolVersion, infoEvent.createdAt);
+  return VersionAssertion(asserted, infoEvent.createdAt);
 }

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -128,15 +128,24 @@ class ProtocolVersionStore {
   /// has been verified — an unverified event is a relay's claim, not the
   /// node's, and recording it would poison the anchor.
   ///
+  /// Only versions [tryResolveTransport] maps to a concrete transport are
+  /// stored. [resolveTransport] already degrades an unrecognised one upwards to
+  /// [kDefaultTransport], but the store outlives that decision: keeping the raw
+  /// number would leave every later assertion measured against a value no
+  /// resolver understands, so the first client to meet a v3 node would anchor
+  /// itself to 3 with no way back to the v2 it actually speaks. Not recording
+  /// it costs nothing — resolution still reads 3 off the info event in hand.
+  ///
   /// Returns true when the stored assertion changed. That includes a same
   /// version re-asserted more recently: the date is what later replays are
   /// measured against, so it has to move forward too.
   bool record(String pubkey, int version, DateTime? createdAt) {
     if (pubkey.isEmpty) return false;
-    // Guard against a malformed tag anchoring the store to a value no resolver
-    // would honour anyway.
-    if (version < 1) {
-      logger.w('Ignoring non-positive protocol_version $version for $pubkey');
+    if (tryResolveTransport(version) == null) {
+      logger.w(
+        'Not recording protocol_version $version for $pubkey: '
+        'this client does not speak it',
+      );
       return false;
     }
 
@@ -228,11 +237,15 @@ class ProtocolVersionStore {
   /// entry. Entries are dropped rather than repaired: an assertion whose shape
   /// this build does not recognise cannot be dated, and something that cannot
   /// be dated is not evidence.
+  ///
+  /// A version this build cannot resolve is dropped here too, for the same
+  /// reason [record] refuses one — an entry written by a build that spoke more
+  /// versions than this one must not anchor it to a number it cannot act on.
   VersionAssertion? _decode(Object? value) {
     if (value is! Map) return null;
 
     final version = _asInt(value['v']);
-    if (version == null || version < 1) return null;
+    if (version == null || tryResolveTransport(version) == null) return null;
 
     final seconds = _asInt(value['t']);
     return VersionAssertion(

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
@@ -207,14 +208,39 @@ int? anchoredProtocolVersionFor(Ref ref) {
     final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
     final remembered =
         ref.read(protocolVersionStoreProvider).versionFor(mostroPubkey);
-    final advertised = infoEvent == null
-        ? null
-        : (infoEvent.protocolVersion ?? kLegacyProtocolVersion);
-    return anchoredProtocolVersion(advertised, remembered);
+    return anchoredProtocolVersion(_advertisedBy(infoEvent), remembered);
   } catch (e) {
     // Null resolves to the safe default rather than to v1, so failing to read
     // the node's state cannot be turned into a downgrade.
     logger.w('Failed to resolve anchored protocol version: $e');
     return null;
   }
+}
+
+/// What [infoEvent] actually asserts about its transport, in the three states
+/// the tag can be in.
+///
+/// - No info event, or a tag that is present but unusable → null. Both are an
+///   absence of evidence, and [resolveTransport] maps null to the safe
+///   default. A malformed value must land here rather than in the legacy
+///   branch: reading `protocol_version=abc` as v1 would pair the client with
+///   gift wrap against a node that may well be speaking NIP-44.
+/// - Tag absent entirely → [kLegacyProtocolVersion]. Silence from a verified
+///   event is a legacy daemon asserting v1.
+/// - Tag present and parseable → that version, whatever it is;
+///   [resolveTransport] decides what to do with one it does not speak.
+int? _advertisedBy(NostrEvent? infoEvent) {
+  if (infoEvent == null) return null;
+
+  final parsed = infoEvent.protocolVersion;
+  if (parsed != null) return parsed;
+
+  if (infoEvent.advertisesProtocolVersion) {
+    logger.w(
+      'Node ${infoEvent.pubkey} advertises an unparseable protocol_version; '
+      'treating the transport as unknown rather than legacy',
+    );
+    return null;
+  }
+  return kLegacyProtocolVersion;
 }

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,7 +39,36 @@ class ProtocolVersionStore {
 
   bool _initialized = false;
 
+  /// Tail of the write chain. Every mutation of the persisted key is appended
+  /// here so writes land in call order.
+  ///
+  /// `SharedPreferencesAsync` holds no Dart-side cache: each call goes
+  /// straight to platform storage and concurrent calls complete in whatever
+  /// order the platform picks. Without this chain a `setString` issued before
+  /// a `clear()` could land after it and resurrect the cleared map, or an
+  /// older snapshot could overwrite a newer one — the ratchet is monotonic in
+  /// memory, but its disk mirror would not be.
+  Future<void> _writes = Future<void>.value();
+
   ProtocolVersionStore(this._prefs);
+
+  /// Completes when every write queued so far has finished. Useful to flush
+  /// before shutdown, and the only way a caller can observe durability —
+  /// [record] returns as soon as memory is updated.
+  Future<void> get pendingWrites => _writes;
+
+  /// Appends [op] to the write chain and returns when it has run. Failures are
+  /// logged and swallowed so one bad write cannot poison every later one.
+  Future<void> _enqueueWrite(
+    Future<void> Function() op,
+    String description,
+  ) {
+    final queued = _writes.then((_) => op()).catchError(
+      (Object e) => logger.e('Failed to $description: $e'),
+    );
+    _writes = queued;
+    return queued;
+  }
 
   /// Loads persisted versions into memory. Must complete before the first
   /// [versionFor] call for the ratchet to apply on a cold start; a store that
@@ -90,26 +120,31 @@ class ProtocolVersionStore {
   /// Drops everything this store knows. Intended for an explicit "forget this
   /// device's history" action, not for routine flows — clearing it reopens the
   /// downgrade window the ratchet exists to close.
-  Future<void> clear() async {
+  Future<void> clear() {
     _versions = {};
-    try {
-      await _prefs.remove(SharedPreferencesKeys.nodeProtocolVersions.value);
-    } catch (e) {
-      logger.e('Failed to clear protocol versions: $e');
-    }
+    return _enqueueWrite(
+      () => _prefs.remove(SharedPreferencesKeys.nodeProtocolVersions.value),
+      'clear protocol versions',
+    );
   }
 
   /// Memory is authoritative, so a failed write costs at most the ratchet's
   /// memory of this node across a restart — never a wrong value.
+  ///
+  /// The snapshot is encoded here, at call time, and the write is queued: what
+  /// reaches disk is the map as it stood when the caller asked, applied in the
+  /// order the callers asked.
   void _persist() {
-    _prefs
-        .setString(
+    final snapshot = jsonEncode(_versions);
+    unawaited(
+      _enqueueWrite(
+        () => _prefs.setString(
           SharedPreferencesKeys.nodeProtocolVersions.value,
-          jsonEncode(_versions),
-        )
-        .catchError(
-          (e) => logger.e('Failed to persist protocol versions: $e'),
-        );
+          snapshot,
+        ),
+        'persist protocol versions',
+      ),
+    );
   }
 
   Future<Map<String, int>> _load() async {
@@ -162,13 +197,20 @@ final protocolVersionStoreProvider = Provider<ProtocolVersionStore>((ref) {
 ///
 /// Returns null only when the node has never been heard from and nothing is
 /// remembered; [resolveTransport] maps that to [kDefaultTransport].
+///
+/// A verified info event that carries no `protocol_version` tag reads as
+/// [kLegacyProtocolVersion], not as "unknown" — see that constant for why the
+/// two cases must stay distinct.
 int? anchoredProtocolVersionFor(Ref ref) {
   try {
     final infoEvent = ref.read(orderRepositoryProvider).mostroInstance;
     final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
     final remembered =
         ref.read(protocolVersionStoreProvider).versionFor(mostroPubkey);
-    return anchoredProtocolVersion(infoEvent?.protocolVersion, remembered);
+    final advertised = infoEvent == null
+        ? null
+        : (infoEvent.protocolVersion ?? kLegacyProtocolVersion);
+    return anchoredProtocolVersion(advertised, remembered);
   } catch (e) {
     // Null resolves to the safe default rather than to v1, so failing to read
     // the node's state cannot be turned into a downgrade.

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
+import 'package:mostro_mobile/services/logger_service.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Remembers the highest `protocol_version` each Mostro node has ever been
+/// *verified* to advertise, so a relay cannot walk a client back to an older
+/// wire transport.
+///
+/// The client learns a node's transport from its kind-38385 info event. Two
+/// guards already sit in front of that event: the signature must verify, and
+/// the event must be newer than the one in use. Neither survives a restart —
+/// `OpenOrdersRepository` holds the info event in memory only, so on a cold
+/// start the first info event to arrive is accepted with nothing to compare
+/// it against. A relay that withholds the current event, or replays a
+/// genuinely signed one from before the operator migrated to v2, downgrades
+/// the client for that whole session.
+///
+/// This store is the part that persists. It is deliberately monotonic: a
+/// recorded version is never lowered, so once a node has been seen speaking
+/// v2 no later event can make this client speak v1 to it again.
+///
+/// Keyed by node pubkey, so switching between Mostro instances keeps each
+/// node's history separate.
+class ProtocolVersionStore {
+  final SharedPreferencesAsync _prefs;
+
+  /// Node pubkey -> highest verified `protocol_version`. Authoritative once
+  /// [init] has run; persistence is a write-behind mirror of it.
+  Map<String, int> _versions = {};
+
+  bool _initialized = false;
+
+  ProtocolVersionStore(this._prefs);
+
+  /// Loads persisted versions into memory. Must complete before the first
+  /// [versionFor] call for the ratchet to apply on a cold start; a store that
+  /// failed to load simply knows nothing and reports null.
+  Future<void> init() async {
+    _versions = await _load();
+    _initialized = true;
+  }
+
+  bool get isInitialized => _initialized;
+
+  /// Highest verified protocol version seen for [pubkey], or null if this
+  /// client has never verified an info event from that node.
+  int? versionFor(String pubkey) => _versions[pubkey];
+
+  /// Records [version] for [pubkey], keeping the higher of the two.
+  ///
+  /// Call this only for a version parsed from an info event whose signature
+  /// has been verified — an unverified event is a relay's claim, not the
+  /// node's, and recording it would poison the ratchet permanently.
+  ///
+  /// Returns true when the stored value changed.
+  bool record(String pubkey, int version) {
+    if (pubkey.isEmpty) return false;
+    // Guard against a malformed tag ratcheting the store to a value no
+    // resolver would honour anyway.
+    if (version < 1) {
+      logger.w('Ignoring non-positive protocol_version $version for $pubkey');
+      return false;
+    }
+
+    final current = _versions[pubkey];
+    if (current != null && current >= version) {
+      if (current > version) {
+        logger.w(
+          'Node $pubkey advertised protocol_version $version but has been '
+          'verified at $current before; keeping $current',
+        );
+      }
+      return false;
+    }
+
+    _versions[pubkey] = version;
+    logger.i('Recorded protocol_version $version for node $pubkey');
+    _persist();
+    return true;
+  }
+
+  /// Drops everything this store knows. Intended for an explicit "forget this
+  /// device's history" action, not for routine flows — clearing it reopens the
+  /// downgrade window the ratchet exists to close.
+  Future<void> clear() async {
+    _versions = {};
+    try {
+      await _prefs.remove(SharedPreferencesKeys.nodeProtocolVersions.value);
+    } catch (e) {
+      logger.e('Failed to clear protocol versions: $e');
+    }
+  }
+
+  /// Memory is authoritative, so a failed write costs at most the ratchet's
+  /// memory of this node across a restart — never a wrong value.
+  void _persist() {
+    _prefs
+        .setString(
+          SharedPreferencesKeys.nodeProtocolVersions.value,
+          jsonEncode(_versions),
+        )
+        .catchError(
+          (e) => logger.e('Failed to persist protocol versions: $e'),
+        );
+  }
+
+  Future<Map<String, int>> _load() async {
+    try {
+      final json = await _prefs.getString(
+        SharedPreferencesKeys.nodeProtocolVersions.value,
+      );
+      if (json == null) return {};
+
+      final decoded = jsonDecode(json);
+      if (decoded is! Map) return {};
+
+      final result = <String, int>{};
+      decoded.forEach((key, value) {
+        if (key is! String || key.isEmpty) return;
+        // Tolerate anything a previous version (or a corrupted write) left
+        // behind: a malformed entry is dropped, never allowed to throw and
+        // take the whole ratchet down with it.
+        final version = value is int
+            ? value
+            : value is String
+                ? int.tryParse(value)
+                : null;
+        if (version != null && version >= 1) {
+          result[key] = version;
+        }
+      });
+      return result;
+    } catch (e) {
+      logger.e('Failed to load protocol versions: $e');
+      return {};
+    }
+  }
+}
+
+final protocolVersionStoreProvider = Provider<ProtocolVersionStore>((ref) {
+  return ProtocolVersionStore(ref.watch(sharedPreferencesProvider));
+});

--- a/lib/features/mostro/protocol_version_store.dart
+++ b/lib/features/mostro/protocol_version_store.dart
@@ -74,9 +74,32 @@ class ProtocolVersionStore {
   /// Loads persisted versions into memory. Must complete before the first
   /// [versionFor] call for the ratchet to apply on a cold start; a store that
   /// failed to load simply knows nothing and reports null.
+  ///
+  /// Merges rather than replaces. A `SubscriptionManager` can exist before this
+  /// runs — `RelaysNotifier` builds one of its own during bootstrap, and every
+  /// instance feeds the info-event stream into [record] — so entries may
+  /// already have been ratcheted into memory. Overwriting them would drop the
+  /// higher version, and the next snapshot would carry that loss to disk: a
+  /// ratchet that forgets is the one thing this store must not be.
   Future<void> init() async {
-    _versions = await _load();
+    final loaded = await _load();
+    final early = _versions;
+    _versions = loaded;
     _initialized = true;
+
+    var merged = false;
+    early.forEach((pubkey, version) {
+      final current = _versions[pubkey];
+      if (current == null || version > current) {
+        _versions[pubkey] = version;
+        merged = true;
+      }
+    });
+
+    // Only when something survived the load, so a normal cold start still
+    // costs no write. This is also the first write allowed through, so what
+    // lands on disk is the union rather than either half.
+    if (merged) _persist();
   }
 
   bool get isInitialized => _initialized;
@@ -114,7 +137,11 @@ class ProtocolVersionStore {
 
     _versions[pubkey] = version;
     logger.i('Recorded protocol_version $version for node $pubkey');
-    _persist();
+    // Nothing reaches disk before [init] has merged what is already there.
+    // A snapshot taken now would be of a map that has not seen storage yet,
+    // and writing it would erase every node this device had verified in an
+    // earlier session — the load that was going to rescue them has not run.
+    if (_initialized) _persist();
     return true;
   }
 

--- a/lib/features/mostro/transport.dart
+++ b/lib/features/mostro/transport.dart
@@ -56,19 +56,33 @@ const int kLegacyProtocolVersion = 1;
 /// transport from an assertion older than one this client has already
 /// verified.
 Transport resolveTransport(int? protocolVersion) {
+  final resolved = tryResolveTransport(protocolVersion);
+  if (resolved != null) return resolved;
+
+  if (protocolVersion != null) {
+    logger.w(
+      'Unsupported protocol_version $protocolVersion; '
+      'falling back to $kDefaultTransport',
+    );
+  }
+  return kDefaultTransport;
+}
+
+/// The transport [protocolVersion] names, or null when this client does not
+/// speak it — including when there is no version to resolve at all.
+///
+/// [resolveTransport] is this with the safe default applied. Callers that need
+/// to know whether a version is one this build understands, rather than what to
+/// do about it, should ask here: deriving that from the resolver keeps the two
+/// from drifting as versions are added.
+Transport? tryResolveTransport(int? protocolVersion) {
   switch (protocolVersion) {
     case 1:
       return Transport.giftWrap;
     case 2:
       return Transport.nip44;
-    case null:
-      return kDefaultTransport;
     default:
-      logger.w(
-        'Unsupported protocol_version $protocolVersion; '
-        'falling back to $kDefaultTransport',
-      );
-      return kDefaultTransport;
+      return null;
   }
 }
 

--- a/lib/features/mostro/transport.dart
+++ b/lib/features/mostro/transport.dart
@@ -27,6 +27,18 @@ enum Transport { giftWrap, nip44 }
 /// downgrade.
 const Transport kDefaultTransport = Transport.nip44;
 
+/// The version a node states by *omitting* the `protocol_version` tag from an
+/// otherwise valid info event.
+///
+/// Legacy daemons (pre-v0.18.0) never emit the tag, so on a verified,
+/// non-superseded info event an absent tag is v1 asserted by omission. That is
+/// a different fact from having no info event at all, and the two must not
+/// collapse into the same `null`: the first is evidence about the node, the
+/// second is the absence of evidence. Reading a legacy node's silence as
+/// [kDefaultTransport] would pin the client to kind 14 against a node that only
+/// ever listens on kind 1059 — a permanent, self-inflicted partition.
+const int kLegacyProtocolVersion = 1;
+
 /// Resolves the wire transport for a node from its advertised
 /// `protocol_version` (§2, §4.1).
 ///

--- a/lib/features/mostro/transport.dart
+++ b/lib/features/mostro/transport.dart
@@ -12,29 +12,74 @@ import 'package:mostro_mobile/services/logger_service.dart';
 /// `docs/architecture/TRANSPORT_V2_MIGRATION.md` (§4.1).
 enum Transport { giftWrap, nip44 }
 
+/// Transport assumed when nothing is known about a node.
+///
+/// v2 (kind 14), matching mostrod's own default: since v0.18.0 the daemon
+/// subscribes to exactly one kind and picks nip44 unless an operator opts into
+/// gift-wrap explicitly, and v0.19.0 removes the choice entirely (issue #786).
+///
+/// The direction of this default is a security property, not a guess about
+/// what most nodes run. "Unknown" used to mean v1, whose intake authenticates
+/// nothing — so a relay could pin a client to the forgeable transport just by
+/// *withholding* the node's info event, no forgery required. Defaulting the
+/// other way makes the failure mode a brief deafness against a genuine v1 node
+/// (self-healing the moment its signed info event arrives) instead of a silent
+/// downgrade.
+const Transport kDefaultTransport = Transport.nip44;
+
 /// Resolves the wire transport for a node from its advertised
 /// `protocol_version` (§2, §4.1).
 ///
-/// - `2` → [Transport.nip44] (v2).
 /// - `1` → [Transport.giftWrap] (v1, explicitly advertised).
-/// - `null` → [Transport.giftWrap]. The tag is absent or the node info has not
-///   been fetched yet; during the migration window this is the common legacy
-///   case, so it resolves to v1 without noise.
-/// - any other value → [Transport.giftWrap], logged at `warn`. We do not speak
-///   that protocol, so we degrade to v1 (version-skew guard) and surface the
-///   degraded state so a misconfigured node is not silently mis-paired.
+/// - `2` → [Transport.nip44] (v2).
+/// - `null` → [kDefaultTransport]. The tag is absent, the node info has not
+///   been fetched yet, or a relay is withholding it.
+/// - any other value → [kDefaultTransport], logged at `warn`. We do not speak
+///   that protocol; falling back to v1 here would hand any party who can put a
+///   number in that tag a downgrade primitive, so an unrecognised version
+///   degrades *upwards* to the safe default instead.
+///
+/// Callers that can reach a [ProtocolVersionStore] should prefer
+/// [resolveAnchoredTransport], which additionally refuses to walk a node back
+/// to a transport older than one it has already been verified to speak.
 Transport resolveTransport(int? protocolVersion) {
   switch (protocolVersion) {
+    case 1:
+      return Transport.giftWrap;
     case 2:
       return Transport.nip44;
-    case 1:
     case null:
-      return Transport.giftWrap;
+      return kDefaultTransport;
     default:
       logger.w(
         'Unsupported protocol_version $protocolVersion; '
-        'degrading to v1 gift wrap',
+        'falling back to $kDefaultTransport',
       );
-      return Transport.giftWrap;
+      return kDefaultTransport;
   }
+}
+
+/// Combines what a node advertises *now* with the highest version it has
+/// previously been verified to advertise, taking the higher of the two.
+///
+/// [advertised] comes from the node's current kind-38385 info event, and
+/// [remembered] from [ProtocolVersionStore]. Both may be null: null
+/// [advertised] means no info event is in hand, null [remembered] means this
+/// client has never verified one from that node.
+///
+/// Taking the maximum is what makes the ratchet hold. Upgrades pass straight
+/// through, while a claim that a node speaks something *older* than it has
+/// already been proven to speak is ignored — that claim is only ever reachable
+/// by a relay replaying or suppressing events, never by the node itself under
+/// a migration that only moves forward.
+int? anchoredProtocolVersion(int? advertised, int? remembered) {
+  if (remembered == null) return advertised;
+  if (advertised == null) return remembered;
+  return advertised > remembered ? advertised : remembered;
+}
+
+/// [resolveTransport] applied to [anchoredProtocolVersion] — the resolution
+/// every caller should use once a [ProtocolVersionStore] is reachable.
+Transport resolveAnchoredTransport(int? advertised, int? remembered) {
+  return resolveTransport(anchoredProtocolVersion(advertised, remembered));
 }

--- a/lib/features/mostro/transport.dart
+++ b/lib/features/mostro/transport.dart
@@ -52,8 +52,9 @@ const int kLegacyProtocolVersion = 1;
 ///   degrades *upwards* to the safe default instead.
 ///
 /// Callers that can reach a [ProtocolVersionStore] should prefer
-/// [resolveAnchoredTransport], which additionally refuses to walk a node back
-/// to a transport older than one it has already been verified to speak.
+/// [resolveAnchoredTransport], which additionally refuses to take a node's
+/// transport from an assertion older than one this client has already
+/// verified.
 Transport resolveTransport(int? protocolVersion) {
   switch (protocolVersion) {
     case 1:
@@ -71,27 +72,89 @@ Transport resolveTransport(int? protocolVersion) {
   }
 }
 
-/// Combines what a node advertises *now* with the highest version it has
-/// previously been verified to advertise, taking the higher of the two.
+/// A protocol version together with the moment the node asserted it.
+///
+/// [createdAt] is the signed `created_at` of the kind-38385 info event that
+/// carried the version. That field sits *inside* the signature, so a relay can
+/// replay an assertion but cannot re-date one. This is what lets
+/// [anchoredProtocolVersion] tell a replayed old event apart from the node
+/// genuinely changing what it speaks.
+class VersionAssertion {
+  final int version;
+
+  /// Null when the event carried no usable `created_at`. An assertion that
+  /// cannot be dated cannot be ranked by freshness, so it falls back to the
+  /// conservative comparison — see [anchoredProtocolVersion].
+  final DateTime? createdAt;
+
+  const VersionAssertion(this.version, this.createdAt);
+
+  @override
+  bool operator ==(Object other) =>
+      other is VersionAssertion &&
+      other.version == version &&
+      other.createdAt == createdAt;
+
+  @override
+  int get hashCode => Object.hash(version, createdAt);
+
+  @override
+  String toString() => 'VersionAssertion($version, $createdAt)';
+}
+
+/// Combines what a node advertises *now* with what it has previously been
+/// verified to advertise, letting the more recent signed assertion win.
 ///
 /// [advertised] comes from the node's current kind-38385 info event, and
 /// [remembered] from [ProtocolVersionStore]. Both may be null: null
 /// [advertised] means no info event is in hand, null [remembered] means this
 /// client has never verified one from that node.
 ///
-/// Taking the maximum is what makes the ratchet hold. Upgrades pass straight
-/// through, while a claim that a node speaks something *older* than it has
-/// already been proven to speak is ignored — that claim is only ever reachable
-/// by a relay replaying or suppressing events, never by the node itself under
-/// a migration that only moves forward.
-int? anchoredProtocolVersion(int? advertised, int? remembered) {
-  if (remembered == null) return advertised;
-  if (advertised == null) return remembered;
-  return advertised > remembered ? advertised : remembered;
+/// Freshness — not the higher number — is what makes the anchor hold. The
+/// threat is a relay withholding the node's current info event and serving an
+/// older signed one in its place; a relay can choose *which* events it serves,
+/// but it cannot mint one, and it cannot move an existing one forward in time
+/// without breaking the signature. So the newest assertion this client has ever
+/// verified is exactly the evidence a relay cannot manufacture, and preferring
+/// it blocks the downgrade.
+///
+/// Anchoring on the *highest* version instead would block one more thing it
+/// should not: the node itself moving back to v1. mostrod 0.18.x still ships
+/// `transport = "gift-wrap"`, so an operator who rolls back a bad v2 rollout
+/// publishes a genuine, newer, signed v1 assertion — and a client that refused
+/// it would be partitioned from that node for good, silently, with no way back
+/// short of reinstalling.
+///
+/// When the two assertions carry the same timestamp — or either cannot be dated
+/// — freshness cannot separate them and the higher version wins. NIP-01's
+/// tie-break on event id already runs upstream in `OpenOrdersRepository`, so a
+/// tie here is between an assertion in hand and one recalled from an earlier
+/// session; resolving it upwards keeps a same-second replay from lowering the
+/// anchor.
+int? anchoredProtocolVersion(
+  VersionAssertion? advertised,
+  VersionAssertion? remembered,
+) {
+  if (remembered == null) return advertised?.version;
+  if (advertised == null) return remembered.version;
+
+  final advertisedAt = advertised.createdAt;
+  final rememberedAt = remembered.createdAt;
+  if (advertisedAt != null && rememberedAt != null) {
+    if (advertisedAt.isAfter(rememberedAt)) return advertised.version;
+    if (rememberedAt.isAfter(advertisedAt)) return remembered.version;
+  }
+
+  return advertised.version > remembered.version
+      ? advertised.version
+      : remembered.version;
 }
 
 /// [resolveTransport] applied to [anchoredProtocolVersion] — the resolution
 /// every caller should use once a [ProtocolVersionStore] is reachable.
-Transport resolveAnchoredTransport(int? advertised, int? remembered) {
+Transport resolveAnchoredTransport(
+  VersionAssertion? advertised,
+  VersionAssertion? remembered,
+) {
   return resolveTransport(anchoredProtocolVersion(advertised, remembered));
 }

--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -301,20 +301,28 @@ Future<MostroMessage?> _handleTradeKeyEvent(NostrEvent event, Session session) a
   // Transport branch (§5 Phase A): v1 gift wrap (kind 1059) yields an inner
   // rumor whose content is the message tuple; v2 NIP-44 direct (kind 14)
   // decrypts straight to the tuple. Both converge on jsonDecode below.
+  // Needed by both transports: v2 pins the kind-14 author, v1 pins the seal
+  // signer. Without it neither path can tell the node apart from any relay
+  // that can reach this trade key.
+  final mostroPubkey = await _loadMostroPubkey();
+  if (mostroPubkey == null) {
+    logger.w('No Mostro pubkey available, cannot decrypt event');
+    return null;
+  }
+
   final String? content;
   if (event.kind == 14) {
-    final mostroPubkey = await _loadMostroPubkey();
-    if (mostroPubkey == null) {
-      logger.w('No Mostro pubkey available, cannot decrypt kind-14 event');
-      return null;
-    }
     content = await NostrUtils.decryptNIP44DirectEvent(
       event,
       session.tradeKey.private,
       expectedAuthor: mostroPubkey,
     );
   } else {
-    content = (await event.unWrap(session.tradeKey.private)).content;
+    content = (await event.unWrap(
+      session.tradeKey.private,
+      expectedAuthor: mostroPubkey,
+    ))
+        .content;
   }
   if (content == null) {
     return null;

--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -305,7 +305,7 @@ Future<MostroMessage?> _handleTradeKeyEvent(NostrEvent event, Session session) a
   // signer. Without it neither path can tell the node apart from any relay
   // that can reach this trade key.
   final mostroPubkey = await _loadMostroPubkey();
-  if (mostroPubkey == null) {
+  if (mostroPubkey == null || mostroPubkey.isEmpty) {
     logger.w('No Mostro pubkey available, cannot decrypt event');
     return null;
   }

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -6,6 +6,7 @@ import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:dart_nostr/nostr/model/request/filter.dart';
 import 'package:dart_nostr/nostr/model/request/request.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
@@ -281,7 +282,7 @@ class RestoreService {
       );
     }
     final wrappedEvent = await mostroMessage.wrapForTransport(
-      protocolVersion: mostroInstance?.protocolVersion,
+      protocolVersion: anchoredProtocolVersionFor(ref),
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -378,7 +379,7 @@ class RestoreService {
       );
     }
     final wrappedEvent = await mostroMessage.wrapForTransport(
-      protocolVersion: mostroInstance?.protocolVersion,
+      protocolVersion: anchoredProtocolVersionFor(ref),
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -459,7 +460,7 @@ class RestoreService {
       );
     }
     final wrappedEvent = await mostroMessage.wrapForTransport(
-      protocolVersion: mostroInstance?.protocolVersion,
+      protocolVersion: anchoredProtocolVersionFor(ref),
       tradeKey: _tempTradeKey!,
       recipientPubKey: settings.mostroPublicKey,
       masterKey: settings.fullPrivacyMode ? null : _masterKey,
@@ -1076,9 +1077,10 @@ class RestoreService {
       _tempTradeKey = await keyManager.deriveTradeKeyFromIndex(1);
 
       // Wait for the node info event (kind 38385) before sending: at app init
-      // mostroInstance is still null, which makes wrapForTransport default to v1
-      // gift wrap. On a protocol v2 node the request would then go out as kind
-      // 1059 and never be answered, leaving the local key index stale.
+      // nothing is known about the node yet, so the transport resolves to the
+      // default. Against a node that speaks the other protocol the request
+      // would go out on the wrong kind and never be answered, leaving the
+      // local key index stale.
       await _waitForNodeConnectivity(ref.read(settingsProvider).mostroPublicKey);
 
       _tempSubscription = await _createTempSubscription();

--- a/lib/features/restore/restore_manager.dart
+++ b/lib/features/restore/restore_manager.dart
@@ -1157,7 +1157,10 @@ Future<Map<String, dynamic>> decodeRestoreMessage(
       expectedAuthor: mostroPubkey,
     );
   } else {
-    final rumor = await event.mostroUnWrap(tempTradeKey);
+    final rumor = await event.mostroUnWrap(
+      tempTradeKey,
+      expectedAuthor: mostroPubkey,
+    );
     content = rumor.content ?? '';
   }
 

--- a/lib/features/settings/about_screen.dart
+++ b/lib/features/settings/about_screen.dart
@@ -338,7 +338,10 @@ class AboutScreen extends ConsumerWidget {
             _buildInfoRowWithDialog(
               context,
               S.of(context)!.protocolVersion,
-              instance.protocolVersion.toString(),
+              // Null when the node sent a protocol_version this client could
+              // not read. Showing "1" for it would claim the node speaks gift
+              // wrap when the transport may well have resolved to NIP-44.
+              instance.protocolVersion?.toString() ?? S.of(context)!.unknown,
               S.of(context)!.protocolVersionExplanation,
             ),
             const SizedBox(height: 16),

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -109,13 +109,19 @@ class SubscriptionManager {
   /// a transport. Resolution can see that the info event is in hand; the store
   /// outlives it. Persisting 1 would leave `remembered == 1` with no info
   /// event after a restart, and a relay that then simply withholds the event
-  /// would resolve v1 off remembered state alone — turning the ratchet, whose
+  /// would resolve v1 off remembered state alone — turning the anchor, whose
   /// whole purpose is to block downgrades, into a durable downgrade primitive.
+  ///
+  /// The event's own `created_at` is what dates the assertion. It is signed,
+  /// so a relay can replay this event but cannot make the copy it replays look
+  /// newer than the one it is trying to displace.
   void _recordAdvertisedProtocolVersion(NostrEvent event) {
     try {
       final version = event.protocolVersion;
       if (version == null) return;
-      ref.read(protocolVersionStoreProvider).record(event.pubkey, version);
+      ref
+          .read(protocolVersionStoreProvider)
+          .record(event.pubkey, version, event.createdAt);
     } catch (e) {
       logger.w('Failed to record advertised protocol version: $e');
     }

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -115,6 +115,9 @@ class SubscriptionManager {
   /// The event's own `created_at` is what dates the assertion. It is signed,
   /// so a relay can replay this event but cannot make the copy it replays look
   /// newer than the one it is trying to displace.
+  ///
+  /// A version this build cannot resolve is dropped by the store itself — see
+  /// [ProtocolVersionStore.record].
   void _recordAdvertisedProtocolVersion(NostrEvent event) {
     try {
       final version = event.protocolVersion;

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -103,6 +103,14 @@ class SubscriptionManager {
   /// repository only emits events it has already matched to the connected
   /// node, and using the event's own author keeps the store correct if that
   /// ever changes.
+  ///
+  /// A missing tag is deliberately *not* recorded as [kLegacyProtocolVersion],
+  /// even though [anchoredProtocolVersionFor] reads it that way when resolving
+  /// a transport. Resolution can see that the info event is in hand; the store
+  /// outlives it. Persisting 1 would leave `remembered == 1` with no info
+  /// event after a restart, and a relay that then simply withholds the event
+  /// would resolve v1 off remembered state alone — turning the ratchet, whose
+  /// whole purpose is to block downgrades, into a durable downgrade primitive.
   void _recordAdvertisedProtocolVersion(NostrEvent event) {
     try {
       final version = event.protocolVersion;

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -8,6 +8,7 @@ import 'package:mostro_mobile/core/models/relay_list_event.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
+import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
 import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription.dart';
@@ -59,13 +60,23 @@ class SubscriptionManager {
   /// switch to the v2 (kind 14) transport once the node advertises
   /// `protocol_version=2`. The info event arrives asynchronously after the
   /// initial subscription, so without this the orders filter would stay pinned
-  /// to the transport resolved at subscription time (typically v1 at cold
-  /// start). Re-subscribes only when the resolved transport actually changes.
+  /// to the transport resolved at subscription time. Re-subscribes only when
+  /// the resolved transport actually changes.
+  ///
+  /// Doubles as the feed for the downgrade ratchet: every event on this stream
+  /// has already had its signature verified and been checked for being newer
+  /// than the one in use (see [OpenOrdersRepository]), which is exactly the
+  /// precondition [ProtocolVersionStore.record] requires.
   void _initMostroInstanceListener() {
     try {
       _mostroInstanceListener =
           ref.read(orderRepositoryProvider).mostroInstanceStream.listen(
-        (_) {
+        (event) {
+          // Before the early returns below: a client with no open sessions
+          // still needs to learn the node's version, or the ratchet would only
+          // ever arm for users who happen to be mid-trade.
+          _recordAdvertisedProtocolVersion(event);
+
           final newTransport = _resolveOrdersTransport();
           if (newTransport == _appliedOrdersTransport) return;
           final sessions = ref.read(sessionNotifierProvider);
@@ -84,16 +95,43 @@ class SubscriptionManager {
     }
   }
 
-  /// Resolves the transport for the orders subscription from the connected
-  /// node's advertised `protocol_version` (§2, §4.1). Defaults to v1 gift wrap
-  /// when the node info is not yet available or unreadable.
+  /// Records the version carried by a verified info [event] against its
+  /// author, so a later attempt to walk this node back to an older transport
+  /// has something to be measured against.
+  ///
+  /// Keyed by `event.pubkey` rather than the configured node pubkey: the
+  /// repository only emits events it has already matched to the connected
+  /// node, and using the event's own author keeps the store correct if that
+  /// ever changes.
+  void _recordAdvertisedProtocolVersion(NostrEvent event) {
+    try {
+      final version = event.protocolVersion;
+      if (version == null) return;
+      ref.read(protocolVersionStoreProvider).record(event.pubkey, version);
+    } catch (e) {
+      logger.w('Failed to record advertised protocol version: $e');
+    }
+  }
+
+  /// Resolves the transport for the orders subscription, combining the node's
+  /// currently advertised `protocol_version` (§2, §4.1) with the highest
+  /// version it has previously been verified to speak.
+  ///
+  /// Falls back to [kDefaultTransport] rather than v1 when the node info is
+  /// unavailable or unreadable: a relay can produce that state at will by
+  /// simply not serving the info event, and v1's intake authenticates nothing.
   Transport _resolveOrdersTransport() {
     try {
       final infoEvent = ref.read(orderRepositoryProvider).mostroInstance;
-      return resolveTransport(infoEvent?.protocolVersion);
+      final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
+      final remembered =
+          ref.read(protocolVersionStoreProvider).versionFor(mostroPubkey);
+      return resolveAnchoredTransport(infoEvent?.protocolVersion, remembered);
     } catch (e) {
-      logger.w('Failed to resolve orders transport, defaulting to v1: $e');
-      return Transport.giftWrap;
+      logger.w(
+        'Failed to resolve orders transport, using $kDefaultTransport: $e',
+      );
+      return kDefaultTransport;
     }
   }
 

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -121,18 +121,7 @@ class SubscriptionManager {
   /// unavailable or unreadable: a relay can produce that state at will by
   /// simply not serving the info event, and v1's intake authenticates nothing.
   Transport _resolveOrdersTransport() {
-    try {
-      final infoEvent = ref.read(orderRepositoryProvider).mostroInstance;
-      final mostroPubkey = ref.read(settingsProvider).mostroPublicKey;
-      final remembered =
-          ref.read(protocolVersionStoreProvider).versionFor(mostroPubkey);
-      return resolveAnchoredTransport(infoEvent?.protocolVersion, remembered);
-    } catch (e) {
-      logger.w(
-        'Failed to resolve orders transport, using $kDefaultTransport: $e',
-      );
-      return kDefaultTransport;
-    }
+    return resolveTransport(anchoredProtocolVersionFor(ref));
   }
 
   void _initSessionListener() {

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -140,7 +140,10 @@ class MostroService {
           expectedAuthor: _settings.mostroPublicKey,
         );
       } else {
-        final decryptedEvent = await event.unWrap(privateKey);
+        final decryptedEvent = await event.unWrap(
+          privateKey,
+          expectedAuthor: _settings.mostroPublicKey,
+        );
         content = decryptedEvent.content;
         decryptedId = decryptedEvent.id;
       }

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:dart_nostr/dart_nostr.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models.dart';
@@ -363,10 +364,11 @@ class MostroService {
       );
     }
 
-    // Route through the transport advertised by the connected node (§5 Phase
-    // B). v1 nodes (default) keep the gift-wrap path byte-for-byte.
+    // Route through the transport the connected node speaks (§5 Phase B),
+    // anchored so a relay cannot steer the send path onto v1 independently of
+    // what the orders subscription is listening on.
     final event = await order.wrapForTransport(
-      protocolVersion: mostroInstance?.protocolVersion,
+      protocolVersion: anchoredProtocolVersionFor(ref),
       tradeKey: session.tradeKey,
       recipientPubKey: _settings.mostroPublicKey,
       masterKey: session.fullPrivacy ? null : session.masterKey,

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -271,13 +271,18 @@ class NostrService {
 
   Future<NostrEvent> decryptNIP59Event(
     NostrEvent event,
-    String privateKey,
-  ) async {
+    String privateKey, {
+    String? expectedAuthor,
+  }) async {
     if (!_isInitialized) {
       throw Exception('Nostr is not initialized. Call init() first.');
     }
 
-    return NostrUtils.decryptNIP59Event(event, privateKey);
+    return NostrUtils.decryptNIP59Event(
+      event,
+      privateKey,
+      expectedAuthor: expectedAuthor ?? settings.mostroPublicKey,
+    );
   }
 
   Future<String> createRumor(

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -269,6 +269,11 @@ class NostrService {
     );
   }
 
+  /// [expectedAuthor] defaults to the configured node, which is the sender for
+  /// every Mostro message on this path. It is resolved and checked here rather
+  /// than passed through: an empty `mostroPublicKey` would otherwise reach the
+  /// author pin as a valid-looking argument, fail the comparison, and report
+  /// "unexpected seal author" for what is really unconfigured settings.
   Future<NostrEvent> decryptNIP59Event(
     NostrEvent event,
     String privateKey, {
@@ -278,10 +283,17 @@ class NostrService {
       throw Exception('Nostr is not initialized. Call init() first.');
     }
 
+    final author = expectedAuthor ?? settings.mostroPublicKey;
+    if (author.isEmpty) {
+      throw StateError(
+        'Cannot authenticate the sender: no Mostro public key configured',
+      );
+    }
+
     return NostrUtils.decryptNIP59Event(
       event,
       privateKey,
-      expectedAuthor: expectedAuthor ?? settings.mostroPublicKey,
+      expectedAuthor: author,
     );
   }
 

--- a/lib/shared/providers/app_init_provider.dart
+++ b/lib/shared/providers/app_init_provider.dart
@@ -4,6 +4,7 @@ import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_provider.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
 import 'package:mostro_mobile/features/mostro/mostro_nodes_provider.dart';
+import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/relays/relay_health_monitor.dart';
 import 'package:mostro_mobile/features/restore/restore_manager.dart';
@@ -33,9 +34,14 @@ final appInitializerProvider = FutureProvider<void>((ref) async {
   await mostroNodes.init();
   unawaited(mostroNodes.fetchAllNodeMetadata());
 
+  // Must load before SubscriptionManager builds its first orders filter: the
+  // ratchet only protects a cold start if the persisted versions are already
+  // in memory when the transport is resolved.
+  await ref.read(protocolVersionStoreProvider).init();
+
   final sessionManager = ref.read(sessionNotifierProvider.notifier);
   await sessionManager.init();
-  
+
   ref.read(subscriptionManagerProvider);
 
   // Start the relay health watchdog: re-engages bootstrap relays and

--- a/lib/shared/utils/nostr_utils.dart
+++ b/lib/shared/utils/nostr_utils.dart
@@ -426,15 +426,7 @@ class NostrUtils {
         '["EVENT", "", $decryptedContent]',
       );
 
-      if (sealEvent.pubkey != expectedAuthor) {
-        throw ArgumentError(
-          'Unexpected seal author: expected $expectedAuthor, '
-          'got ${sealEvent.pubkey}',
-        );
-      }
-      if (!isValidEventSignature(sealEvent)) {
-        throw ArgumentError('Invalid seal signature');
-      }
+      authenticateSeal(sealEvent, expectedAuthor);
 
       final finalDecryptedContent = await decryptNIP44(
         sealEvent.content!,
@@ -467,6 +459,12 @@ class NostrUtils {
         ),
         subscriptionId: '',
       );
+    } on ArgumentError {
+      // Authentication verdicts propagate unwrapped. Folding them into the
+      // generic Exception below would make "this message is not from the node"
+      // indistinguishable from "the payload was malformed", both to callers
+      // and to anyone reading a log line.
+      rethrow;
     } catch (e) {
       throw Exception('Failed to decrypt NIP-59 event: $e');
     }
@@ -517,6 +515,31 @@ class NostrUtils {
       );
     } catch (e) {
       throw Exception('Failed to decrypt NIP-44 direct event: $e');
+    }
+  }
+
+  /// Authenticates a NIP-59 seal (kind 13) as having been written by
+  /// [expectedAuthor].
+  ///
+  /// The seal is the only layer of a gift wrap that names its sender under a
+  /// signature: the outer wrap (kind 1059) is signed by a throwaway ephemeral
+  /// key and proves nothing, and the rumor inside is unsigned by design, so
+  /// its `pubkey` field is a claim rather than evidence. mostrod builds the
+  /// seal as `EventBuilder::seal(...).sign(identity_keys)` (mostro-core
+  /// `nip59.rs`), and the node uses one keypair for identity and trade, so the
+  /// seal's author is the configured node pubkey.
+  ///
+  /// Single implementation on purpose: both gift-wrap unwrapping paths call
+  /// this, so a change to what "authenticated" means cannot reach one and miss
+  /// the other. Throws when the seal fails either check.
+  static void authenticateSeal(NostrEvent seal, String expectedAuthor) {
+    if (seal.pubkey != expectedAuthor) {
+      throw ArgumentError(
+        'Unexpected seal author: expected $expectedAuthor, got ${seal.pubkey}',
+      );
+    }
+    if (!isValidEventSignature(seal)) {
+      throw ArgumentError('Invalid seal signature');
     }
   }
 

--- a/lib/shared/utils/nostr_utils.dart
+++ b/lib/shared/utils/nostr_utils.dart
@@ -475,7 +475,7 @@ class NostrUtils {
         'Unexpected author: expected $expectedAuthor, got ${event.pubkey}',
       );
     }
-    if (!_isValidEventSignature(event)) {
+    if (!isValidEventSignature(event)) {
       throw ArgumentError('Invalid kind-14 event signature');
     }
 
@@ -492,7 +492,14 @@ class NostrUtils {
 
   /// Verifies a Nostr event's id and Schnorr signature (NIP-01): recomputes the
   /// id from the serialized event and checks the signature over it.
-  static bool _isValidEventSignature(NostrEvent event) {
+  ///
+  /// Prefer this over `NostrEvent.isVerified()` for any event whose *content*
+  /// is trusted. `isVerified()` only checks the Schnorr signature against the
+  /// event's self-declared `id`, so a genuine `(id, sig, pubkey)` triple lifted
+  /// from one event and pasted onto arbitrary content and tags still passes it.
+  /// Recomputing the id from the serialized event is what binds the signature
+  /// to what the event actually says.
+  static bool isValidEventSignature(NostrEvent event) {
     final id = event.id;
     final sig = event.sig;
     final createdAt = event.createdAt;

--- a/lib/shared/utils/nostr_utils.dart
+++ b/lib/shared/utils/nostr_utils.dart
@@ -380,10 +380,28 @@ class NostrUtils {
     return wrapEvent;
   }
 
+  /// Decrypts a protocol-v1 (NIP-59 gift wrap) Mostro event and authenticates
+  /// its sender.
+  ///
+  /// The outer wrap (kind 1059) is signed by a throwaway ephemeral key and
+  /// proves nothing — anyone can encrypt to a public trade key. The rumor
+  /// inside carries a `pubkey` field but is unsigned by design, so that field
+  /// is a claim, not evidence. The authentication in NIP-59 lives in the
+  /// middle layer: the seal (kind 13) is signed by the sender's real identity
+  /// key. mostrod builds it exactly that way — `EventBuilder::seal(...)
+  /// .sign(identity_keys)` in mostro-core's `nip59.rs` — and the node uses a
+  /// single keypair for identity and trade, so the seal's author is the
+  /// configured node pubkey.
+  ///
+  /// [expectedAuthor] is checked against the seal's author and the seal's
+  /// signature is verified, which is what makes this path forgery-resistant.
+  /// Without both, any party able to reach the victim's trade key could inject
+  /// arbitrary Mostro messages.
   static Future<NostrEvent> decryptNIP59Event(
     NostrEvent event,
-    String privateKey,
-  ) async {
+    String privateKey, {
+    required String expectedAuthor,
+  }) async {
     if (event.kind != 1059) {
       throw ArgumentError('Wrong kind: ${event.kind}');
     }
@@ -402,14 +420,26 @@ class NostrUtils {
         event.pubkey,
       );
 
-      final rumorEvent = NostrEvent.deserialized(
+      // This is the seal (kind 13), not the rumor: the rumor is one layer
+      // further in, inside the seal's encrypted content.
+      final sealEvent = NostrEvent.deserialized(
         '["EVENT", "", $decryptedContent]',
       );
 
+      if (sealEvent.pubkey != expectedAuthor) {
+        throw ArgumentError(
+          'Unexpected seal author: expected $expectedAuthor, '
+          'got ${sealEvent.pubkey}',
+        );
+      }
+      if (!isValidEventSignature(sealEvent)) {
+        throw ArgumentError('Invalid seal signature');
+      }
+
       final finalDecryptedContent = await decryptNIP44(
-        rumorEvent.content!,
+        sealEvent.content!,
         privateKey,
-        rumorEvent.pubkey,
+        sealEvent.pubkey,
       );
 
       final wrap = jsonDecode(finalDecryptedContent) as Map<String, dynamic>;

--- a/test/data/models/nostr_event_extensions_test.dart
+++ b/test/data/models/nostr_event_extensions_test.dart
@@ -192,7 +192,10 @@ void main() {
   group('NostrEventExtensions.mostroUnWrap', () {
     test('rejects an event that is not a gift wrap', () async {
       await expectLater(
-        orderEvent().mostroUnWrap(NostrKeyPairs(private: '1' * 64)),
+        orderEvent().mostroUnWrap(
+          NostrKeyPairs(private: '1' * 64),
+          expectedAuthor: 'b' * 64,
+        ),
         throwsArgumentError,
       );
     });
@@ -209,7 +212,10 @@ void main() {
       );
 
       await expectLater(
-        event.mostroUnWrap(NostrKeyPairs(private: '1' * 64)),
+        event.mostroUnWrap(
+          NostrKeyPairs(private: '1' * 64),
+          expectedAuthor: 'b' * 64,
+        ),
         throwsArgumentError,
       );
     });

--- a/test/data/repositories/open_orders_info_event_test.dart
+++ b/test/data/repositories/open_orders_info_event_test.dart
@@ -264,4 +264,40 @@ void main() {
       expect(repository.mostroInstance!.id, nextInfo.id);
     });
   });
+
+  group('OpenOrdersRepository subscription filters', () {
+    // The order history window is a UI concern; the info event is a protocol
+    // one. Kind 38385 is addressable, so a relay holds exactly one copy per
+    // node and a `since` bound simply hides it once the node has been up
+    // longer than the window. With the safe default now resolving to v2, an
+    // unseen info event strands the client on kind 14 against a v1 node.
+    test('requests the info event without the order history cutoff', () {
+      buildRepository();
+
+      final request =
+          verify(mockNostrService.subscribeToEvents(captureAny)).captured.single
+              as NostrRequest;
+
+      final infoFilter = request.filters.singleWhere(
+        (f) => f.kinds!.contains(infoEventKind),
+      );
+      expect(infoFilter.since, isNull);
+      expect(infoFilter.authors, [nodeKeys.public]);
+      expect(infoFilter.kinds, [infoEventKind]);
+    });
+
+    test('still bounds the order history', () {
+      buildRepository();
+
+      final request =
+          verify(mockNostrService.subscribeToEvents(captureAny)).captured.single
+              as NostrRequest;
+
+      final orderFilter = request.filters.singleWhere(
+        (f) => f.kinds!.contains(orderEventKind),
+      );
+      expect(orderFilter.since, isNotNull);
+      expect(orderFilter.kinds, [orderEventKind]);
+    });
+  });
 }

--- a/test/data/repositories/open_orders_info_event_test.dart
+++ b/test/data/repositories/open_orders_info_event_test.dart
@@ -14,11 +14,13 @@ import '../../mocks.mocks.dart';
 NostrEvent _signedInfoEvent(
   NostrKeyPairs keyPair, {
   String protocolVersion = '2',
+  DateTime? createdAt,
 }) {
   return NostrEvent.fromPartialData(
     kind: 38385,
     content: '',
     keyPairs: keyPair,
+    createdAt: createdAt,
     tags: [
       ['d', 'info'],
       ['y', 'mostro'],
@@ -169,6 +171,97 @@ void main() {
         repository.mostroInstance!.tags,
         contains(equals(['protocol_version', '2'])),
       );
+    });
+  });
+
+  group('OpenOrdersRepository info event freshness', () {
+    // Signature validity says the node authored the event, not that it is
+    // current. A relay that holds on to a superseded info event can replay it
+    // to roll the node's advertised config back — the downgrade path that
+    // survives signature verification.
+    test('ignores a signed but superseded info event', () async {
+      final repository = buildRepository();
+      final now = DateTime.now();
+
+      final current = _signedInfoEvent(
+        nodeKeys,
+        protocolVersion: '2',
+        createdAt: now,
+      );
+      final superseded = _signedInfoEvent(
+        nodeKeys,
+        protocolVersion: '1',
+        createdAt: now.subtract(const Duration(days: 30)),
+      );
+
+      eventController.add(current);
+      await pumpEventQueue();
+      eventController.add(superseded);
+      await pumpEventQueue();
+
+      // Both are genuinely signed; only recency separates them.
+      expect(NostrUtils.isValidEventSignature(superseded), isTrue);
+      expect(repository.mostroInstance!.id, current.id);
+    });
+
+    test('applies a newer info event', () async {
+      final repository = buildRepository();
+      final now = DateTime.now();
+
+      final older = _signedInfoEvent(
+        nodeKeys,
+        createdAt: now.subtract(const Duration(hours: 1)),
+      );
+      final newer = _signedInfoEvent(nodeKeys, createdAt: now);
+
+      eventController.add(older);
+      await pumpEventQueue();
+      eventController.add(newer);
+      await pumpEventQueue();
+
+      expect(repository.mostroInstance!.id, newer.id);
+    });
+
+    test('ignores a re-delivery of the already accepted event', () async {
+      final repository = buildRepository();
+      final event = _signedInfoEvent(nodeKeys, createdAt: DateTime.now());
+
+      final emissions = <NostrEvent>[];
+      final sub = repository.mostroInstanceStream.listen(emissions.add);
+
+      // The same event arriving from several relays must not re-emit.
+      eventController.add(event);
+      await pumpEventQueue();
+      eventController.add(event);
+      await pumpEventQueue();
+
+      expect(emissions, hasLength(1));
+      await sub.cancel();
+    });
+
+    test('accepts the newly selected node info after an instance switch',
+        () async {
+      final repository = buildRepository();
+      final now = DateTime.now();
+
+      eventController.add(_signedInfoEvent(nodeKeys, createdAt: now));
+      await pumpEventQueue();
+
+      // The next node's info event is older in wall-clock terms; the switch
+      // must not let the previous node's timestamp shut it out.
+      final nextNodeKeys = NostrUtils.generateKeyPair();
+      repository.updateSettings(
+        settings.copyWith(mostroPublicKey: nextNodeKeys.public),
+      );
+
+      final nextInfo = _signedInfoEvent(
+        nextNodeKeys,
+        createdAt: now.subtract(const Duration(days: 7)),
+      );
+      eventController.add(nextInfo);
+      await pumpEventQueue();
+
+      expect(repository.mostroInstance!.id, nextInfo.id);
     });
   });
 }

--- a/test/data/repositories/open_orders_info_event_test.dart
+++ b/test/data/repositories/open_orders_info_event_test.dart
@@ -300,4 +300,71 @@ void main() {
       expect(orderFilter.kinds, [orderEventKind]);
     });
   });
+
+  // NIP-01 orders addressable events by created_at, and settles a tie on the
+  // lower id. Without the tie-break, whichever relay answers first pins the
+  // config for the session and two clients can disagree about what the node
+  // said.
+  group('OpenOrdersRepository info event created_at ties', () {
+    /// Two distinct info events sharing a timestamp, returned lower id first.
+    List<NostrEvent> tiedPair(DateTime at) {
+      final pair = <NostrEvent>[];
+      var protocolVersion = 2;
+      while (pair.length < 2) {
+        final candidate = _signedInfoEvent(
+          nodeKeys,
+          createdAt: at,
+          protocolVersion: '${protocolVersion++}',
+        );
+        if (!pair.any((e) => e.id == candidate.id)) pair.add(candidate);
+      }
+      pair.sort((a, b) => a.id!.compareTo(b.id!));
+      return pair;
+    }
+
+    test('a tie is won by the lower id, whichever arrives first', () async {
+      final repository = buildRepository();
+      final pair = tiedPair(DateTime.now());
+      final lower = pair.first;
+      final higher = pair.last;
+
+      eventController.add(higher);
+      await pumpEventQueue();
+      expect(repository.mostroInstance!.id, higher.id);
+
+      eventController.add(lower);
+      await pumpEventQueue();
+      expect(repository.mostroInstance!.id, lower.id);
+    });
+
+    test('the higher id does not displace the lower one', () async {
+      final repository = buildRepository();
+      final pair = tiedPair(DateTime.now());
+      final lower = pair.first;
+      final higher = pair.last;
+
+      eventController.add(lower);
+      await pumpEventQueue();
+
+      eventController.add(higher);
+      await pumpEventQueue();
+      expect(repository.mostroInstance!.id, lower.id);
+    });
+
+    test('an exact re-delivery is still ignored', () async {
+      final repository = buildRepository();
+      final info = _signedInfoEvent(nodeKeys, createdAt: DateTime.now());
+
+      final emitted = <NostrEvent>[];
+      final sub = repository.mostroInstanceStream.listen(emitted.add);
+
+      eventController.add(info);
+      await pumpEventQueue();
+      eventController.add(info);
+      await pumpEventQueue();
+
+      expect(emitted.length, 1);
+      await sub.cancel();
+    });
+  });
 }

--- a/test/data/repositories/open_orders_info_event_test.dart
+++ b/test/data/repositories/open_orders_info_event_test.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/repositories/open_orders_repository.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+import '../../mocks.mocks.dart';
+
+/// Builds a kind-38385 info event of the shape mostrod publishes: empty
+/// content, everything carried in tags.
+NostrEvent _signedInfoEvent(
+  NostrKeyPairs keyPair, {
+  String protocolVersion = '2',
+}) {
+  return NostrEvent.fromPartialData(
+    kind: 38385,
+    content: '',
+    keyPairs: keyPair,
+    tags: [
+      ['d', 'info'],
+      ['y', 'mostro'],
+      ['z', 'info'],
+      ['protocol_version', protocolVersion],
+    ],
+  );
+}
+
+/// Re-tags [source] while keeping its original id/sig/pubkey — what a relay
+/// can do for free, and what `NostrEvent.isVerified()` fails to catch.
+NostrEvent _reTagged(NostrEvent source, List<List<String>> tags) {
+  return NostrEvent(
+    id: source.id,
+    sig: source.sig,
+    pubkey: source.pubkey,
+    kind: source.kind,
+    content: source.content,
+    createdAt: source.createdAt,
+    tags: tags,
+  );
+}
+
+void main() {
+  late MockNostrService mockNostrService;
+  late StreamController<NostrEvent> eventController;
+  late NostrKeyPairs nodeKeys;
+  late Settings settings;
+
+  setUp(() {
+    nodeKeys = NostrUtils.generateKeyPair();
+    mockNostrService = MockNostrService();
+    eventController = StreamController<NostrEvent>.broadcast();
+
+    settings = Settings(
+      relays: const ['wss://relay.example'],
+      fullPrivacyMode: false,
+      mostroPublicKey: nodeKeys.public,
+    );
+
+    when(mockNostrService.isInitialized).thenReturn(true);
+    when(mockNostrService.subscribeToEvents(any))
+        .thenAnswer((_) => eventController.stream);
+  });
+
+  tearDown(() async {
+    await eventController.close();
+  });
+
+  OpenOrdersRepository buildRepository() =>
+      OpenOrdersRepository(mockNostrService, settings);
+
+  group('OpenOrdersRepository info event (kind 38385) verification', () {
+    test('accepts a genuinely signed info event from the configured node',
+        () async {
+      final repository = buildRepository();
+      final event = _signedInfoEvent(nodeKeys);
+
+      eventController.add(event);
+      await pumpEventQueue();
+
+      expect(repository.mostroInstance, isNotNull);
+      expect(repository.mostroInstance!.id, event.id);
+    });
+
+    test('emits the accepted info event on mostroInstanceStream', () async {
+      final repository = buildRepository();
+      final emitted = repository.mostroInstanceStream.first;
+
+      eventController.add(_signedInfoEvent(nodeKeys));
+
+      expect((await emitted).kind, 38385);
+    });
+
+    test('rejects an info event whose signature does not verify', () async {
+      final repository = buildRepository();
+      final genuine = _signedInfoEvent(nodeKeys);
+
+      final forged = NostrEvent(
+        id: genuine.id,
+        sig: 'f' * 128,
+        pubkey: nodeKeys.public,
+        kind: genuine.kind,
+        content: genuine.content,
+        createdAt: genuine.createdAt,
+        tags: genuine.tags,
+      );
+
+      eventController.add(forged);
+      await pumpEventQueue();
+
+      expect(repository.mostroInstance, isNull);
+    });
+
+    // The downgrade primitive this guard exists for: flip protocol_version
+    // 2 -> 1 on a genuine event, keeping the node's real pubkey and a real
+    // signature triple. Accepting this pins the client to the v1 gift-wrap
+    // transport, whose intake authenticates nothing.
+    test('rejects a protocol_version downgrade re-tagged onto a real signature',
+        () async {
+      final repository = buildRepository();
+      final genuine = _signedInfoEvent(nodeKeys, protocolVersion: '2');
+
+      final downgraded = _reTagged(genuine, [
+        ['d', 'info'],
+        ['y', 'mostro'],
+        ['z', 'info'],
+        ['protocol_version', '1'],
+      ]);
+
+      // The weak check the codebase reaches for elsewhere would allow this.
+      expect(downgraded.isVerified(), isTrue);
+
+      eventController.add(downgraded);
+      await pumpEventQueue();
+
+      expect(repository.mostroInstance, isNull);
+    });
+
+    test('rejects an info event authored by a different key', () async {
+      final repository = buildRepository();
+      final impostor = NostrUtils.generateKeyPair();
+
+      eventController.add(_signedInfoEvent(impostor, protocolVersion: '1'));
+      await pumpEventQueue();
+
+      expect(repository.mostroInstance, isNull);
+    });
+
+    test('a rejected event does not evict an already accepted one', () async {
+      final repository = buildRepository();
+      final genuine = _signedInfoEvent(nodeKeys);
+
+      eventController.add(genuine);
+      await pumpEventQueue();
+      expect(repository.mostroInstance, isNotNull);
+
+      eventController.add(_reTagged(genuine, [
+        ['d', 'info'],
+        ['y', 'mostro'],
+        ['z', 'info'],
+        ['protocol_version', '1'],
+      ]));
+      await pumpEventQueue();
+
+      expect(repository.mostroInstance!.id, genuine.id);
+      expect(
+        repository.mostroInstance!.tags,
+        contains(equals(['protocol_version', '2'])),
+      );
+    });
+  });
+}

--- a/test/features/mostro/anchored_transport_resolution_test.dart
+++ b/test/features/mostro/anchored_transport_resolution_test.dart
@@ -166,4 +166,40 @@ void main() {
       expect(resolveTransport(anchored()), Transport.giftWrap);
     });
   });
+
+  // Three states, not two. `protocolVersion` returns null for an absent tag
+  // and for an unusable one, and only the first is the node asserting v1.
+  group('a malformed protocol_version tag', () {
+    test('an unparseable value falls back to the safe default', () async {
+      await deliver(_infoEvent(nodeKeys, protocolVersion: 'abc'));
+
+      expect(anchored(), isNull);
+      expect(resolveTransport(anchored()), kDefaultTransport);
+    });
+
+    test('an empty value falls back to the safe default', () async {
+      await deliver(_infoEvent(nodeKeys, protocolVersion: ''));
+
+      expect(anchored(), isNull);
+      expect(resolveTransport(anchored()), kDefaultTransport);
+    });
+
+    test('does not lower a node already verified at v2', () async {
+      container.read(protocolVersionStoreProvider).record(nodeKeys.public, 2);
+
+      await deliver(_infoEvent(nodeKeys, protocolVersion: 'abc'));
+
+      expect(anchored(), 2);
+      expect(resolveTransport(anchored()), Transport.nip44);
+    });
+
+    test('a version this client does not speak is not read as legacy',
+        () async {
+      await deliver(_infoEvent(nodeKeys, protocolVersion: '99'));
+
+      // Parseable, so it reaches resolveTransport, which degrades upwards.
+      expect(anchored(), 99);
+      expect(resolveTransport(anchored()), kDefaultTransport);
+    });
+  });
 }

--- a/test/features/mostro/anchored_transport_resolution_test.dart
+++ b/test/features/mostro/anchored_transport_resolution_test.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
+import 'package:mostro_mobile/data/repositories/open_orders_repository.dart';
+import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../mocks.mocks.dart';
+
+/// A kind-38385 info event shaped like mostrod's: empty content, everything in
+/// tags. Passing null for [protocolVersion] omits the tag entirely, which is
+/// what every daemon before v0.18.0 publishes.
+NostrEvent _infoEvent(
+  NostrKeyPairs keyPair, {
+  required String? protocolVersion,
+}) {
+  return NostrEvent.fromPartialData(
+    kind: 38385,
+    content: '',
+    keyPairs: keyPair,
+    tags: [
+      ['d', 'info'],
+      ['y', 'mostro'],
+      ['z', 'info'],
+      if (protocolVersion != null) ['protocol_version', protocolVersion],
+    ],
+  );
+}
+
+class _FakeSharedPreferencesAsync implements SharedPreferencesAsync {
+  final Map<String, String> strings = {};
+
+  @override
+  Future<String?> getString(String key) async => strings[key];
+
+  @override
+  Future<void> setString(String key, String value) async {
+    strings[key] = value;
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    strings.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+/// Reads [anchoredProtocolVersionFor] from inside the container. It takes a
+/// `Ref`, which only a provider has; refresh this to re-evaluate it.
+final _anchored = Provider<int?>((ref) => anchoredProtocolVersionFor(ref));
+
+void main() {
+  late MockNostrService mockNostrService;
+  late StreamController<NostrEvent> eventController;
+  late NostrKeyPairs nodeKeys;
+  late _FakeSharedPreferencesAsync prefs;
+  late ProviderContainer container;
+
+  setUp(() async {
+    nodeKeys = NostrUtils.generateKeyPair();
+    mockNostrService = MockNostrService();
+    eventController = StreamController<NostrEvent>.broadcast();
+
+    final settings = Settings(
+      relays: const ['wss://relay.example'],
+      fullPrivacyMode: false,
+      mostroPublicKey: nodeKeys.public,
+    );
+
+    prefs = _FakeSharedPreferencesAsync();
+    prefs.strings[SharedPreferencesKeys.appSettings.value] =
+        jsonEncode(settings.toJson());
+
+    when(mockNostrService.isInitialized).thenReturn(true);
+    when(mockNostrService.subscribeToEvents(any))
+        .thenAnswer((_) => eventController.stream);
+
+    container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        orderRepositoryProvider.overrideWithValue(
+          OpenOrdersRepository(mockNostrService, settings),
+        ),
+      ],
+    );
+
+    await container.read(settingsProvider.notifier).init();
+    expect(container.read(settingsProvider).mostroPublicKey, nodeKeys.public);
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await eventController.close();
+  });
+
+  int? anchored() => container.refresh(_anchored);
+
+  /// Feeds [event] through the repository and waits for it to be applied.
+  Future<void> deliver(NostrEvent event) async {
+    final applied = container
+        .read(orderRepositoryProvider)
+        .mostroInstanceStream
+        .first
+        .timeout(const Duration(seconds: 2));
+    eventController.add(event);
+    await applied;
+  }
+
+  // The `null` returned by NostrEventExtensions.protocolVersion means two
+  // different things, and collapsing them is a self-inflicted partition: a
+  // legacy node that publishes a perfectly valid info event without the tag
+  // would resolve to kind 14 and never be heard from again, because it only
+  // ever listens on kind 1059.
+  group('a verified info event with no protocol_version tag', () {
+    test('resolves to gift wrap, not to the safe default', () async {
+      await deliver(_infoEvent(nodeKeys, protocolVersion: null));
+
+      expect(anchored(), kLegacyProtocolVersion);
+      expect(resolveTransport(anchored()), Transport.giftWrap);
+    });
+
+    test('is still distinct from having no info event at all', () {
+      // Nothing delivered: absence of evidence, so the safe default stands.
+      expect(anchored(), isNull);
+      expect(resolveTransport(anchored()), kDefaultTransport);
+    });
+
+    test('does not walk back a node already verified at v2', () async {
+      container.read(protocolVersionStoreProvider).record(nodeKeys.public, 2);
+
+      await deliver(_infoEvent(nodeKeys, protocolVersion: null));
+
+      // The ratchet outranks a tag-less event: on a node that has already
+      // migrated, only a relay replaying an old event produces this state.
+      expect(anchored(), 2);
+      expect(resolveTransport(anchored()), Transport.nip44);
+    });
+  });
+
+  group('a verified info event advertising a version', () {
+    test('v2 resolves to nip44', () async {
+      await deliver(_infoEvent(nodeKeys, protocolVersion: '2'));
+
+      expect(anchored(), 2);
+      expect(resolveTransport(anchored()), Transport.nip44);
+    });
+
+    test('an explicit v1 resolves to gift wrap', () async {
+      await deliver(_infoEvent(nodeKeys, protocolVersion: '1'));
+
+      expect(anchored(), 1);
+      expect(resolveTransport(anchored()), Transport.giftWrap);
+    });
+  });
+}

--- a/test/features/mostro/anchored_transport_resolution_test.dart
+++ b/test/features/mostro/anchored_transport_resolution_test.dart
@@ -21,14 +21,19 @@ import '../../mocks.mocks.dart';
 /// A kind-38385 info event shaped like mostrod's: empty content, everything in
 /// tags. Passing null for [protocolVersion] omits the tag entirely, which is
 /// what every daemon before v0.18.0 publishes.
+///
+/// [createdAt] is the signed timestamp the anchor weighs assertions by, so
+/// tests that pit an event against a remembered one set it explicitly.
 NostrEvent _infoEvent(
   NostrKeyPairs keyPair, {
   required String? protocolVersion,
+  DateTime? createdAt,
 }) {
   return NostrEvent.fromPartialData(
     kind: 38385,
     content: '',
     keyPairs: keyPair,
+    createdAt: createdAt,
     tags: [
       ['d', 'info'],
       ['y', 'mostro'],
@@ -37,6 +42,11 @@ NostrEvent _infoEvent(
     ],
   );
 }
+
+/// Two moments in a node's life, as info-event timestamps: the event that
+/// announced v2, and a later one that announces a rollback to v1.
+final _migration = DateTime.utc(2026, 1, 1);
+final _rollback = DateTime.utc(2026, 6, 1);
 
 class _FakeSharedPreferencesAsync implements SharedPreferencesAsync {
   final Map<String, String> strings = {};
@@ -140,14 +150,34 @@ void main() {
     });
 
     test('does not walk back a node already verified at v2', () async {
-      container.read(protocolVersionStoreProvider).record(nodeKeys.public, 2);
+      container
+          .read(protocolVersionStoreProvider)
+          .record(nodeKeys.public, 2, _rollback);
 
-      await deliver(_infoEvent(nodeKeys, protocolVersion: null));
+      await deliver(
+        _infoEvent(nodeKeys, protocolVersion: null, createdAt: _migration),
+      );
 
-      // The ratchet outranks a tag-less event: on a node that has already
-      // migrated, only a relay replaying an old event produces this state.
+      // The anchor outranks an older tag-less event: on a node that has
+      // already migrated, only a relay replaying an old event produces this.
       expect(anchored(), 2);
       expect(resolveTransport(anchored()), Transport.nip44);
+    });
+
+    test('does follow a node that goes back to v1 more recently', () async {
+      container
+          .read(protocolVersionStoreProvider)
+          .record(nodeKeys.public, 2, _migration);
+
+      await deliver(
+        _infoEvent(nodeKeys, protocolVersion: null, createdAt: _rollback),
+      );
+
+      // A tag-less event this client has never seen before, signed after the
+      // v2 one, is the operator rolling back — not a relay, which can replay
+      // an event but cannot re-date it.
+      expect(anchored(), kLegacyProtocolVersion);
+      expect(resolveTransport(anchored()), Transport.giftWrap);
     });
   });
 
@@ -185,9 +215,15 @@ void main() {
     });
 
     test('does not lower a node already verified at v2', () async {
-      container.read(protocolVersionStoreProvider).record(nodeKeys.public, 2);
+      container
+          .read(protocolVersionStoreProvider)
+          .record(nodeKeys.public, 2, _migration);
 
-      await deliver(_infoEvent(nodeKeys, protocolVersion: 'abc'));
+      // Unusable in either direction: it asserts nothing, so however recent it
+      // is it cannot displace the remembered assertion.
+      await deliver(
+        _infoEvent(nodeKeys, protocolVersion: 'abc', createdAt: _rollback),
+      );
 
       expect(anchored(), 2);
       expect(resolveTransport(anchored()), Transport.nip44);

--- a/test/features/mostro/mostro_instance_test.dart
+++ b/test/features/mostro/mostro_instance_test.dart
@@ -1,6 +1,7 @@
 import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
 
 void main() {
   group('MostroInstance anti-abuse bond tags', () {
@@ -326,9 +327,12 @@ void main() {
       );
     }
 
-    test('tag absent → getter null, model defaults to v1', () {
+    // Silence from a verified event is a pre-v0.18.0 daemon asserting v1 by
+    // omission — a fact about the node, unlike a tag it failed to write.
+    test('tag absent → raw getter null, asserted and model read v1', () {
       final event = buildEvent(const []);
       expect(event.protocolVersion, isNull);
+      expect(event.assertedProtocolVersion, kLegacyProtocolVersion);
       expect(MostroInstance.fromEvent(event).protocolVersion, 1);
     });
 
@@ -337,6 +341,7 @@ void main() {
         ['protocol_version', '2'],
       ]);
       expect(event.protocolVersion, 2);
+      expect(event.assertedProtocolVersion, 2);
       expect(MostroInstance.fromEvent(event).protocolVersion, 2);
     });
 
@@ -345,15 +350,40 @@ void main() {
         ['protocol_version', '1'],
       ]);
       expect(event.protocolVersion, 1);
+      expect(event.assertedProtocolVersion, 1);
       expect(MostroInstance.fromEvent(event).protocolVersion, 1);
     });
 
-    test('unparseable value → getter null, model defaults to v1', () {
+    // The conflation advertisesProtocolVersion exists to avoid: the node meant
+    // to state a version and the value says nothing, so the model must not
+    // report v1 for a node whose transport may well have resolved to v2.
+    test('unparseable value → asserted null, model reports nothing', () {
       final event = buildEvent(const [
         ['protocol_version', 'abc'],
       ]);
       expect(event.protocolVersion, isNull);
-      expect(MostroInstance.fromEvent(event).protocolVersion, 1);
+      expect(event.advertisesProtocolVersion, isTrue);
+      expect(event.assertedProtocolVersion, isNull);
+      expect(MostroInstance.fromEvent(event).protocolVersion, isNull);
+    });
+
+    test('empty value → asserted null, model reports nothing', () {
+      final event = buildEvent(const [
+        ['protocol_version', ''],
+      ]);
+      expect(event.assertedProtocolVersion, isNull);
+      expect(MostroInstance.fromEvent(event).protocolVersion, isNull);
+    });
+
+    // A version this client does not speak is still what the node said, and
+    // the About screen shows it as such; resolveTransport is what decides not
+    // to pair with it.
+    test('a version this client does not speak is reported as advertised', () {
+      final event = buildEvent(const [
+        ['protocol_version', '3'],
+      ]);
+      expect(event.assertedProtocolVersion, 3);
+      expect(MostroInstance.fromEvent(event).protocolVersion, 3);
     });
   });
 }

--- a/test/features/mostro/protocol_version_store_test.dart
+++ b/test/features/mostro/protocol_version_store_test.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
+import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Minimal in-memory double for the three methods the store uses.
+class _FakeSharedPreferencesAsync implements SharedPreferencesAsync {
+  final Map<String, String> strings = {};
+
+  /// When set, every write fails — used to prove memory stays authoritative.
+  final bool failWrites;
+
+  _FakeSharedPreferencesAsync({this.failWrites = false});
+
+  @override
+  Future<String?> getString(String key) async => strings[key];
+
+  @override
+  Future<void> setString(String key, String value) async {
+    if (failWrites) throw Exception('disk full');
+    strings[key] = value;
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    strings.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+const _nodeA =
+    '9d9d0455a96871f2dc4289b8312429db2e925f167b37c77bf7b28014be235980';
+const _nodeB =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+
+final _key = SharedPreferencesKeys.nodeProtocolVersions.value;
+
+void main() {
+  late _FakeSharedPreferencesAsync prefs;
+  late ProtocolVersionStore store;
+
+  setUp(() async {
+    prefs = _FakeSharedPreferencesAsync();
+    store = ProtocolVersionStore(prefs);
+    await store.init();
+  });
+
+  group('ProtocolVersionStore basics', () {
+    test('knows nothing about a node it has never seen', () {
+      expect(store.versionFor(_nodeA), isNull);
+    });
+
+    test('records a version and reports it back', () {
+      expect(store.record(_nodeA, 2), isTrue);
+      expect(store.versionFor(_nodeA), 2);
+    });
+
+    test('keeps each node separate', () {
+      store.record(_nodeA, 2);
+      store.record(_nodeB, 1);
+
+      expect(store.versionFor(_nodeA), 2);
+      expect(store.versionFor(_nodeB), 1);
+    });
+
+    test('ignores an empty pubkey', () {
+      expect(store.record('', 2), isFalse);
+    });
+
+    test('ignores a non-positive version', () {
+      expect(store.record(_nodeA, 0), isFalse);
+      expect(store.record(_nodeA, -1), isFalse);
+      expect(store.versionFor(_nodeA), isNull);
+    });
+  });
+
+  group('ProtocolVersionStore ratchet', () {
+    // The whole point of the store: once a node has been verified speaking v2,
+    // nothing can make this client speak v1 to it again.
+    test('never lowers a recorded version', () {
+      store.record(_nodeA, 2);
+
+      expect(store.record(_nodeA, 1), isFalse);
+      expect(store.versionFor(_nodeA), 2);
+    });
+
+    test('raises a recorded version', () {
+      store.record(_nodeA, 1);
+
+      expect(store.record(_nodeA, 2), isTrue);
+      expect(store.versionFor(_nodeA), 2);
+    });
+
+    test('re-recording the same version is a no-op', () {
+      store.record(_nodeA, 2);
+
+      expect(store.record(_nodeA, 2), isFalse);
+      expect(store.versionFor(_nodeA), 2);
+    });
+
+    test('a downgrade attempt on one node does not touch another', () {
+      store.record(_nodeA, 2);
+      store.record(_nodeB, 2);
+
+      store.record(_nodeA, 1);
+
+      expect(store.versionFor(_nodeA), 2);
+      expect(store.versionFor(_nodeB), 2);
+    });
+  });
+
+  group('ProtocolVersionStore persistence', () {
+    test('survives a restart', () async {
+      store.record(_nodeA, 2);
+
+      final reopened = ProtocolVersionStore(prefs);
+      await reopened.init();
+
+      expect(reopened.versionFor(_nodeA), 2);
+    });
+
+    test('the ratchet holds across a restart', () async {
+      store.record(_nodeA, 2);
+
+      final reopened = ProtocolVersionStore(prefs);
+      await reopened.init();
+
+      expect(reopened.record(_nodeA, 1), isFalse);
+      expect(reopened.versionFor(_nodeA), 2);
+    });
+
+    test('writes the whole snapshot, not just the last change', () async {
+      store.record(_nodeA, 2);
+      store.record(_nodeB, 1);
+
+      expect(
+        jsonDecode(prefs.strings[_key]!),
+        {_nodeA: 2, _nodeB: 1},
+      );
+    });
+
+    test('a failed write leaves memory authoritative', () async {
+      final failing = _FakeSharedPreferencesAsync(failWrites: true);
+      final s = ProtocolVersionStore(failing);
+      await s.init();
+
+      expect(s.record(_nodeA, 2), isTrue);
+      expect(s.versionFor(_nodeA), 2);
+    });
+
+    test('clear forgets everything', () async {
+      store.record(_nodeA, 2);
+      await store.clear();
+
+      expect(store.versionFor(_nodeA), isNull);
+      expect(prefs.strings[_key], isNull);
+    });
+  });
+
+  group('ProtocolVersionStore corrupt storage', () {
+    Future<ProtocolVersionStore> storeWith(String raw) async {
+      prefs.strings[_key] = raw;
+      final s = ProtocolVersionStore(prefs);
+      await s.init();
+      return s;
+    }
+
+    test('starts empty on unparseable JSON', () async {
+      final s = await storeWith('{not json');
+      expect(s.versionFor(_nodeA), isNull);
+      expect(s.isInitialized, isTrue);
+    });
+
+    test('starts empty when the payload is not a map', () async {
+      final s = await storeWith('[1, 2, 3]');
+      expect(s.versionFor(_nodeA), isNull);
+    });
+
+    // A single bad entry must not cost the ratchet its memory of every other
+    // node — that would be a downgrade window opened by a storage bug.
+    test('drops malformed entries but keeps the good ones', () async {
+      final s = await storeWith(jsonEncode({
+        _nodeA: 2,
+        _nodeB: 'garbage',
+        'another': null,
+        'negative': -5,
+      }));
+
+      expect(s.versionFor(_nodeA), 2);
+      expect(s.versionFor(_nodeB), isNull);
+      expect(s.versionFor('another'), isNull);
+      expect(s.versionFor('negative'), isNull);
+    });
+
+    test('accepts a numeric string version', () async {
+      final s = await storeWith(jsonEncode({_nodeA: '2'}));
+      expect(s.versionFor(_nodeA), 2);
+    });
+  });
+}

--- a/test/features/mostro/protocol_version_store_test.dart
+++ b/test/features/mostro/protocol_version_store_test.dart
@@ -33,6 +33,50 @@ class _FakeSharedPreferencesAsync implements SharedPreferencesAsync {
       throw UnimplementedError('${invocation.memberName}');
 }
 
+
+class _Countdown {
+  int _micros;
+  _Countdown(this._micros);
+
+  Duration next() {
+    final current = Duration(microseconds: _micros);
+    _micros = _micros > 500 ? _micros - 500 : 0;
+    return current;
+  }
+}
+
+/// Completes its writes in reverse call order, so a store that fires them
+/// concurrently loses the race and a store that queues them does not.
+class _ReorderingSharedPreferencesAsync implements SharedPreferencesAsync {
+  final Map<String, String> strings = {};
+
+  /// Longest delay first: each successive call waits less than the one before
+  /// it, so without serialisation the last call lands first. Held in a box
+  /// because `SharedPreferencesAsync` is `@immutable`.
+  final _Countdown _delay = _Countdown(5000);
+
+  @override
+  Future<String?> getString(String key) async => strings[key];
+
+  @override
+  Future<void> setString(String key, String value) async {
+    await _stagger();
+    strings[key] = value;
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    await _stagger();
+    strings.remove(key);
+  }
+
+  Future<void> _stagger() => Future.delayed(_delay.next());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
 const _nodeA =
     '9d9d0455a96871f2dc4289b8312429db2e925f167b37c77bf7b28014be235980';
 const _nodeB =
@@ -117,6 +161,7 @@ void main() {
   group('ProtocolVersionStore persistence', () {
     test('survives a restart', () async {
       store.record(_nodeA, 2);
+      await store.pendingWrites;
 
       final reopened = ProtocolVersionStore(prefs);
       await reopened.init();
@@ -126,6 +171,7 @@ void main() {
 
     test('the ratchet holds across a restart', () async {
       store.record(_nodeA, 2);
+      await store.pendingWrites;
 
       final reopened = ProtocolVersionStore(prefs);
       await reopened.init();
@@ -137,6 +183,7 @@ void main() {
     test('writes the whole snapshot, not just the last change', () async {
       store.record(_nodeA, 2);
       store.record(_nodeB, 1);
+      await store.pendingWrites;
 
       expect(
         jsonDecode(prefs.strings[_key]!),
@@ -200,6 +247,35 @@ void main() {
     test('accepts a numeric string version', () async {
       final s = await storeWith(jsonEncode({_nodeA: '2'}));
       expect(s.versionFor(_nodeA), 2);
+    });
+  });
+
+  group('ProtocolVersionStore write ordering', () {
+    late _ReorderingSharedPreferencesAsync slowPrefs;
+    late ProtocolVersionStore orderedStore;
+
+    setUp(() async {
+      slowPrefs = _ReorderingSharedPreferencesAsync();
+      orderedStore = ProtocolVersionStore(slowPrefs);
+      await orderedStore.init();
+    });
+
+    test('the newest snapshot is the one that lands', () async {
+      orderedStore.record(_nodeA, 1);
+      orderedStore.record(_nodeA, 2);
+      await orderedStore.pendingWrites;
+
+      // Unserialised, the second (faster) write would land first and the first
+      // would overwrite it with the stale {_nodeA: 1}.
+      expect(jsonDecode(slowPrefs.strings[_key]!), {_nodeA: 2});
+    });
+
+    test('a write issued before clear() does not resurrect the map', () async {
+      orderedStore.record(_nodeA, 2);
+      await orderedStore.clear();
+
+      expect(slowPrefs.strings[_key], isNull);
+      expect(orderedStore.versionFor(_nodeA), isNull);
     });
   });
 }

--- a/test/features/mostro/protocol_version_store_test.dart
+++ b/test/features/mostro/protocol_version_store_test.dart
@@ -77,6 +77,34 @@ class _ReorderingSharedPreferencesAsync implements SharedPreferencesAsync {
       throw UnimplementedError('${invocation.memberName}');
 }
 
+/// Delays only the read, so `init()` is still awaiting `_load()` while a
+/// `record()` lands. Reproduces bootstrap order: `RelaysNotifier` builds a
+/// `SubscriptionManager` — and with it the info-event feed into `record()` —
+/// before `appInitializerProvider` gets to `init()`.
+class _SlowReadSharedPreferencesAsync implements SharedPreferencesAsync {
+  final Map<String, String> strings = {};
+
+  @override
+  Future<String?> getString(String key) async {
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    return strings[key];
+  }
+
+  @override
+  Future<void> setString(String key, String value) async {
+    strings[key] = value;
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    strings.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
 const _nodeA =
     '9d9d0455a96871f2dc4289b8312429db2e925f167b37c77bf7b28014be235980';
 const _nodeB =
@@ -278,4 +306,82 @@ void main() {
       expect(orderedStore.versionFor(_nodeA), isNull);
     });
   });
+  group('ProtocolVersionStore records arriving before init', () {
+    late _SlowReadSharedPreferencesAsync slowRead;
+    late ProtocolVersionStore earlyStore;
+
+    setUp(() {
+      slowRead = _SlowReadSharedPreferencesAsync();
+      earlyStore = ProtocolVersionStore(slowRead);
+    });
+
+    test('a version recorded while loading is not dropped', () async {
+      final loading = earlyStore.init();
+      earlyStore.record(_nodeA, 2);
+      await loading;
+
+      expect(earlyStore.versionFor(_nodeA), 2);
+    });
+
+    test('and reaches disk instead of being erased by the next snapshot',
+        () async {
+      final loading = earlyStore.init();
+      earlyStore.record(_nodeA, 2);
+      await loading;
+
+      // A later record for a different node snapshots the whole map. If init()
+      // had dropped _nodeA, this write is what would carry the loss to disk.
+      earlyStore.record(_nodeB, 2);
+      await earlyStore.pendingWrites;
+
+      expect(jsonDecode(slowRead.strings[_key]!), {_nodeA: 2, _nodeB: 2});
+    });
+
+    test('the persisted value wins when it is the higher one', () async {
+      slowRead.strings[_key] = jsonEncode({_nodeA: 2});
+
+      final loading = earlyStore.init();
+      // A legacy info event racing the load must not walk the ratchet back.
+      earlyStore.record(_nodeA, 1);
+      await loading;
+
+      expect(earlyStore.versionFor(_nodeA), 2);
+    });
+
+    test('an early record for an unrelated node keeps the loaded ones',
+        () async {
+      slowRead.strings[_key] = jsonEncode({_nodeB: 2});
+
+      final loading = earlyStore.init();
+      earlyStore.record(_nodeA, 2);
+      await loading;
+
+      expect(earlyStore.versionFor(_nodeA), 2);
+      expect(earlyStore.versionFor(_nodeB), 2);
+    });
+
+    test('a record before init does not erase an earlier session', () async {
+      slowRead.strings[_key] = jsonEncode({_nodeB: 2});
+
+      // Bootstrap at its worst: the info event lands before init() is even
+      // called. A snapshot of the still-empty map would overwrite _nodeB.
+      earlyStore.record(_nodeA, 2);
+      await earlyStore.pendingWrites;
+      expect(jsonDecode(slowRead.strings[_key]!), {_nodeB: 2});
+
+      await earlyStore.init();
+      await earlyStore.pendingWrites;
+
+      expect(jsonDecode(slowRead.strings[_key]!), {_nodeB: 2, _nodeA: 2});
+      expect(earlyStore.versionFor(_nodeB), 2);
+    });
+
+    test('a plain cold start writes nothing', () async {
+      await earlyStore.init();
+      await earlyStore.pendingWrites;
+
+      expect(slowRead.strings[_key], isNull);
+    });
+  });
+
 }

--- a/test/features/mostro/protocol_version_store_test.dart
+++ b/test/features/mostro/protocol_version_store_test.dart
@@ -176,6 +176,23 @@ void main() {
       expect(store.record(_nodeA, -1, _at(_migration)), isFalse);
       expect(store.versionFor(_nodeA), isNull);
     });
+
+    // Resolution degrades an unknown version upwards to the safe default, but
+    // the store outlives the info event that carried it. Anchoring to a number
+    // no resolver understands would pin the first client to meet a v3 node at
+    // 3, with no way back to the v2 it actually speaks.
+    test('ignores a version this client does not speak', () {
+      expect(store.record(_nodeA, 3, _at(_migration)), isFalse);
+      expect(store.record(_nodeA, 99, _at(_migration)), isFalse);
+      expect(store.versionFor(_nodeA), isNull);
+    });
+
+    test('an unsupported version does not displace a recorded one', () {
+      store.record(_nodeA, 2, _at(_migration));
+
+      expect(store.record(_nodeA, 3, _at(_rollback)), isFalse);
+      expect(store.versionFor(_nodeA), 2);
+    });
   });
 
   group('ProtocolVersionStore anchor', () {
@@ -357,6 +374,9 @@ void main() {
         // An entry that cannot be dated cannot be weighed against a signed
         // event, so it is not evidence and is dropped like any other.
         'undatable': 2,
+        // Written by a build that spoke more versions than this one. Loading it
+        // would anchor this client to a number it cannot act on.
+        'unspeakable': _entry(3, _migration),
       }));
 
       expect(s.versionFor(_nodeA), 2);
@@ -364,6 +384,7 @@ void main() {
       expect(s.versionFor('another'), isNull);
       expect(s.versionFor('negative'), isNull);
       expect(s.versionFor('undatable'), isNull);
+      expect(s.versionFor('unspeakable'), isNull);
     });
 
     test('accepts numeric strings for both fields', () async {

--- a/test/features/mostro/protocol_version_store_test.dart
+++ b/test/features/mostro/protocol_version_store_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
 import 'package:mostro_mobile/features/mostro/protocol_version_store.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Minimal in-memory double for the three methods the store uses.
@@ -112,6 +113,22 @@ const _nodeB =
 
 final _key = SharedPreferencesKeys.nodeProtocolVersions.value;
 
+/// Three moments in a node's life, as info-event `created_at` seconds: the
+/// last event before the operator migrated, the one announcing v2, and the one
+/// announcing a rollback to v1.
+const int _beforeMigration = 1000;
+const int _migration = 2000;
+const int _rollback = 3000;
+
+DateTime _at(int seconds) =>
+    DateTime.fromMillisecondsSinceEpoch(seconds * 1000, isUtc: true);
+
+/// The persisted shape of one entry.
+Map<String, Object> _entry(int version, int seconds) => {
+      'v': version,
+      't': seconds,
+    };
+
 void main() {
   late _FakeSharedPreferencesAsync prefs;
   late ProtocolVersionStore store;
@@ -125,61 +142,108 @@ void main() {
   group('ProtocolVersionStore basics', () {
     test('knows nothing about a node it has never seen', () {
       expect(store.versionFor(_nodeA), isNull);
+      expect(store.assertionFor(_nodeA), isNull);
     });
 
     test('records a version and reports it back', () {
-      expect(store.record(_nodeA, 2), isTrue);
+      expect(store.record(_nodeA, 2, _at(_migration)), isTrue);
       expect(store.versionFor(_nodeA), 2);
     });
 
+    test('reports the date the version was asserted', () {
+      store.record(_nodeA, 2, _at(_migration));
+
+      expect(
+        store.assertionFor(_nodeA),
+        VersionAssertion(2, _at(_migration)),
+      );
+    });
+
     test('keeps each node separate', () {
-      store.record(_nodeA, 2);
-      store.record(_nodeB, 1);
+      store.record(_nodeA, 2, _at(_migration));
+      store.record(_nodeB, 1, _at(_beforeMigration));
 
       expect(store.versionFor(_nodeA), 2);
       expect(store.versionFor(_nodeB), 1);
     });
 
     test('ignores an empty pubkey', () {
-      expect(store.record('', 2), isFalse);
+      expect(store.record('', 2, _at(_migration)), isFalse);
     });
 
     test('ignores a non-positive version', () {
-      expect(store.record(_nodeA, 0), isFalse);
-      expect(store.record(_nodeA, -1), isFalse);
+      expect(store.record(_nodeA, 0, _at(_migration)), isFalse);
+      expect(store.record(_nodeA, -1, _at(_migration)), isFalse);
       expect(store.versionFor(_nodeA), isNull);
     });
   });
 
-  group('ProtocolVersionStore ratchet', () {
-    // The whole point of the store: once a node has been verified speaking v2,
-    // nothing can make this client speak v1 to it again.
-    test('never lowers a recorded version', () {
-      store.record(_nodeA, 2);
+  group('ProtocolVersionStore anchor', () {
+    // The whole point of the store: a relay can pick which signed events it
+    // serves, but it cannot mint one or move one forward in time, so an
+    // assertion older than the newest verified one is never accepted.
+    test('refuses an assertion older than the one it holds', () {
+      store.record(_nodeA, 2, _at(_migration));
 
-      expect(store.record(_nodeA, 1), isFalse);
+      expect(store.record(_nodeA, 1, _at(_beforeMigration)), isFalse);
       expect(store.versionFor(_nodeA), 2);
+    });
+
+    // The case the anchor is dated for, and the one a purely monotonic ratchet
+    // gets wrong: mostrod 0.18.x still ships gift-wrap, so an operator undoing
+    // a bad v2 rollout signs a newer v1 assertion. Refusing it would partition
+    // this client from the node until the app was reinstalled.
+    test('follows a newer v1 assertion after a recorded v2', () {
+      store.record(_nodeA, 2, _at(_migration));
+
+      expect(store.record(_nodeA, 1, _at(_rollback)), isTrue);
+      expect(store.versionFor(_nodeA), 1);
     });
 
     test('raises a recorded version', () {
-      store.record(_nodeA, 1);
+      store.record(_nodeA, 1, _at(_beforeMigration));
 
-      expect(store.record(_nodeA, 2), isTrue);
+      expect(store.record(_nodeA, 2, _at(_migration)), isTrue);
       expect(store.versionFor(_nodeA), 2);
     });
 
-    test('re-recording the same version is a no-op', () {
-      store.record(_nodeA, 2);
+    test('re-recording the same assertion is a no-op', () {
+      store.record(_nodeA, 2, _at(_migration));
 
-      expect(store.record(_nodeA, 2), isFalse);
+      expect(store.record(_nodeA, 2, _at(_migration)), isFalse);
+      expect(store.versionFor(_nodeA), 2);
+    });
+
+    // The date is what later replays are measured against, so a re-assertion
+    // of the same version has to move it forward.
+    test('a newer assertion of the same version advances the date', () {
+      store.record(_nodeA, 2, _at(_migration));
+
+      expect(store.record(_nodeA, 2, _at(_rollback)), isTrue);
+      expect(store.assertionFor(_nodeA)?.createdAt, _at(_rollback));
+    });
+
+    // Freshness cannot separate same-second assertions, so the safer transport
+    // wins rather than whichever relay answered first.
+    test('a same-second downgrade loses to the recorded version', () {
+      store.record(_nodeA, 2, _at(_migration));
+
+      expect(store.record(_nodeA, 1, _at(_migration)), isFalse);
+      expect(store.versionFor(_nodeA), 2);
+    });
+
+    test('an undated assertion cannot lower a dated one', () {
+      store.record(_nodeA, 2, _at(_migration));
+
+      expect(store.record(_nodeA, 1, null), isFalse);
       expect(store.versionFor(_nodeA), 2);
     });
 
     test('a downgrade attempt on one node does not touch another', () {
-      store.record(_nodeA, 2);
-      store.record(_nodeB, 2);
+      store.record(_nodeA, 2, _at(_migration));
+      store.record(_nodeB, 2, _at(_migration));
 
-      store.record(_nodeA, 1);
+      store.record(_nodeA, 1, _at(_beforeMigration));
 
       expect(store.versionFor(_nodeA), 2);
       expect(store.versionFor(_nodeB), 2);
@@ -188,7 +252,7 @@ void main() {
 
   group('ProtocolVersionStore persistence', () {
     test('survives a restart', () async {
-      store.record(_nodeA, 2);
+      store.record(_nodeA, 2, _at(_migration));
       await store.pendingWrites;
 
       final reopened = ProtocolVersionStore(prefs);
@@ -197,26 +261,51 @@ void main() {
       expect(reopened.versionFor(_nodeA), 2);
     });
 
-    test('the ratchet holds across a restart', () async {
-      store.record(_nodeA, 2);
+    test('the date survives a restart too', () async {
+      store.record(_nodeA, 2, _at(_migration));
       await store.pendingWrites;
 
       final reopened = ProtocolVersionStore(prefs);
       await reopened.init();
 
-      expect(reopened.record(_nodeA, 1), isFalse);
+      // Without it, the anchor after a restart could only compare versions —
+      // exactly the monotonic behaviour this store moved away from.
+      expect(reopened.assertionFor(_nodeA)?.createdAt, _at(_migration));
+      expect(reopened.record(_nodeA, 1, _at(_rollback)), isTrue);
+    });
+
+    test('the anchor holds across a restart', () async {
+      store.record(_nodeA, 2, _at(_migration));
+      await store.pendingWrites;
+
+      final reopened = ProtocolVersionStore(prefs);
+      await reopened.init();
+
+      expect(reopened.record(_nodeA, 1, _at(_beforeMigration)), isFalse);
       expect(reopened.versionFor(_nodeA), 2);
     });
 
     test('writes the whole snapshot, not just the last change', () async {
-      store.record(_nodeA, 2);
-      store.record(_nodeB, 1);
+      store.record(_nodeA, 2, _at(_migration));
+      store.record(_nodeB, 1, _at(_beforeMigration));
       await store.pendingWrites;
 
       expect(
         jsonDecode(prefs.strings[_key]!),
-        {_nodeA: 2, _nodeB: 1},
+        {
+          _nodeA: _entry(2, _migration),
+          _nodeB: _entry(1, _beforeMigration),
+        },
       );
+    });
+
+    test('an undated assertion persists without a date', () async {
+      store.record(_nodeA, 2, null);
+      await store.pendingWrites;
+
+      expect(jsonDecode(prefs.strings[_key]!), {
+        _nodeA: {'v': 2},
+      });
     });
 
     test('a failed write leaves memory authoritative', () async {
@@ -224,12 +313,12 @@ void main() {
       final s = ProtocolVersionStore(failing);
       await s.init();
 
-      expect(s.record(_nodeA, 2), isTrue);
+      expect(s.record(_nodeA, 2, _at(_migration)), isTrue);
       expect(s.versionFor(_nodeA), 2);
     });
 
     test('clear forgets everything', () async {
-      store.record(_nodeA, 2);
+      store.record(_nodeA, 2, _at(_migration));
       await store.clear();
 
       expect(store.versionFor(_nodeA), isNull);
@@ -256,25 +345,46 @@ void main() {
       expect(s.versionFor(_nodeA), isNull);
     });
 
-    // A single bad entry must not cost the ratchet its memory of every other
+    // A single bad entry must not cost the anchor its memory of every other
     // node — that would be a downgrade window opened by a storage bug.
     test('drops malformed entries but keeps the good ones', () async {
       final s = await storeWith(jsonEncode({
-        _nodeA: 2,
+        _nodeA: _entry(2, _migration),
         _nodeB: 'garbage',
         'another': null,
-        'negative': -5,
+        'negative': _entry(-5, _migration),
+        // The pre-dated shape, from a build before the anchor carried a date.
+        // An entry that cannot be dated cannot be weighed against a signed
+        // event, so it is not evidence and is dropped like any other.
+        'undatable': 2,
       }));
 
       expect(s.versionFor(_nodeA), 2);
       expect(s.versionFor(_nodeB), isNull);
       expect(s.versionFor('another'), isNull);
       expect(s.versionFor('negative'), isNull);
+      expect(s.versionFor('undatable'), isNull);
     });
 
-    test('accepts a numeric string version', () async {
-      final s = await storeWith(jsonEncode({_nodeA: '2'}));
-      expect(s.versionFor(_nodeA), 2);
+    test('accepts numeric strings for both fields', () async {
+      final s = await storeWith(jsonEncode({
+        _nodeA: {'v': '2', 't': '$_migration'},
+      }));
+
+      expect(s.assertionFor(_nodeA), VersionAssertion(2, _at(_migration)));
+    });
+
+    test('keeps an entry whose date is missing or unusable', () async {
+      final s = await storeWith(jsonEncode({
+        _nodeA: {'v': 2},
+        _nodeB: {'v': 2, 't': 'whenever'},
+      }));
+
+      // The version is still evidence, it just cannot be ranked by freshness;
+      // the anchor falls back to refusing anything lower.
+      expect(s.assertionFor(_nodeA), const VersionAssertion(2, null));
+      expect(s.assertionFor(_nodeB), const VersionAssertion(2, null));
+      expect(s.record(_nodeA, 1, _at(_rollback)), isFalse);
     });
   });
 
@@ -289,17 +399,20 @@ void main() {
     });
 
     test('the newest snapshot is the one that lands', () async {
-      orderedStore.record(_nodeA, 1);
-      orderedStore.record(_nodeA, 2);
+      orderedStore.record(_nodeA, 1, _at(_beforeMigration));
+      orderedStore.record(_nodeA, 2, _at(_migration));
       await orderedStore.pendingWrites;
 
       // Unserialised, the second (faster) write would land first and the first
-      // would overwrite it with the stale {_nodeA: 1}.
-      expect(jsonDecode(slowPrefs.strings[_key]!), {_nodeA: 2});
+      // would overwrite it with the stale v1 entry.
+      expect(
+        jsonDecode(slowPrefs.strings[_key]!),
+        {_nodeA: _entry(2, _migration)},
+      );
     });
 
     test('a write issued before clear() does not resurrect the map', () async {
-      orderedStore.record(_nodeA, 2);
+      orderedStore.record(_nodeA, 2, _at(_migration));
       await orderedStore.clear();
 
       expect(slowPrefs.strings[_key], isNull);
@@ -317,7 +430,7 @@ void main() {
 
     test('a version recorded while loading is not dropped', () async {
       final loading = earlyStore.init();
-      earlyStore.record(_nodeA, 2);
+      earlyStore.record(_nodeA, 2, _at(_migration));
       await loading;
 
       expect(earlyStore.versionFor(_nodeA), 2);
@@ -326,34 +439,49 @@ void main() {
     test('and reaches disk instead of being erased by the next snapshot',
         () async {
       final loading = earlyStore.init();
-      earlyStore.record(_nodeA, 2);
+      earlyStore.record(_nodeA, 2, _at(_migration));
       await loading;
 
       // A later record for a different node snapshots the whole map. If init()
       // had dropped _nodeA, this write is what would carry the loss to disk.
-      earlyStore.record(_nodeB, 2);
+      earlyStore.record(_nodeB, 2, _at(_migration));
       await earlyStore.pendingWrites;
 
-      expect(jsonDecode(slowRead.strings[_key]!), {_nodeA: 2, _nodeB: 2});
+      expect(
+        jsonDecode(slowRead.strings[_key]!),
+        {_nodeA: _entry(2, _migration), _nodeB: _entry(2, _migration)},
+      );
     });
 
-    test('the persisted value wins when it is the higher one', () async {
-      slowRead.strings[_key] = jsonEncode({_nodeA: 2});
+    test('the persisted assertion wins when it is the more recent one',
+        () async {
+      slowRead.strings[_key] = jsonEncode({_nodeA: _entry(2, _migration)});
 
       final loading = earlyStore.init();
-      // A legacy info event racing the load must not walk the ratchet back.
-      earlyStore.record(_nodeA, 1);
+      // A replayed pre-migration event racing the load must not lower the
+      // anchor once the load catches up with it.
+      earlyStore.record(_nodeA, 1, _at(_beforeMigration));
       await loading;
 
       expect(earlyStore.versionFor(_nodeA), 2);
     });
 
-    test('an early record for an unrelated node keeps the loaded ones',
-        () async {
-      slowRead.strings[_key] = jsonEncode({_nodeB: 2});
+    test('an early record still wins when it is the more recent one', () async {
+      slowRead.strings[_key] = jsonEncode({_nodeA: _entry(2, _migration)});
 
       final loading = earlyStore.init();
-      earlyStore.record(_nodeA, 2);
+      earlyStore.record(_nodeA, 1, _at(_rollback));
+      await loading;
+
+      expect(earlyStore.versionFor(_nodeA), 1);
+    });
+
+    test('an early record for an unrelated node keeps the loaded ones',
+        () async {
+      slowRead.strings[_key] = jsonEncode({_nodeB: _entry(2, _migration)});
+
+      final loading = earlyStore.init();
+      earlyStore.record(_nodeA, 2, _at(_migration));
       await loading;
 
       expect(earlyStore.versionFor(_nodeA), 2);
@@ -361,18 +489,24 @@ void main() {
     });
 
     test('a record before init does not erase an earlier session', () async {
-      slowRead.strings[_key] = jsonEncode({_nodeB: 2});
+      slowRead.strings[_key] = jsonEncode({_nodeB: _entry(2, _migration)});
 
       // Bootstrap at its worst: the info event lands before init() is even
       // called. A snapshot of the still-empty map would overwrite _nodeB.
-      earlyStore.record(_nodeA, 2);
+      earlyStore.record(_nodeA, 2, _at(_migration));
       await earlyStore.pendingWrites;
-      expect(jsonDecode(slowRead.strings[_key]!), {_nodeB: 2});
+      expect(
+        jsonDecode(slowRead.strings[_key]!),
+        {_nodeB: _entry(2, _migration)},
+      );
 
       await earlyStore.init();
       await earlyStore.pendingWrites;
 
-      expect(jsonDecode(slowRead.strings[_key]!), {_nodeB: 2, _nodeA: 2});
+      expect(
+        jsonDecode(slowRead.strings[_key]!),
+        {_nodeB: _entry(2, _migration), _nodeA: _entry(2, _migration)},
+      );
       expect(earlyStore.versionFor(_nodeB), 2);
     });
 

--- a/test/features/mostro/transport_consistency_test.dart
+++ b/test/features/mostro/transport_consistency_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/features/mostro/transport.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// The kind the orders subscription would listen on for [version].
+int _listeningKind(int? version) {
+  final filter = buildOrdersFilter(
+    resolveTransport(version),
+    ['a' * 64],
+    'b' * 64,
+  );
+  return filter.kinds!.single;
+}
+
+/// The kind an outbound message would actually be published as for [version].
+Future<int> _publishingKind(int? version) async {
+  final tradeKey = NostrUtils.generateKeyPair();
+  final message = MostroMessage(action: Action.fiatSent, id: 'order-1');
+
+  final event = await message.wrapForTransport(
+    protocolVersion: version,
+    tradeKey: tradeKey,
+    recipientPubKey: NostrUtils.generateKeyPair().public,
+  );
+  return event.kind!;
+}
+
+void main() {
+  // Send and receive derive their kind from the same resolution. If they ever
+  // disagree the client is partitioned from the node — listening on one kind
+  // while publishing on another — and the half an attacker controls is the
+  // forgeable one. These lock the two together at the only values that reach
+  // the wire.
+  group('send and receive resolve to the same kind', () {
+    for (final version in <int?>[null, 1, 2, 3, 99]) {
+      test('protocol_version $version', () async {
+        expect(await _publishingKind(version), _listeningKind(version));
+      });
+    }
+  });
+
+  group('resolved kinds are the protocol kinds', () {
+    test('v1 is gift wrap (1059)', () async {
+      expect(_listeningKind(1), 1059);
+      expect(await _publishingKind(1), 1059);
+    });
+
+    test('v2 is NIP-44 direct (14)', () async {
+      expect(_listeningKind(2), 14);
+      expect(await _publishingKind(2), 14);
+    });
+
+    // An unknown node must not land on the forgeable transport, on either
+    // side of the connection.
+    test('an unknown node lands on kind 14, not 1059', () async {
+      expect(_listeningKind(null), 14);
+      expect(await _publishingKind(null), 14);
+    });
+  });
+}

--- a/test/features/mostro/transport_test.dart
+++ b/test/features/mostro/transport_test.dart
@@ -36,46 +36,124 @@ void main() {
     });
 
     test('uses the advertised version when nothing is remembered', () {
-      expect(anchoredProtocolVersion(1, null), 1);
-      expect(anchoredProtocolVersion(2, null), 2);
+      expect(anchoredProtocolVersion(_v(1, _beforeMigration), null), 1);
+      expect(anchoredProtocolVersion(_v(2, _migration), null), 2);
     });
 
     test('uses the remembered version when nothing is advertised', () {
-      expect(anchoredProtocolVersion(null, 1), 1);
-      expect(anchoredProtocolVersion(null, 2), 2);
+      expect(anchoredProtocolVersion(null, _v(1, _beforeMigration)), 1);
+      expect(anchoredProtocolVersion(null, _v(2, _migration)), 2);
     });
 
     test('lets a node upgrade', () {
-      expect(anchoredProtocolVersion(2, 1), 2);
+      expect(
+        anchoredProtocolVersion(_v(2, _migration), _v(1, _beforeMigration)),
+        2,
+      );
     });
 
-    test('refuses to walk a node back below what it has proven', () {
-      expect(anchoredProtocolVersion(1, 2), 2);
+    // The attack the anchor exists to stop: a relay withholds the node's
+    // current event and serves a pre-migration one it cannot re-date.
+    test('refuses an assertion older than the one already verified', () {
+      expect(
+        anchoredProtocolVersion(_v(1, _beforeMigration), _v(2, _migration)),
+        2,
+      );
+    });
+
+    // The other half of the same rule, and the reason it is dated rather than
+    // monotonic: an operator rolling a bad v2 rollout back publishes a genuine,
+    // newer, signed v1 assertion. Refusing it would partition the client from
+    // the node permanently and silently.
+    test('follows a node that asserts v1 again more recently', () {
+      expect(
+        anchoredProtocolVersion(_v(1, _rollback), _v(2, _migration)),
+        1,
+      );
     });
 
     test('agreeing sources pass straight through', () {
-      expect(anchoredProtocolVersion(2, 2), 2);
-      expect(anchoredProtocolVersion(1, 1), 1);
+      expect(anchoredProtocolVersion(_v(2, _migration), _v(2, _migration)), 2);
+      expect(
+        anchoredProtocolVersion(
+          _v(1, _beforeMigration),
+          _v(1, _beforeMigration),
+        ),
+        1,
+      );
+    });
+
+    // Freshness cannot separate same-second assertions — NIP-01's id tie-break
+    // runs upstream, on events, not here — so the safer transport wins.
+    test('a same-second downgrade loses to the higher version', () {
+      expect(
+        anchoredProtocolVersion(_v(1, _migration), _v(2, _migration)),
+        2,
+      );
+    });
+
+    group('an assertion that cannot be dated', () {
+      test('never lowers a dated one', () {
+        expect(
+          anchoredProtocolVersion(
+            const VersionAssertion(1, null),
+            _v(2, _migration),
+          ),
+          2,
+        );
+      });
+
+      test('is not lowered by a dated one either', () {
+        expect(
+          anchoredProtocolVersion(
+            _v(1, _rollback),
+            const VersionAssertion(2, null),
+          ),
+          2,
+        );
+      });
+
+      test('falls back to the higher version when both are undated', () {
+        expect(
+          anchoredProtocolVersion(
+            const VersionAssertion(1, null),
+            const VersionAssertion(2, null),
+          ),
+          2,
+        );
+      });
     });
   });
 
   group('resolveAnchoredTransport', () {
     test('first contact with a legacy v1 node still reaches v1', () {
-      expect(resolveAnchoredTransport(1, null), Transport.giftWrap);
+      expect(
+        resolveAnchoredTransport(_v(1, _beforeMigration), null),
+        Transport.giftWrap,
+      );
     });
 
     test('first contact with a v2 node reaches v2', () {
-      expect(resolveAnchoredTransport(2, null), Transport.nip44);
+      expect(
+        resolveAnchoredTransport(_v(2, _migration), null),
+        Transport.nip44,
+      );
     });
 
     // The attack this whole chain exists to stop: the node is known to speak
     // v2, and a relay tries to put the client back on the forgeable transport.
     test('a replayed v1 advertisement cannot downgrade a known v2 node', () {
-      expect(resolveAnchoredTransport(1, 2), Transport.nip44);
+      expect(
+        resolveAnchoredTransport(_v(1, _beforeMigration), _v(2, _migration)),
+        Transport.nip44,
+      );
     });
 
     test('withholding the info event cannot downgrade a known v2 node', () {
-      expect(resolveAnchoredTransport(null, 2), Transport.nip44);
+      expect(
+        resolveAnchoredTransport(null, _v(2, _migration)),
+        Transport.nip44,
+      );
     });
 
     test('withholding the info event on first contact reaches the default',
@@ -84,11 +162,39 @@ void main() {
     });
 
     test('a node that has only ever been seen at v1 stays reachable', () {
-      expect(resolveAnchoredTransport(1, 1), Transport.giftWrap);
+      expect(
+        resolveAnchoredTransport(
+          _v(1, _beforeMigration),
+          _v(1, _beforeMigration),
+        ),
+        Transport.giftWrap,
+      );
     });
 
     test('a v1 node that upgrades is followed to v2', () {
-      expect(resolveAnchoredTransport(2, 1), Transport.nip44);
+      expect(
+        resolveAnchoredTransport(_v(2, _migration), _v(1, _beforeMigration)),
+        Transport.nip44,
+      );
+    });
+
+    test('a v2 node that the operator rolls back is followed to v1', () {
+      expect(
+        resolveAnchoredTransport(_v(1, _rollback), _v(2, _migration)),
+        Transport.giftWrap,
+      );
     });
   });
 }
+
+/// Three moments in a node's life, as `created_at` seconds: the last info
+/// event before the operator migrated, the one that announced v2, and the one
+/// that announced a rollback to v1.
+const int _beforeMigration = 1000;
+const int _migration = 2000;
+const int _rollback = 3000;
+
+VersionAssertion _v(int version, int seconds) => VersionAssertion(
+      version,
+      DateTime.fromMillisecondsSinceEpoch(seconds * 1000, isUtc: true),
+    );

--- a/test/features/mostro/transport_test.dart
+++ b/test/features/mostro/transport_test.dart
@@ -30,6 +30,34 @@ void main() {
     });
   });
 
+  // Callers that need to know whether a version is one this build understands
+  // ask here rather than hardcoding the set, so the two cannot drift apart as
+  // versions are added.
+  group('tryResolveTransport', () {
+    test('names the transport for a version this client speaks', () {
+      expect(tryResolveTransport(1), Transport.giftWrap);
+      expect(tryResolveTransport(2), Transport.nip44);
+    });
+
+    test('has no answer for a version this client does not speak', () {
+      expect(tryResolveTransport(3), isNull);
+      expect(tryResolveTransport(99), isNull);
+      expect(tryResolveTransport(0), isNull);
+      expect(tryResolveTransport(-1), isNull);
+    });
+
+    test('has no answer when there is no version at all', () {
+      expect(tryResolveTransport(null), isNull);
+    });
+
+    // The distinction resolveTransport erases: it answers kDefaultTransport for
+    // both, and only logs for the second.
+    test('separates "nothing advertised" from "unsupported"', () {
+      expect(resolveTransport(null), resolveTransport(3));
+      expect(tryResolveTransport(null), tryResolveTransport(3));
+    });
+  });
+
   group('anchoredProtocolVersion', () {
     test('knows nothing when neither source knows anything', () {
       expect(anchoredProtocolVersion(null, null), isNull);

--- a/test/features/mostro/transport_test.dart
+++ b/test/features/mostro/transport_test.dart
@@ -3,21 +3,92 @@ import 'package:mostro_mobile/features/mostro/transport.dart';
 
 void main() {
   group('resolveTransport', () {
-    test('protocol_version 2 → nip44', () {
-      expect(resolveTransport(2), Transport.nip44);
-    });
-
     test('protocol_version 1 → giftWrap', () {
       expect(resolveTransport(1), Transport.giftWrap);
     });
 
-    test('null (tag absent / node info not yet fetched) → giftWrap', () {
-      expect(resolveTransport(null), Transport.giftWrap);
+    test('protocol_version 2 → nip44', () {
+      expect(resolveTransport(2), Transport.nip44);
     });
 
-    test('unsupported version → degrades to giftWrap', () {
-      expect(resolveTransport(3), Transport.giftWrap);
-      expect(resolveTransport(0), Transport.giftWrap);
+    // "Unknown" is a state any relay can create for free by not serving the
+    // node's info event. Resolving it to v1 — whose intake authenticates
+    // nothing — made omission a downgrade primitive, so it resolves to the
+    // safe default instead.
+    test('null (tag absent, info not fetched, or withheld) → default', () {
+      expect(resolveTransport(null), kDefaultTransport);
+      expect(kDefaultTransport, Transport.nip44);
+    });
+
+    // Same reasoning: degrading an unrecognised version to v1 would let any
+    // party who can put a number in that tag pick the forgeable transport.
+    test('unsupported version degrades upwards to the default, not to v1', () {
+      expect(resolveTransport(3), kDefaultTransport);
+      expect(resolveTransport(99), kDefaultTransport);
+      expect(resolveTransport(0), kDefaultTransport);
+      expect(resolveTransport(-1), kDefaultTransport);
+    });
+  });
+
+  group('anchoredProtocolVersion', () {
+    test('knows nothing when neither source knows anything', () {
+      expect(anchoredProtocolVersion(null, null), isNull);
+    });
+
+    test('uses the advertised version when nothing is remembered', () {
+      expect(anchoredProtocolVersion(1, null), 1);
+      expect(anchoredProtocolVersion(2, null), 2);
+    });
+
+    test('uses the remembered version when nothing is advertised', () {
+      expect(anchoredProtocolVersion(null, 1), 1);
+      expect(anchoredProtocolVersion(null, 2), 2);
+    });
+
+    test('lets a node upgrade', () {
+      expect(anchoredProtocolVersion(2, 1), 2);
+    });
+
+    test('refuses to walk a node back below what it has proven', () {
+      expect(anchoredProtocolVersion(1, 2), 2);
+    });
+
+    test('agreeing sources pass straight through', () {
+      expect(anchoredProtocolVersion(2, 2), 2);
+      expect(anchoredProtocolVersion(1, 1), 1);
+    });
+  });
+
+  group('resolveAnchoredTransport', () {
+    test('first contact with a legacy v1 node still reaches v1', () {
+      expect(resolveAnchoredTransport(1, null), Transport.giftWrap);
+    });
+
+    test('first contact with a v2 node reaches v2', () {
+      expect(resolveAnchoredTransport(2, null), Transport.nip44);
+    });
+
+    // The attack this whole chain exists to stop: the node is known to speak
+    // v2, and a relay tries to put the client back on the forgeable transport.
+    test('a replayed v1 advertisement cannot downgrade a known v2 node', () {
+      expect(resolveAnchoredTransport(1, 2), Transport.nip44);
+    });
+
+    test('withholding the info event cannot downgrade a known v2 node', () {
+      expect(resolveAnchoredTransport(null, 2), Transport.nip44);
+    });
+
+    test('withholding the info event on first contact reaches the default',
+        () {
+      expect(resolveAnchoredTransport(null, null), kDefaultTransport);
+    });
+
+    test('a node that has only ever been seen at v1 stays reachable', () {
+      expect(resolveAnchoredTransport(1, 1), Transport.giftWrap);
+    });
+
+    test('a v1 node that upgrades is followed to v2', () {
+      expect(resolveAnchoredTransport(2, 1), Transport.nip44);
     });
   });
 }

--- a/test/shared/utils/event_signature_test.dart
+++ b/test/shared/utils/event_signature_test.dart
@@ -1,0 +1,175 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// Builds a kind-38385 info event of the shape the daemon publishes
+/// (empty content, everything in tags), signed by [keyPair].
+NostrEvent _infoEvent(NostrKeyPairs keyPair, {String protocolVersion = '2'}) {
+  return NostrEvent.fromPartialData(
+    kind: 38385,
+    content: '',
+    keyPairs: keyPair,
+    tags: [
+      ['d', 'info'],
+      ['y', 'mostro'],
+      ['protocol_version', protocolVersion],
+    ],
+  );
+}
+
+void main() {
+  group('NostrUtils.isValidEventSignature', () {
+    test('accepts a genuinely signed event', () {
+      final event = _infoEvent(NostrUtils.generateKeyPair());
+
+      expect(NostrUtils.isValidEventSignature(event), isTrue);
+    });
+
+    test('accepts a signed event with non-empty content and no tags', () {
+      final event = NostrEvent.fromPartialData(
+        kind: 1,
+        content: 'plain note',
+        keyPairs: NostrUtils.generateKeyPair(),
+        tags: const [],
+      );
+
+      expect(NostrUtils.isValidEventSignature(event), isTrue);
+    });
+
+    test('rejects tampered tags — the id no longer matches the content', () {
+      final signed = _infoEvent(NostrUtils.generateKeyPair());
+
+      // Flip protocol_version 2 -> 1 while keeping the original id/sig.
+      final tampered = NostrEvent(
+        id: signed.id,
+        sig: signed.sig,
+        pubkey: signed.pubkey,
+        kind: signed.kind,
+        content: signed.content,
+        createdAt: signed.createdAt,
+        tags: const [
+          ['d', 'info'],
+          ['y', 'mostro'],
+          ['protocol_version', '1'],
+        ],
+      );
+
+      expect(NostrUtils.isValidEventSignature(tampered), isFalse);
+    });
+
+    test('rejects tampered content', () {
+      final signed = NostrEvent.fromPartialData(
+        kind: 1,
+        content: 'original',
+        keyPairs: NostrUtils.generateKeyPair(),
+        tags: const [],
+      );
+
+      final tampered = NostrEvent(
+        id: signed.id,
+        sig: signed.sig,
+        pubkey: signed.pubkey,
+        kind: signed.kind,
+        content: 'spoofed',
+        createdAt: signed.createdAt,
+        tags: signed.tags,
+      );
+
+      expect(NostrUtils.isValidEventSignature(tampered), isFalse);
+    });
+
+    // This is the case NostrEvent.isVerified() lets through: it only checks
+    // the Schnorr signature against the event's self-declared id, so a genuine
+    // (id, sig, pubkey) triple lifted from one event and pasted onto a
+    // different payload passes it. Recomputing the id is what catches it.
+    test('rejects a genuine signature triple pasted onto a different payload',
+        () {
+      final keyPair = NostrUtils.generateKeyPair();
+      final genuine = _infoEvent(keyPair);
+
+      final forged = NostrEvent(
+        id: genuine.id,
+        sig: genuine.sig,
+        pubkey: genuine.pubkey,
+        kind: 38385,
+        content: '',
+        createdAt: genuine.createdAt,
+        tags: const [
+          ['d', 'info'],
+          ['y', 'mostro'],
+          ['protocol_version', '1'],
+        ],
+      );
+
+      // The weaker check the rest of the codebase reaches for is fooled...
+      expect(forged.isVerified(), isTrue);
+      // ...while recomputing the id is not.
+      expect(NostrUtils.isValidEventSignature(forged), isFalse);
+    });
+
+    test('rejects an event signed by a different key', () {
+      final signed = _infoEvent(NostrUtils.generateKeyPair());
+      final impostor = NostrUtils.generateKeyPair();
+
+      final swapped = NostrEvent(
+        id: signed.id,
+        sig: signed.sig,
+        pubkey: impostor.public,
+        kind: signed.kind,
+        content: signed.content,
+        createdAt: signed.createdAt,
+        tags: signed.tags,
+      );
+
+      expect(NostrUtils.isValidEventSignature(swapped), isFalse);
+    });
+
+    test('rejects an event with a malformed signature', () {
+      final signed = _infoEvent(NostrUtils.generateKeyPair());
+
+      final broken = NostrEvent(
+        id: signed.id,
+        sig: 'not-a-signature',
+        pubkey: signed.pubkey,
+        kind: signed.kind,
+        content: signed.content,
+        createdAt: signed.createdAt,
+        tags: signed.tags,
+      );
+
+      expect(NostrUtils.isValidEventSignature(broken), isFalse);
+    });
+
+    test('rejects an unsigned event', () {
+      final signed = _infoEvent(NostrUtils.generateKeyPair());
+
+      final unsigned = NostrEvent(
+        id: signed.id,
+        sig: null,
+        pubkey: signed.pubkey,
+        kind: signed.kind,
+        content: signed.content,
+        createdAt: signed.createdAt,
+        tags: signed.tags,
+      );
+
+      expect(NostrUtils.isValidEventSignature(unsigned), isFalse);
+    });
+
+    test('rejects an event with no id', () {
+      final signed = _infoEvent(NostrUtils.generateKeyPair());
+
+      final idless = NostrEvent(
+        id: null,
+        sig: signed.sig,
+        pubkey: signed.pubkey,
+        kind: signed.kind,
+        content: signed.content,
+        createdAt: signed.createdAt,
+        tags: signed.tags,
+      );
+
+      expect(NostrUtils.isValidEventSignature(idless), isFalse);
+    });
+  });
+}

--- a/test/shared/utils/nip59_authentication_test.dart
+++ b/test/shared/utils/nip59_authentication_test.dart
@@ -52,14 +52,21 @@ void main() {
         recipientPubKey: recipient.public,
       );
 
-      // It decrypts perfectly — nothing about the encryption is broken.
+      // It decrypts perfectly — nothing about the encryption is broken, so the
+      // rejection must come from the author pin and nowhere else.
       await expectLater(
         NostrUtils.decryptNIP59Event(
           forged,
           recipient.private,
           expectedAuthor: node.public,
         ),
-        throwsA(isA<Exception>()),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('Unexpected seal author'),
+          ),
+        ),
       );
     });
 
@@ -80,11 +87,17 @@ void main() {
       ) as Map<String, dynamic>;
       sealJson['sig'] = 'f' * 128;
 
+      // One ephemeral keypair for both the encryption and the wrap author:
+      // NIP-44 derives its key by ECDH, so the recipient decrypts using
+      // `tamperedWrap.pubkey`. Two different keypairs here would make the
+      // *outer* decryption fail, and the test would pass without ever reaching
+      // the seal-signature check it exists to cover.
+      final wrapperKeys = NostrUtils.generateKeyPair();
       final tamperedWrap = await NostrUtils.createWrap(
-        NostrUtils.generateKeyPair(),
+        wrapperKeys,
         await NostrUtils.encryptNIP44(
           jsonEncode(sealJson),
-          NostrUtils.generateKeyPair().private,
+          wrapperKeys.private,
           recipient.public,
         ),
         recipient.public,
@@ -96,7 +109,13 @@ void main() {
           recipient.private,
           expectedAuthor: node.public,
         ),
-        throwsA(isA<Exception>()),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Invalid seal signature',
+          ),
+        ),
       );
     });
 
@@ -144,7 +163,13 @@ void main() {
 
       await expectLater(
         forged.unWrap(recipient.private, expectedAuthor: node.public),
-        throwsA(isA<Exception>()),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('Unexpected seal author'),
+          ),
+        ),
       );
     });
   });

--- a/test/shared/utils/nip59_authentication_test.dart
+++ b/test/shared/utils/nip59_authentication_test.dart
@@ -1,0 +1,151 @@
+import 'dart:convert';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// Wraps [content] as mostrod does on the v1 transport: rumor -> seal signed
+/// by the sender's identity key -> gift wrap under a throwaway ephemeral key.
+Future<NostrEvent> _giftWrap({
+  required NostrKeyPairs sender,
+  required String recipientPubKey,
+  String content = '[{"order":{"action":"pay-invoice"}}]',
+}) {
+  return NostrUtils.createNIP59Event(content, recipientPubKey, sender.private);
+}
+
+void main() {
+  late NostrKeyPairs node;
+  late NostrKeyPairs recipient;
+
+  setUp(() {
+    node = NostrUtils.generateKeyPair();
+    recipient = NostrUtils.generateKeyPair();
+  });
+
+  group('decryptNIP59Event sender authentication', () {
+    test('accepts a gift wrap sealed by the expected author', () async {
+      final wrap = await _giftWrap(
+        sender: node,
+        recipientPubKey: recipient.public,
+      );
+
+      final rumor = await NostrUtils.decryptNIP59Event(
+        wrap,
+        recipient.private,
+        expectedAuthor: node.public,
+      );
+
+      expect(rumor.content, '[{"order":{"action":"pay-invoice"}}]');
+    });
+
+    // The core of MM-001: the outer wrap is signed by a throwaway key and the
+    // recipient's trade pubkey is public (it rides in the `p` tag of every
+    // event addressed to them), so anyone who can see the relay traffic can
+    // encrypt a well-formed gift wrap to a victim. Only the seal names the
+    // real sender.
+    test('rejects a gift wrap sealed by anyone else', () async {
+      final attacker = NostrUtils.generateKeyPair();
+      final forged = await _giftWrap(
+        sender: attacker,
+        recipientPubKey: recipient.public,
+      );
+
+      // It decrypts perfectly — nothing about the encryption is broken.
+      await expectLater(
+        NostrUtils.decryptNIP59Event(
+          forged,
+          recipient.private,
+          expectedAuthor: node.public,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('rejects a seal whose signature does not verify', () async {
+      final wrap = await _giftWrap(
+        sender: node,
+        recipientPubKey: recipient.public,
+      );
+
+      // Rebuild the wrap around a seal carrying the node's pubkey but a
+      // signature that was never produced for it.
+      final sealJson = jsonDecode(
+        await NostrUtils.decryptNIP44(
+          wrap.content!,
+          recipient.private,
+          wrap.pubkey,
+        ),
+      ) as Map<String, dynamic>;
+      sealJson['sig'] = 'f' * 128;
+
+      final tamperedWrap = await NostrUtils.createWrap(
+        NostrUtils.generateKeyPair(),
+        await NostrUtils.encryptNIP44(
+          jsonEncode(sealJson),
+          NostrUtils.generateKeyPair().private,
+          recipient.public,
+        ),
+        recipient.public,
+      );
+
+      await expectLater(
+        NostrUtils.decryptNIP59Event(
+          tamperedWrap,
+          recipient.private,
+          expectedAuthor: node.public,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('still rejects a non-gift-wrap kind', () async {
+      final notAWrap = NostrEvent.fromPartialData(
+        kind: 1,
+        content: 'hello',
+        keyPairs: node,
+        tags: const [],
+      );
+
+      await expectLater(
+        NostrUtils.decryptNIP59Event(
+          notAWrap,
+          recipient.private,
+          expectedAuthor: node.public,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('NostrEventExtensions.unWrap', () {
+    test('round-trips a message from the expected author', () async {
+      final wrap = await _giftWrap(
+        sender: node,
+        recipientPubKey: recipient.public,
+        content: '[{"order":{"action":"fiat-sent-ok"}}]',
+      );
+
+      final rumor = await wrap.unWrap(
+        recipient.private,
+        expectedAuthor: node.public,
+      );
+
+      expect(rumor.content, contains('fiat-sent-ok'));
+    });
+
+    test('refuses a message from an impostor', () async {
+      final attacker = NostrUtils.generateKeyPair();
+      final forged = await _giftWrap(
+        sender: attacker,
+        recipientPubKey: recipient.public,
+      );
+
+      await expectLater(
+        forged.unWrap(recipient.private, expectedAuthor: node.public),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Makes the client's choice of wire transport depend only on evidence it can verify, and authenticates the sender of protocol v1 messages.

- Verify the signature of the node's kind-38385 info event before applying it, and ignore events that do not supersede the one already in use (NIP-01 addressable ordering, id tie-break included).
- Persist, per node pubkey, the last version that node was verified to assert *and* the asserting event's signed `created_at`, and resolve the transport from whichever assertion is the more recent evidence.
- Resolve the transport through a single entry point shared by the send path and the orders subscription, so the two cannot drift apart.
- Pin the seal author and verify its signature when unwrapping NIP-59 gift wraps — the same check mostro-core already performs daemon-side (`nip59.rs:201`).

## Behaviour change

A node whose `protocol_version` is unknown now resolves to v2 (kind 14) rather than v1, matching mostrod's own default since v0.18.0. Against a node genuinely running `transport = "gift-wrap"`, the client switches back to kind 1059 as soon as that node's signed info event arrives.

## The anchor is dated, not monotonic

A relay picks which signed events it serves, but it cannot mint one and cannot re-date one without breaking the signature. "Newer than anything this client has verified" is therefore exactly the evidence a relay cannot manufacture, and that — not the higher version number — is what the anchor compares:

- A replayed pre-migration v1 event loses against a recorded v2. This is the downgrade the PR exists to block.
- A **newer** signed v1 assertion wins. mostrod 0.18.x still ships `transport = "gift-wrap"`, so an operator undoing a bad v2 rollout publishes exactly that; a monotonic ratchet would refuse it and partition every client that had ever seen v2, silently, with no recovery short of reinstalling.
- Ties, and assertions that cannot be dated, fall back to the higher version.

Two things are never recorded: a version this client cannot resolve, and an absent tag. Resolution reads an absent tag as v1 because it can see the info event is in hand; the store outlives it, and persisting 1 would let a relay resolve v1 off remembered state alone by simply withholding the event.

Full rationale in `docs/architecture/TRANSPORT_V2_MIGRATION.md` §4.1.

## Notes

- `NostrService.decryptNIP59Event` and `NostrEvent.unWrap`/`mostroUnWrap` gained a required `expectedAuthor` argument. Run `dart run build_runner build -d` to refresh mocks.
- 17 atomic commits. `flutter analyze` clean; `flutter test` 1210 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added sender authentication for encrypted messages, rejecting impostors and invalid signatures.
  * Validated incoming node information before accepting updates.

* **Reliability**
  * Preserved verified protocol versions across sessions and restarts.
  * Unknown or unsupported versions now safely use NIP-44 transport.
  * Improved handling of stale, duplicate, malformed, and legacy node information.
  * Improved peer and dispute chat delivery and message recovery.
  * Displays “Unknown” when a node’s protocol version is unavailable.

* **Tests**
  * Expanded coverage for authentication, signatures, transport selection, persistence, chat handling, and downgrade protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
