### PR TITLE
feat(relays): allow insecure ws:// relays in debug builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ When implementing or debugging protocol-related features (order flows, actions, 
 
 ### Relay Management System
 - **Automatic Sync**: Real-time synchronization with Mostro instance relay lists via kind 10002 events
-- **Manual Addition**: Users can add custom relays with strict validation (wss://, domains only, connectivity required)
+- **Manual Addition**: Users can add custom relays with strict validation (wss:// to domain names with optional port, connectivity required). Non-release builds and the Mortsom test environment (`Config.allowInsecureRelays`) additionally accept local hosts (`localhost`, IPv4) and plain `ws://` **only** towards those local hosts
 - **Instance Validation**: Author pubkey checking prevents relay contamination between Mostro instances  
 - **Two-tier Testing**: Nostr protocol + WebSocket connectivity validation
 - **Memory Safety**: Isolated test instances protect main app connectivity during validation
@@ -80,7 +80,8 @@ When implementing or debugging protocol-related features (order flows, actions, 
 #### Manual Relay Addition
 - Users can manually add relays via `addRelayWithSmartValidation()` method
 - Five sequential validations: URL normalization, duplicate check, domain validation, connectivity testing, blacklist management  
-- Security requirements: Only wss:// protocol, domain-only (no IP addresses), mandatory connectivity test
+- Security requirements: Only wss:// protocol to domain names (optional port), no IP addresses, mandatory connectivity test. When `Config.allowInsecureRelays` is true (debug/profile builds, Mortsom test environment) local hosts are also accepted and plain `ws://` is allowed only towards them; release builds never accept `ws://`
+- Validation logic lives in `lib/features/relays/relay_url_validator.dart` (`RelayUrlValidator.validate()` returns the URL or a typed `RelayUrlRejection` used to pick the error message)
 - Smart URL handling: Auto-adds "wss://" prefix if missing
 - Source tracking: Manual relays marked as `RelaySource.user`
 - Blacklist override: Manual addition automatically removes relay from blacklist
@@ -98,7 +99,7 @@ When implementing or debugging protocol-related features (order flows, actions, 
 
 #### Relay Validation System  
 - Two-tier connectivity testing: Primary Nostr protocol test (REQ/EVENT/EOSE), WebSocket fallback
-- Domain-only policy: IP addresses completely rejected
+- Domain-only policy in release builds: IP addresses rejected; local hosts (`localhost`, IPv4, optional port) accepted only when `Config.allowInsecureRelays` is true
 - URL normalization: Trailing slash removal prevents duplicate entries
 - Instance-isolated testing: Test connections don't affect main app connectivity
 
@@ -428,7 +429,7 @@ For complete technical documentation, see `RELAY_SYNC_IMPLEMENTATION.md`.
 - **Dual Storage Implementation**: Mostro/default relays persist in `settings.relays` and use blacklist for deactivation, user relays persist in `settings.userRelays` with complete JSON metadata via `toJson()`/`fromJson()`
 - **Differentiated Lifecycle Management**: `removeRelayWithBlacklist()` adds Mostro/default relays to blacklist for potential restoration, `removeRelay()` permanently deletes user relays from both state and storage
 - **Storage Synchronization**: `_saveRelays()` method saves all active relays to `settings.relays` while separately preserving user relay metadata in `settings.userRelays`
-- **URL Normalization Process**: Relay URLs undergo normalization by trimming whitespace and removing trailing slashes using `_normalizeRelayUrl()` method throughout blacklist operations in `_handleMostroRelayListUpdate()`
+- **URL Normalization Process**: Every dedupe/blacklist comparison goes through `RelayUrlValidator.canonicalKey()` (trim, strip trailing slashes, lowercase scheme and host); `RelaysNotifier._normalizeRelayUrl()` delegates to it so stored legacy URLs and newly validated input compare the same way
 - **Settings Persistence Mechanism**: The Settings `copyWith()` method uses null-aware operators (`??`) to preserve existing values for selectedLanguage and defaultLightningAddress when not explicitly overridden
 - **Relay Validation Protocol**: Connectivity testing follows a two-tier approach: primary Nostr protocol test (sends REQ, waits for EVENT/EOSE) via `_testNostrProtocol()`, fallback WebSocket test via `_testBasicWebSocketConnectivity()`
 - **Blacklist Matching Logic**: All blacklist operations normalize both stored blacklist URLs and incoming relay URLs to ensure consistent string matching regardless of format variations
@@ -519,6 +520,7 @@ For complete technical documentation, see `RELAY_SYNC_IMPLEMENTATION.md`.
 ### Relay System Files
 - `lib/core/models/relay_list_event.dart` - NIP-65 event parser for kind 10002
 - `lib/features/relays/relay.dart` - Enhanced relay model with source tracking
+- `lib/features/relays/relay_url_validator.dart` - Pure URL validation/normalization and canonical comparison key
 - `lib/features/relays/relays_notifier.dart` - Core relay management and sync logic
 - `lib/features/relays/relays_provider.dart` - Riverpod provider configuration
 - `lib/features/settings/settings.dart` - Settings model with blacklist support

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ When implementing or debugging protocol-related features (order flows, actions, 
 
 ### Relay Management System
 - **Automatic Sync**: Real-time synchronization with Mostro instance relay lists via kind 10002 events
-- **Manual Addition**: Users can add custom relays with strict validation (wss:// to domain names with optional port, connectivity required). Non-release builds and the Mortsom test environment (`Config.allowInsecureRelays`) additionally accept local hosts (`localhost`, IPv4) and plain `ws://` **only** towards those local hosts
+- **Manual Addition**: Users can add custom relays with strict validation (wss:// to domain names with optional port, connectivity required). Non-release builds and the Mortsom test environment (`Config.allowInsecureRelays`) additionally accept local hosts (`localhost` or a private IPv4 address: loopback, 10/8, 172.16/12, 192.168/16) and plain `ws://` **only** towards those local hosts
 - **Instance Validation**: Author pubkey checking prevents relay contamination between Mostro instances  
 - **Two-tier Testing**: Nostr protocol + WebSocket connectivity validation
 - **Memory Safety**: Isolated test instances protect main app connectivity during validation
@@ -80,7 +80,7 @@ When implementing or debugging protocol-related features (order flows, actions, 
 #### Manual Relay Addition
 - Users can manually add relays via `addRelayWithSmartValidation()` method
 - Five sequential validations: URL normalization, duplicate check, domain validation, connectivity testing, blacklist management  
-- Security requirements: Only wss:// protocol to domain names (optional port), no IP addresses, mandatory connectivity test. When `Config.allowInsecureRelays` is true (debug/profile builds, Mortsom test environment) local hosts are also accepted and plain `ws://` is allowed only towards them; release builds never accept `ws://`
+- Security requirements: Only wss:// protocol to domain names (optional port), no IP addresses, mandatory connectivity test. When `Config.allowInsecureRelays` is true (debug/profile builds, Mortsom test environment) local hosts are also accepted and plain `ws://` is allowed only towards them; release builds never accept `ws://`. A public IPv4 address is never a local host, so it is rejected in every build
 - Validation logic lives in `lib/features/relays/relay_url_validator.dart` (`RelayUrlValidator.validate()` returns the URL or a typed `RelayUrlRejection` used to pick the error message)
 - Smart URL handling: Auto-adds "wss://" prefix if missing
 - Source tracking: Manual relays marked as `RelaySource.user`
@@ -99,7 +99,7 @@ When implementing or debugging protocol-related features (order flows, actions, 
 
 #### Relay Validation System  
 - Two-tier connectivity testing: Primary Nostr protocol test (REQ/EVENT/EOSE), WebSocket fallback
-- Domain-only policy in release builds: IP addresses rejected; local hosts (`localhost`, IPv4, optional port) accepted only when `Config.allowInsecureRelays` is true
+- Domain-only policy in release builds: IP addresses rejected; local hosts (`localhost` or a private IPv4 address, optional port) accepted only when `Config.allowInsecureRelays` is true. Public IPv4 addresses are rejected in every build
 - URL normalization: Trailing slash removal prevents duplicate entries
 - Instance-isolated testing: Test connections don't affect main app connectivity
 

--- a/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
+++ b/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
@@ -434,76 +434,66 @@ Future<bool> _testBasicWebSocketConnectivity(String url) async {
 
 ### Smart Relay Addition with Comprehensive Validation
 
-#### Six-Step Validation Process (Lines 332-401)
+#### Six-Step Validation Process
 ```dart
 Future<RelayValidationResult> addRelayWithSmartValidation(
   String input, {
-  required String errorOnlySecure,                          // Line 334
-  required String errorNoHttp,                              // Line 335
-  required String errorInvalidDomain,                       // Line 336
-  required String errorAlreadyExists,                       // Line 337
-  required String errorNotValid,                            // Line 338
+  required String errorOnlySecure,
+  required String errorNoHttp,
+  required String errorInvalidDomain,
+  required String errorAlreadyExists,
+  required String errorNotValid,
 }) async {
-  // Step 1: Normalize URL
-  final normalizedUrl = normalizeRelayUrl(input);           // Line 341
+  // Step 1: Validate and normalize (typed rejection picks the message)
+  final validation = _urlValidator.validate(input);
+  final normalizedUrl = validation.url;
   if (normalizedUrl == null) {
-    if (input.trim().toLowerCase().startsWith('ws://')) {
-      return RelayValidationResult(
-        success: false,
-        error: errorOnlySecure,                              // Line 346
-      );
-    } else if (input.trim().toLowerCase().startsWith('http')) {
-      return RelayValidationResult(
-        success: false,
-        error: errorNoHttp,                                  // Line 351
-      );
-    } else {
-      return RelayValidationResult(
-        success: false,
-        error: errorInvalidDomain,                           // Line 356
-      );
-    }
+    final error = switch (validation.rejection!) {
+      RelayUrlRejection.insecureScheme => errorOnlySecure,
+      RelayUrlRejection.httpScheme => errorNoHttp,
+      RelayUrlRejection.invalidHost => errorInvalidDomain,
+    };
+    return RelayValidationResult(success: false, error: error);
   }
 
-  // Step 2: Check for duplicates
-  if (state.any((relay) => relay.url == normalizedUrl)) {   // Line 362
-    return RelayValidationResult(
-      success: false,
-      error: errorAlreadyExists,                             // Line 365
-    );
+  // Step 2: Check for duplicates through the canonical key
+  // (stored URLs may predate normalization)
+  if (state.any((relay) => _normalizeRelayUrl(relay.url) == normalizedUrl)) {
+    return RelayValidationResult(success: false, error: errorAlreadyExists);
   }
 
   // Step 3: Test connectivity using dart_nostr - MUST PASS to proceed
-  final isHealthy = await testRelayConnectivity(normalizedUrl); // Line 370
+  final isHealthy = await testRelayConnectivity(normalizedUrl);
 
   // Step 4: Only add relay if it passes connectivity test
   if (!isHealthy) {
-    return RelayValidationResult(
-      success: false,
-      error: errorNotValid,                                  // Line 376
-    );
+    return RelayValidationResult(success: false, error: errorNotValid);
   }
 
-  // Step 5: Remove from blacklist if present (user wants to manually add it)
-  if (settings.state.blacklistedRelays.contains(normalizedUrl)) { // Line 381
-    await settings.removeFromBlacklist(normalizedUrl);      // Line 382
-    _logger.i('Removed $normalizedUrl from blacklist - user manually added it'); // Line 383
+  // Step 5: Remove from blacklist if present (user wants to manually add it),
+  // again comparing canonical keys
+  final blacklisted = settings.state.blacklistedRelays
+      .where((url) => _normalizeRelayUrl(url) == normalizedUrl)
+      .toList();
+  for (final url in blacklisted) {
+    await settings.removeFromBlacklist(url);
+    logger.i('Removed $url from blacklist - user manually added it');
   }
 
   // Step 6: Add relay as user relay
   final newRelay = Relay(
-    url: normalizedUrl,                                      // Line 388
-    isHealthy: true,                                         // Line 389
-    source: RelaySource.user,                               // Line 390
-    addedAt: DateTime.now(),                                // Line 391
+    url: normalizedUrl,
+    isHealthy: true,
+    source: RelaySource.user,
+    addedAt: DateTime.now(),
   );
-  state = [...state, newRelay];                             // Line 393
-  await _saveRelays();                                      // Line 394
+  state = [...state, newRelay];
+  await _saveRelays();
 
   return RelayValidationResult(
-    success: true,                                           // Line 397
-    normalizedUrl: normalizedUrl,                           // Line 398
-    isHealthy: true,                                        // Line 399
+    success: true,
+    normalizedUrl: normalizedUrl,
+    isHealthy: true,
   );
 }
 ```
@@ -1260,7 +1250,7 @@ Storage Persistence → UI Feedback
 - **Subscription Isolation**: Each Mostro instance gets isolated subscriptions
 
 ### Network Security
-- **Secure Connections Only**: Rejects http:// always and insecure ws:// except towards local hosts in non-release builds
+- **Secure Connections Only**: Rejects http:// always. Insecure ws:// is rejected unless `Config.allowInsecureRelays` is true (non-release builds, or the Mortsom test environment: armed entry point plus `MORTSOM_TEST_ENV`), and even then only towards local hosts (`localhost`, IPv4)
 - **Connectivity Validation**: Mandatory connectivity testing before relay addition
 - **Test Instance Isolation**: Connectivity tests use separate Nostr instances
 

--- a/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
+++ b/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
@@ -203,31 +203,32 @@ void _loadRelays() {
 
 ### Dual Storage Management System
 
-#### Storage Persistence (Lines 81-104)
+#### Storage Persistence (Lines 86-110)
 ```dart
 Future<void> _saveRelays() async {
-  // Get blacklisted relays
-  final blacklistedUrls = settings.state.blacklistedRelays;  // Line 83
+  // Get blacklisted relays (membership is checked through the canonical
+  // key: stored relay URLs may predate normalization)
+  final blacklistedUrls = settings.state.blacklistedRelays;  // Line 89
   
   // Include ALL active relays (Mostro/default + user) that are NOT blacklisted
   final allActiveRelayUrls = state
-      .where((r) => !blacklistedUrls.contains(r.url))        // Line 87
-      .map((r) => r.url)                                     // Line 88
-      .toList();                                             // Line 89
+      .where((r) => !_isBlacklisted(r.url))                  // Line 93
+      .map((r) => r.url)                                     // Line 94
+      .toList();                                             // Line 95
   
   // Separate user relays for metadata preservation
-  final userRelays = state.where((r) => r.source == RelaySource.user).toList(); // Line 92
+  final userRelays = state.where((r) => r.source == RelaySource.user).toList(); // Line 98
   
-  _logger.i('Saving ${allActiveRelayUrls.length} active relays (excluding ${blacklistedUrls.length} blacklisted) and ${userRelays.length} user relays metadata'); // Line 94
+  _logger.i('Saving ${allActiveRelayUrls.length} active relays (excluding ${blacklistedUrls.length} blacklisted) and ${userRelays.length} user relays metadata'); // Line 100
   
   // Save ALL active relays to settings.relays (NostrService will use these)
-  await settings.updateRelays(allActiveRelayUrls);           // Line 97
+  await settings.updateRelays(allActiveRelayUrls);           // Line 103
   
   // Save user relays metadata to settings.userRelays (for persistence/reconstruction)
-  final userRelaysJson = userRelays.map((r) => r.toJson()).toList(); // Line 100
-  await settings.updateUserRelays(userRelaysJson);           // Line 101
+  final userRelaysJson = userRelays.map((r) => r.toJson()).toList(); // Line 106
+  await settings.updateUserRelays(userRelaysJson);           // Line 107
   
-  _logger.i('Relays saved successfully');                    // Line 103
+  _logger.i('Relays saved successfully');                    // Line 109
 }
 ```
 
@@ -282,8 +283,10 @@ validated input.
 **Security Features**:
 - **Protocol Enforcement**: Release builds accept only `wss://`; plain `ws://`
   is never accepted towards a public host in any build
-- **Host Policy**: Domain names (optional port) always; `localhost`/IPv4 only
-  when `Config.allowInsecureRelays` is true
+- **Host Policy**: Domain names (optional port) always; `localhost` and
+  private IPv4 addresses (loopback, 10/8, 172.16/12, 192.168/16) only when
+  `Config.allowInsecureRelays` is true. Public IPv4 addresses are always
+  rejected
 - **Auto-prefix Addition**: Bare hosts get `wss://`, never `ws://`
 
 ### Two-Tier Connectivity Validation System
@@ -737,7 +740,7 @@ Future<void> removeRelayWithBlacklist(String url) async {
 #### Blacklist Toggle for Mostro Relays (Lines 794-812)
 ```dart
 Future<void> toggleMostroRelayBlacklist(String url) async {
-  final isCurrentlyBlacklisted = settings.state.blacklistedRelays.contains(url); // Line 795
+  final isCurrentlyBlacklisted = _isBlacklisted(url);        // Line 795
   
   if (isCurrentlyBlacklisted) {
     // Remove from blacklist and trigger sync to add back
@@ -830,18 +833,27 @@ Future<void> _cleanAllRelaysAndResync() async {
 String _normalizeRelayUrl(String url) => RelayUrlValidator.canonicalKey(url);
 ```
 
-#### Safety Validation (Lines 779-789)
+#### Safety Validation (Lines 772-789)
 ```dart
 bool wouldLeaveNoActiveRelays(String urlToBlacklist) {
-  final currentActiveRelays = state.map((r) => r.url).toList(); // Line 780
-  final currentBlacklist = settings.state.blacklistedRelays; // Line 781
-  
+  // Both sides go through the canonical key so a legacy stored URL still
+  // matches the relay it refers to
+  final currentActiveRelays =
+      state.map((r) => _normalizeRelayUrl(r.url)).toList();  // Line 774
+  final currentBlacklist =
+      settings.state.blacklistedRelays.map(_normalizeRelayUrl); // Line 776
+
   // Simulate what would happen if we blacklist this URL
-  final wouldBeBlacklisted = [...currentBlacklist, urlToBlacklist]; // Line 784
-  final wouldRemainActive = currentActiveRelays.where((url) => !wouldBeBlacklisted.contains(url)).toList(); // Line 785
+  final wouldBeBlacklisted = {                               // Line 779
+    ...currentBlacklist,                                     // Line 780
+    _normalizeRelayUrl(urlToBlacklist),                      // Line 781
+  };                                                         // Line 782
+  final wouldRemainActive = currentActiveRelays
+      .where((url) => !wouldBeBlacklisted.contains(url))     // Line 784
+      .toList();                                             // Line 785
   
   _logger.d('Current active: ${currentActiveRelays.length}, Would remain: ${wouldRemainActive.length}'); // Line 787
-  return wouldRemainActive.isEmpty;                         // Line 788
+  return wouldRemainActive.isEmpty;                          // Line 788
 }
 ```
 
@@ -1250,7 +1262,7 @@ Storage Persistence → UI Feedback
 - **Subscription Isolation**: Each Mostro instance gets isolated subscriptions
 
 ### Network Security
-- **Secure Connections Only**: Rejects http:// always. Insecure ws:// is rejected unless `Config.allowInsecureRelays` is true (non-release builds, or the Mortsom test environment: armed entry point plus `MORTSOM_TEST_ENV`), and even then only towards local hosts (`localhost`, IPv4)
+- **Secure Connections Only**: Rejects http:// always. Insecure ws:// is rejected unless `Config.allowInsecureRelays` is true (non-release builds, or the Mortsom test environment: armed entry point plus `MORTSOM_TEST_ENV`), and even then only towards local hosts (`localhost` or a private IPv4 address: loopback, 10/8, 172.16/12, 192.168/16)
 - **Connectivity Validation**: Mandatory connectivity testing before relay addition
 - **Test Instance Isolation**: Connectivity tests use separate Nostr instances
 

--- a/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
+++ b/docs/architecture/RELAY_SYNC_IMPLEMENTATION.md
@@ -239,54 +239,52 @@ Future<void> _saveRelays() async {
 
 ### URL Normalization and Validation System
 
-#### Smart URL Normalization (Lines 122-134)
+Validation lives in a pure, dependency-free class,
+`lib/features/relays/relay_url_validator.dart`, so it is unit-tested directly
+(`test/features/relays/relay_url_validator_test.dart`). `RelaysNotifier`
+builds it from `Config.allowInsecureRelays` and exposes `normalizeRelayUrl()`
+as a thin delegate; tests inject a validator through the `urlValidator`
+constructor parameter.
+
+#### `RelayUrlValidator.validate()`
 ```dart
-String? normalizeRelayUrl(String input) {
-  input = input.trim().toLowerCase();                        // Line 123
-
-  if (!isValidDomainFormat(input)) return null;             // Line 125
-
-  if (input.startsWith('wss://')) {
-    return input; // Already properly formatted                // Line 128
-  } else if (input.startsWith('ws://') || input.startsWith('http')) {
-    return null; // Reject non-secure protocols              // Line 130
-  } else {
-    return 'wss://$input'; // Auto-add wss:// prefix         // Line 132
-  }
-}
+final validator = RelayUrlValidator(allowInsecure: Config.allowInsecureRelays);
+final result = validator.validate(input); // RelayUrlValidation
+result.url;        // normalized URL, or null
+result.rejection;  // RelayUrlRejection.insecureScheme | httpScheme | invalidHost
 ```
 
-#### Domain Format Validation (Lines 137-158)
-```dart
-bool isValidDomainFormat(String input) {
-  // Remove protocol prefix if present
-  if (input.startsWith('wss://')) {
-    input = input.substring(6);                              // Line 140
-  } else if (input.startsWith('ws://')) {
-    input = input.substring(5);                              // Line 142
-  } else if (input.startsWith('http://')) {
-    input = input.substring(7);                              // Line 144
-  } else if (input.startsWith('https://')) {
-    input = input.substring(8);                              // Line 146
-  }
+Policy:
 
-  // Reject IP addresses (basic check for numbers and dots only)
-  if (RegExp(r'^[\d.]+$').hasMatch(input)) {
-    return false;                                            // Line 151
-  }
+| Input | Release build | `allowInsecure` (debug/profile, Mortsom) |
+|---|---|---|
+| `wss://relay.example.com[:port]`, bare host | accepted | accepted |
+| `wss://localhost[:port]`, `wss://10.0.2.2` | `invalidHost` | accepted |
+| `ws://localhost[:port]`, `ws://10.0.2.2` | `insecureScheme` | accepted |
+| `ws://relay.example.com` | `insecureScheme` | `insecureScheme` (plain text only to local hosts) |
+| `http(s)://…` | `httpScheme` | `httpScheme` |
+| malformed host, octet > 255, port outside 1-65535 | `invalidHost` (`insecureScheme` if given as `ws://`) | `invalidHost` |
 
-  // Domain regex: valid domain format with at least one dot
-  final domainRegex = RegExp(
-      r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$'); // Line 155
-  return domainRegex.hasMatch(input) && input.contains('.'); // Line 157
-}
-```
+The scheme is decided first (split on the first `://`), then the host is
+validated, so a bare domain that merely starts with `http` is accepted. The
+rejection reason drives the localized error in
+`addRelayWithSmartValidation()` (`relayErrorOnlySecure`, `relayErrorNoHttp`,
+`relayErrorInvalidDomain`).
+
+#### Canonical key
+`RelayUrlValidator.canonicalKey(url)` trims, strips trailing slashes and
+lowercases scheme and host (a path keeps its case). It is the single
+normalizer used by `normalize()` and by every dedupe/blacklist comparison in
+`RelaysNotifier` (`_normalizeRelayUrl()` delegates to it), so URLs stored by
+older app versions (`wss://Relay.Example.com/`) still match freshly
+validated input.
 
 **Security Features**:
-- **Protocol Enforcement**: Only accepts `wss://` (secure WebSocket) connections
-- **IP Address Rejection**: Prevents direct IP connections for security
-- **Domain Validation**: RFC-compliant domain name validation
-- **Auto-prefix Addition**: User-friendly input handling
+- **Protocol Enforcement**: Release builds accept only `wss://`; plain `ws://`
+  is never accepted towards a public host in any build
+- **Host Policy**: Domain names (optional port) always; `localhost`/IPv4 only
+  when `Config.allowInsecureRelays` is true
+- **Auto-prefix Addition**: Bare hosts get `wss://`, never `ws://`
 
 ### Two-Tier Connectivity Validation System
 
@@ -837,16 +835,9 @@ Future<void> _cleanAllRelaysAndResync() async {
 
 ### Utility Methods and Helpers
 
-#### URL Normalization (Lines 847-854)
+#### URL Normalization
 ```dart
-String _normalizeRelayUrl(String url) {
-  url = url.trim();                                         // Line 848
-  // Remove trailing slash if present
-  if (url.endsWith('/')) {                                  // Line 850
-    url = url.substring(0, url.length - 1);                // Line 851
-  }
-  return url;                                               // Line 853
-}
+String _normalizeRelayUrl(String url) => RelayUrlValidator.canonicalKey(url);
 ```
 
 #### Safety Validation (Lines 779-789)
@@ -1258,8 +1249,8 @@ Storage Persistence → UI Feedback
 ### Input Validation and Sanitization
 
 #### URL Security
-- **Protocol Enforcement**: Only accepts secure WebSocket connections (wss://)
-- **IP Address Rejection**: Prevents direct IP connections for security
+- **Protocol Enforcement**: Release builds only accept secure WebSocket connections (wss://); non-release builds and the Mortsom test environment accept plain `ws://` only towards local hosts
+- **IP Address Rejection**: Direct IP connections rejected in release builds (local hosts allowed only when `Config.allowInsecureRelays` is true)
 - **Domain Validation**: RFC-compliant domain name validation
 - **Input Sanitization**: Proper trimming and normalization of user input
 
@@ -1269,7 +1260,7 @@ Storage Persistence → UI Feedback
 - **Subscription Isolation**: Each Mostro instance gets isolated subscriptions
 
 ### Network Security
-- **Secure Connections Only**: Rejects insecure ws:// and http:// protocols
+- **Secure Connections Only**: Rejects http:// always and insecure ws:// except towards local hosts in non-release builds
 - **Connectivity Validation**: Mandatory connectivity testing before relay addition
 - **Test Instance Isolation**: Connectivity tests use separate Nostr instances
 

--- a/docs/automation-contract.md
+++ b/docs/automation-contract.md
@@ -115,7 +115,8 @@ When enabled:
   accepted by the add-relay validation (`ws://` is never accepted towards a
   public host). Non-release builds (debug and profile, see
   `Config.allowInsecureRelays`) accept them too, independently of the test
-  environment; release builds never do;
+  environment; a release build accepts them only inside the test environment
+  (armed entry point plus the define), never on its own;
 - a red `TEST ENVIRONMENT · Mortsom` banner (`env.marker`) is shown on every
   screen.
 

--- a/docs/automation-contract.md
+++ b/docs/automation-contract.md
@@ -111,8 +111,9 @@ When enabled:
   list instead, so a disconnected local relay produces a test failure, not
   public-network traffic. A build that arms the test environment without
   `MORTSOM_RELAYS` fails at startup rather than starting with no relay;
-- plain `ws://` relays on private addresses are accepted by the add-relay
-  validation;
+- plain `ws://` relays on local hosts (`localhost`, IPv4, optional port) are
+  accepted by the add-relay validation. Debug builds (`kDebugMode`) accept
+  them too, independently of the test environment; release builds never do;
 - a red `TEST ENVIRONMENT · Mortsom` banner (`env.marker`) is shown on every
   screen.
 

--- a/docs/automation-contract.md
+++ b/docs/automation-contract.md
@@ -111,9 +111,10 @@ When enabled:
   list instead, so a disconnected local relay produces a test failure, not
   public-network traffic. A build that arms the test environment without
   `MORTSOM_RELAYS` fails at startup rather than starting with no relay;
-- plain `ws://` relays on local hosts (`localhost`, IPv4, optional port) are
-  accepted by the add-relay validation (`ws://` is never accepted towards a
-  public host). Non-release builds (debug and profile, see
+- plain `ws://` relays on local hosts (`localhost` or a private IPv4 address:
+  loopback, 10/8, 172.16/12, 192.168/16, optional port) are accepted by the
+  add-relay validation (`ws://` is never accepted towards a public host, and a
+  public IPv4 address is never a local host). Non-release builds (debug and profile, see
   `Config.allowInsecureRelays`) accept them too, independently of the test
   environment; a release build accepts them only inside the test environment
   (armed entry point plus the define), never on its own;

--- a/docs/automation-contract.md
+++ b/docs/automation-contract.md
@@ -112,8 +112,10 @@ When enabled:
   public-network traffic. A build that arms the test environment without
   `MORTSOM_RELAYS` fails at startup rather than starting with no relay;
 - plain `ws://` relays on local hosts (`localhost`, IPv4, optional port) are
-  accepted by the add-relay validation. Debug builds (`kDebugMode`) accept
-  them too, independently of the test environment; release builds never do;
+  accepted by the add-relay validation (`ws://` is never accepted towards a
+  public host). Non-release builds (debug and profile, see
+  `Config.allowInsecureRelays`) accept them too, independently of the test
+  environment; release builds never do;
 - a red `TEST ENVIRONMENT · Mortsom` banner (`env.marker`) is shown on every
   screen.
 

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -62,6 +62,12 @@ class Config {
   // Debug mode
   static bool get isDebug => !kReleaseMode;
 
+  /// Whether the add-relay validation accepts plain `ws://` towards local
+  /// hosts (`localhost`, IPv4). True in the Mortsom test environment and in
+  /// any non-release build (debug and profile); never in release builds.
+  static bool get allowInsecureRelays =>
+      TestEnvironment.allowInsecureRelays || isDebug;
+
   // Key derivation configuration
   static const String keyDerivationPath = "m/44'/1237'/38383'/0";
 

--- a/lib/core/test_environment.dart
+++ b/lib/core/test_environment.dart
@@ -68,9 +68,10 @@ class TestEnvironment {
   static bool get disableBootstrapFallback => enabled;
 
   /// Local test relays are plain `ws://` on a private address (for example
-  /// `ws://localhost:7000`). That is acceptable inside the test environment
-  /// and in debug builds, never in release builds.
-  static bool get allowInsecureRelays => enabled || kDebugMode;
+  /// `ws://localhost:7000`), so the test environment accepts them. The
+  /// general build policy (non-release builds accept them too) lives in
+  /// `Config.allowInsecureRelays`, not here.
+  static bool get allowInsecureRelays => enabled;
 
   /// Copy of the visible environment marker.
   static const String markerLabel = 'TEST ENVIRONMENT · Mortsom';

--- a/lib/core/test_environment.dart
+++ b/lib/core/test_environment.dart
@@ -67,9 +67,10 @@ class TestEnvironment {
   /// bootstrap relays: a disconnected local relay must fail the test.
   static bool get disableBootstrapFallback => enabled;
 
-  /// Local test relays are plain `ws://` on a private address; that is
-  /// only acceptable inside the test environment.
-  static bool get allowInsecureRelays => enabled;
+  /// Local test relays are plain `ws://` on a private address (for example
+  /// `ws://localhost:7000`). That is acceptable inside the test environment
+  /// and in debug builds, never in release builds.
+  static bool get allowInsecureRelays => enabled || kDebugMode;
 
   /// Copy of the visible environment marker.
   static const String markerLabel = 'TEST ENVIRONMENT · Mortsom';

--- a/lib/features/relays/relay_url_validator.dart
+++ b/lib/features/relays/relay_url_validator.dart
@@ -1,7 +1,8 @@
 /// Why a user-entered relay URL was rejected by [RelayUrlValidator].
 enum RelayUrlRejection {
   /// Plain `ws://` is not allowed in this build, or it targets a non-local
-  /// host (plain text is only ever accepted towards `localhost`/IPv4).
+  /// host (plain text is only ever accepted towards `localhost` or a private
+  /// IPv4 address).
   insecureScheme,
 
   /// `http://` / `https://` are never relay URLs.
@@ -31,9 +32,10 @@ class RelayUrlValidation {
 /// Policy:
 /// - `wss://` (or a bare host, which gets `wss://` prepended) to a public
 ///   domain name is always accepted. An optional `:port` is allowed.
-/// - With [allowInsecure], local hosts (`localhost` or a dotted IPv4, optional
-///   `:port`) are accepted too, and plain `ws://` is accepted **only** towards
-///   those local hosts. Plain text to a public relay is never accepted.
+/// - With [allowInsecure], local hosts (`localhost` or a private IPv4 address
+///   as defined in [_isPrivateIPv4], optional `:port`) are accepted too, and
+///   plain `ws://` is accepted **only** towards those local hosts. Neither a
+///   public IPv4 address nor plain text to a public relay is ever accepted.
 /// - `http(s)://` is always rejected.
 ///
 /// Callers decide when [allowInsecure] is acceptable: see
@@ -54,8 +56,9 @@ class RelayUrlValidator {
       r'^(?<host>[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*)'
       r'(?::(?<port>\d{1,5}))?$');
 
-  /// `localhost` or a dotted IPv4 address with an optional `:port`. Octet and
-  /// port ranges are checked in [_isValidLocalHost].
+  /// `localhost` or a dotted IPv4 address with an optional `:port`. Octet
+  /// ranges, the private-address requirement and the port range are checked
+  /// in [_isValidLocalHost].
   static final RegExp _localHostRegex = RegExp(
       r'^(?<host>localhost|\d{1,3}(\.\d{1,3}){3})(?::(?<port>\d{1,5}))?$');
 
@@ -131,20 +134,31 @@ class RelayUrlValidator {
         _isValidPort(match.namedGroup('port'));
   }
 
-  /// `localhost` or IPv4 with octets in 0-255 and, if given, a port in
-  /// 1-65535.
+  /// `localhost` or a private IPv4 address with octets in 0-255 and, if
+  /// given, a port in 1-65535. A public IPv4 address is not a local host: it
+  /// must not be reachable over plain text just because the build allows
+  /// insecure relays.
   static bool _isValidLocalHost(String host) {
     final match = _localHostRegex.firstMatch(host);
     if (match == null) return false;
 
     final name = match.namedGroup('host')!;
     if (name != 'localhost') {
-      final octetsInRange =
-          name.split('.').every((octet) => int.parse(octet) <= _maxOctet);
-      if (!octetsInRange) return false;
+      final octets = name.split('.').map(int.parse).toList();
+      if (octets.any((octet) => octet > _maxOctet)) return false;
+      if (!_isPrivateIPv4(octets)) return false;
     }
     return _isValidPort(match.namedGroup('port'));
   }
+
+  /// Loopback and the RFC 1918 private ranges: 127.0.0.0/8, 10.0.0.0/8,
+  /// 172.16.0.0/12 and 192.168.0.0/16. Covers `10.0.2.2` (the Android
+  /// emulator's host) and a LAN address when testing on a physical device.
+  static bool _isPrivateIPv4(List<int> octets) =>
+      octets[0] == 127 ||
+      octets[0] == 10 ||
+      (octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31) ||
+      (octets[0] == 192 && octets[1] == 168);
 
   static bool _isValidPort(String? port) {
     if (port == null) return true;

--- a/lib/features/relays/relay_url_validator.dart
+++ b/lib/features/relays/relay_url_validator.dart
@@ -13,8 +13,13 @@ class RelayUrlValidator {
       r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$');
 
   /// `localhost` or a dotted IPv4 address, with an optional `:port`.
+  /// Octet and port ranges are checked separately in [_isValidLocalHost].
   static final RegExp _localHostRegex =
-      RegExp(r'^(localhost|\d{1,3}(\.\d{1,3}){3})(:\d{1,5})?$');
+      RegExp(r'^(localhost|\d{1,3}(\.\d{1,3}){3})(:(\d{1,5}))?$');
+
+  static const int _maxOctet = 255;
+  static const int _maxPort = 65535;
+  static final RegExp _trailingSlashes = RegExp(r'/+$');
 
   /// Normalizes [input] into a relay URL, or returns null when rejected.
   ///
@@ -24,7 +29,8 @@ class RelayUrlValidator {
   /// - A bare host gets a `wss://` prefix; it is never silently downgraded
   ///   to `ws://`, the user has to ask for that explicitly.
   String? normalize(String input) {
-    final value = input.trim().toLowerCase();
+    final value =
+        input.trim().toLowerCase().replaceFirst(_trailingSlashes, '');
 
     if (!isValidHost(value)) return null;
 
@@ -38,12 +44,32 @@ class RelayUrlValidator {
   bool isValidHost(String input) {
     final host = _stripProtocol(input);
 
-    if (allowInsecure && _localHostRegex.hasMatch(host)) return true;
+    if (allowInsecure && _isValidLocalHost(host)) return true;
 
     // Reject IP addresses (numbers and dots only).
     if (RegExp(r'^[\d.]+$').hasMatch(host)) return false;
 
     return _domainRegex.hasMatch(host) && host.contains('.');
+  }
+
+  /// `localhost` or IPv4 with octets in 0-255 and, if given, a port in
+  /// 1-65535.
+  static bool _isValidLocalHost(String host) {
+    final match = _localHostRegex.firstMatch(host);
+    if (match == null) return false;
+
+    final name = match.group(1)!;
+    if (name != 'localhost') {
+      final octetsInRange = name
+          .split('.')
+          .every((octet) => int.parse(octet) <= _maxOctet);
+      if (!octetsInRange) return false;
+    }
+
+    final port = match.group(4);
+    if (port == null) return true;
+    final portNumber = int.parse(port);
+    return portNumber >= 1 && portNumber <= _maxPort;
   }
 
   static String _stripProtocol(String input) {

--- a/lib/features/relays/relay_url_validator.dart
+++ b/lib/features/relays/relay_url_validator.dart
@@ -1,55 +1,134 @@
+/// Why a user-entered relay URL was rejected by [RelayUrlValidator].
+enum RelayUrlRejection {
+  /// Plain `ws://` is not allowed in this build, or it targets a non-local
+  /// host (plain text is only ever accepted towards `localhost`/IPv4).
+  insecureScheme,
+
+  /// `http://` / `https://` are never relay URLs.
+  httpScheme,
+
+  /// The host (or port) is malformed or not allowed in this build.
+  invalidHost,
+}
+
+/// Outcome of [RelayUrlValidator.validate]: exactly one of [url] or
+/// [rejection] is set.
+class RelayUrlValidation {
+  const RelayUrlValidation.accepted(String this.url) : rejection = null;
+  const RelayUrlValidation.rejected(RelayUrlRejection this.rejection)
+      : url = null;
+
+  final String? url;
+  final RelayUrlRejection? rejection;
+
+  bool get isAccepted => url != null;
+}
+
 /// Pure validation and normalization of user-entered relay URLs.
 ///
 /// Kept free of Riverpod/Nostr dependencies so it can be unit-tested directly.
-/// [allowInsecure] enables plain `ws://` relays and local hosts (`localhost`,
-/// IPv4 addresses, optional port). Callers decide when that is acceptable:
-/// see `TestEnvironment.allowInsecureRelays`.
+///
+/// Policy:
+/// - `wss://` (or a bare host, which gets `wss://` prepended) to a public
+///   domain name is always accepted. An optional `:port` is allowed.
+/// - With [allowInsecure], local hosts (`localhost` or a dotted IPv4, optional
+///   `:port`) are accepted too, and plain `ws://` is accepted **only** towards
+///   those local hosts. Plain text to a public relay is never accepted.
+/// - `http(s)://` is always rejected.
+///
+/// Callers decide when [allowInsecure] is acceptable: see
+/// `Config.allowInsecureRelays`.
 class RelayUrlValidator {
   const RelayUrlValidator({required this.allowInsecure});
 
   final bool allowInsecure;
 
-  static final RegExp _domainRegex = RegExp(
-      r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$');
-
-  /// `localhost` or a dotted IPv4 address, with an optional `:port`.
-  /// Octet and port ranges are checked separately in [_isValidLocalHost].
-  static final RegExp _localHostRegex =
-      RegExp(r'^(localhost|\d{1,3}(\.\d{1,3}){3})(:(\d{1,5}))?$');
-
   static const int _maxOctet = 255;
   static const int _maxPort = 65535;
+
   static final RegExp _trailingSlashes = RegExp(r'/+$');
 
-  /// Normalizes [input] into a relay URL, or returns null when rejected.
-  ///
-  /// - `wss://` is kept as-is.
-  /// - `ws://` is kept only when [allowInsecure] is true.
-  /// - `http(s)://` is always rejected.
-  /// - A bare host gets a `wss://` prefix; it is never silently downgraded
-  ///   to `ws://`, the user has to ask for that explicitly.
-  String? normalize(String input) {
-    final value =
-        input.trim().toLowerCase().replaceFirst(_trailingSlashes, '');
+  /// A domain name (at least one dot enforced separately) with an optional
+  /// `:port`. The port range is checked in [_isValidPort].
+  static final RegExp _domainRegex = RegExp(
+      r'^(?<host>[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*)'
+      r'(?::(?<port>\d{1,5}))?$');
 
-    if (!isValidHost(value)) return null;
+  /// `localhost` or a dotted IPv4 address with an optional `:port`. Octet and
+  /// port ranges are checked in [_isValidLocalHost].
+  static final RegExp _localHostRegex = RegExp(
+      r'^(?<host>localhost|\d{1,3}(\.\d{1,3}){3})(?::(?<port>\d{1,5}))?$');
 
-    if (value.startsWith('wss://')) return value;
-    if (value.startsWith('ws://')) return allowInsecure ? value : null;
-    if (value.startsWith('http')) return null;
-    return 'wss://$value';
+  /// Numbers and dots only: an IP-looking host that is not a valid local host.
+  static final RegExp _bareIpRegex = RegExp(r'^[\d.]+$');
+
+  /// Canonical comparison key for a relay URL, shared by every place that
+  /// dedupes or blacklists relays: trimmed, trailing slashes removed, scheme
+  /// and host lowercased (a path, if any, keeps its case).
+  static String canonicalKey(String url) {
+    final trimmed = url.trim().replaceFirst(_trailingSlashes, '');
+    final schemeEnd = trimmed.indexOf('://');
+    final hostStart = schemeEnd == -1 ? 0 : schemeEnd + 3;
+    final pathStart = trimmed.indexOf('/', hostStart);
+    if (pathStart == -1) return trimmed.toLowerCase();
+    return trimmed.substring(0, pathStart).toLowerCase() +
+        trimmed.substring(pathStart);
   }
 
-  /// Whether the host part of [input] (protocol prefix optional) is acceptable.
-  bool isValidHost(String input) {
-    final host = _stripProtocol(input);
+  /// Normalizes [input] into a relay URL, or returns null when rejected.
+  /// Use [validate] when the rejection reason matters.
+  String? normalize(String input) => validate(input).url;
 
+  /// Validates [input] and returns either the normalized URL or the reason
+  /// it was rejected.
+  RelayUrlValidation validate(String input) {
+    final value = canonicalKey(input);
+
+    final schemeEnd = value.indexOf('://');
+    final scheme = schemeEnd == -1 ? null : value.substring(0, schemeEnd);
+    final host = schemeEnd == -1 ? value : value.substring(schemeEnd + 3);
+
+    switch (scheme) {
+      case null:
+      case 'wss':
+        if (!_isValidHost(host)) {
+          return const RelayUrlValidation.rejected(
+              RelayUrlRejection.invalidHost);
+        }
+        return RelayUrlValidation.accepted('wss://$host');
+      case 'ws':
+        // Plain text only ever towards a local host, and only when allowed.
+        if (!allowInsecure) {
+          return const RelayUrlValidation.rejected(
+              RelayUrlRejection.insecureScheme);
+        }
+        if (_isValidLocalHost(host)) {
+          return RelayUrlValidation.accepted('ws://$host');
+        }
+        // Allowed build but not a valid local host: either a well-formed
+        // public host (plain text refused) or a malformed host/port, which
+        // must not be reported as a scheme problem.
+        return RelayUrlValidation.rejected(_isValidHost(host)
+            ? RelayUrlRejection.insecureScheme
+            : RelayUrlRejection.invalidHost);
+      case 'http':
+      case 'https':
+        return const RelayUrlValidation.rejected(RelayUrlRejection.httpScheme);
+      default:
+        return const RelayUrlValidation.rejected(RelayUrlRejection.invalidHost);
+    }
+  }
+
+  /// Whether [host] (no scheme, already lowercased, optional `:port`) is an
+  /// acceptable relay host in this build.
+  bool _isValidHost(String host) {
     if (allowInsecure && _isValidLocalHost(host)) return true;
+    if (_bareIpRegex.hasMatch(host.split(':').first)) return false;
 
-    // Reject IP addresses (numbers and dots only).
-    if (RegExp(r'^[\d.]+$').hasMatch(host)) return false;
-
-    return _domainRegex.hasMatch(host) && host.contains('.');
+    final match = _domainRegex.firstMatch(host);
+    if (match == null) return false;
+    return match.namedGroup('host')!.contains('.') &&
+        _isValidPort(match.namedGroup('port'));
   }
 
   /// `localhost` or IPv4 with octets in 0-255 and, if given, a port in
@@ -58,24 +137,18 @@ class RelayUrlValidator {
     final match = _localHostRegex.firstMatch(host);
     if (match == null) return false;
 
-    final name = match.group(1)!;
+    final name = match.namedGroup('host')!;
     if (name != 'localhost') {
-      final octetsInRange = name
-          .split('.')
-          .every((octet) => int.parse(octet) <= _maxOctet);
+      final octetsInRange =
+          name.split('.').every((octet) => int.parse(octet) <= _maxOctet);
       if (!octetsInRange) return false;
     }
+    return _isValidPort(match.namedGroup('port'));
+  }
 
-    final port = match.group(4);
+  static bool _isValidPort(String? port) {
     if (port == null) return true;
     final portNumber = int.parse(port);
     return portNumber >= 1 && portNumber <= _maxPort;
-  }
-
-  static String _stripProtocol(String input) {
-    for (final prefix in const ['wss://', 'ws://', 'https://', 'http://']) {
-      if (input.startsWith(prefix)) return input.substring(prefix.length);
-    }
-    return input;
   }
 }

--- a/lib/features/relays/relay_url_validator.dart
+++ b/lib/features/relays/relay_url_validator.dart
@@ -1,0 +1,55 @@
+/// Pure validation and normalization of user-entered relay URLs.
+///
+/// Kept free of Riverpod/Nostr dependencies so it can be unit-tested directly.
+/// [allowInsecure] enables plain `ws://` relays and local hosts (`localhost`,
+/// IPv4 addresses, optional port). Callers decide when that is acceptable:
+/// see `TestEnvironment.allowInsecureRelays`.
+class RelayUrlValidator {
+  const RelayUrlValidator({required this.allowInsecure});
+
+  final bool allowInsecure;
+
+  static final RegExp _domainRegex = RegExp(
+      r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$');
+
+  /// `localhost` or a dotted IPv4 address, with an optional `:port`.
+  static final RegExp _localHostRegex =
+      RegExp(r'^(localhost|\d{1,3}(\.\d{1,3}){3})(:\d{1,5})?$');
+
+  /// Normalizes [input] into a relay URL, or returns null when rejected.
+  ///
+  /// - `wss://` is kept as-is.
+  /// - `ws://` is kept only when [allowInsecure] is true.
+  /// - `http(s)://` is always rejected.
+  /// - A bare host gets a `wss://` prefix; it is never silently downgraded
+  ///   to `ws://`, the user has to ask for that explicitly.
+  String? normalize(String input) {
+    final value = input.trim().toLowerCase();
+
+    if (!isValidHost(value)) return null;
+
+    if (value.startsWith('wss://')) return value;
+    if (value.startsWith('ws://')) return allowInsecure ? value : null;
+    if (value.startsWith('http')) return null;
+    return 'wss://$value';
+  }
+
+  /// Whether the host part of [input] (protocol prefix optional) is acceptable.
+  bool isValidHost(String input) {
+    final host = _stripProtocol(input);
+
+    if (allowInsecure && _localHostRegex.hasMatch(host)) return true;
+
+    // Reject IP addresses (numbers and dots only).
+    if (RegExp(r'^[\d.]+$').hasMatch(host)) return false;
+
+    return _domainRegex.hasMatch(host) && host.contains('.');
+  }
+
+  static String _stripProtocol(String input) {
+    for (final prefix in const ['wss://', 'ws://', 'https://', 'http://']) {
+      if (input.startsWith(prefix)) return input.substring(prefix.length);
+    }
+    return input;
+  }
+}

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -11,6 +11,7 @@ import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 import 'relay.dart';
+import 'relay_url_validator.dart';
 
 class RelayValidationResult {
   final bool success;
@@ -116,53 +117,17 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     await _saveRelays();
   }
 
-  /// Smart URL normalization - handles different input formats
-  String? normalizeRelayUrl(String input) {
-    input = input.trim().toLowerCase();
+  RelayUrlValidator get _urlValidator =>
+      RelayUrlValidator(allowInsecure: TestEnvironment.allowInsecureRelays);
 
-    if (!isValidDomainFormat(input)) return null;
+  /// Smart URL normalization - handles different input formats.
+  /// Plain `ws://` and local hosts are accepted only when
+  /// [TestEnvironment.allowInsecureRelays] is true (debug builds or the
+  /// Mortsom test environment).
+  String? normalizeRelayUrl(String input) => _urlValidator.normalize(input);
 
-    if (input.startsWith('wss://')) {
-      return input; // Already properly formatted
-    } else if (input.startsWith('ws://')) {
-      // Plain WebSocket relays are accepted only inside the Mortsom test
-      // environment, where the relay is a local process on a private address.
-      return TestEnvironment.allowInsecureRelays ? input : null;
-    } else if (input.startsWith('http')) {
-      return null; // Reject non-secure protocols
-    } else {
-      return 'wss://$input'; // Auto-add wss:// prefix
-    }
-  }
-
-  /// Domain validation using RegExp
-  bool isValidDomainFormat(String input) {
-    // Remove protocol prefix if present
-    if (input.startsWith('wss://')) {
-      input = input.substring(6);
-    } else if (input.startsWith('ws://')) {
-      input = input.substring(5);
-    } else if (input.startsWith('http://')) {
-      input = input.substring(7);
-    } else if (input.startsWith('https://')) {
-      input = input.substring(8);
-    }
-
-    // Reject IP addresses (basic check for numbers and dots only), except
-    // the emulator's host address family inside the test environment.
-    if (TestEnvironment.allowInsecureRelays &&
-        RegExp(r'^[\d.]+(:\d+)?$').hasMatch(input)) {
-      return true;
-    }
-    if (RegExp(r'^[\d.]+$').hasMatch(input)) {
-      return false;
-    }
-
-    // Domain regex: valid domain format with at least one dot
-    final domainRegex = RegExp(
-        r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$');
-    return domainRegex.hasMatch(input) && input.contains('.');
-  }
+  /// Domain validation (protocol prefix optional).
+  bool isValidDomainFormat(String input) => _urlValidator.isValidHost(input);
 
   /// Test connectivity using proper Nostr protocol validation
   /// Sends REQ message and waits for EVENT + EOSE responses

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -84,12 +84,13 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   }
 
   Future<void> _saveRelays() async {
-    // Get blacklisted relays
+    // Get blacklisted relays (membership is checked through the canonical
+    // key: stored relay URLs may predate normalization)
     final blacklistedUrls = settings.state.blacklistedRelays;
     
     // Include ALL active relays (Mostro/default + user) that are NOT blacklisted
     final allActiveRelayUrls = state
-        .where((r) => !blacklistedUrls.contains(r.url))
+        .where((r) => !_isBlacklisted(r.url))
         .map((r) => r.url)
         .toList();
     
@@ -700,8 +701,14 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   }
 
   /// Check if a relay URL is currently blacklisted
-  bool isRelayBlacklisted(String url) {
-    return settings.state.blacklistedRelays.contains(url);
+  bool isRelayBlacklisted(String url) => _isBlacklisted(url);
+
+  /// Blacklist membership through the canonical key, so legacy entries and
+  /// relay URLs that differ only in case or trailing slashes still match.
+  bool _isBlacklisted(String url) {
+    final key = _normalizeRelayUrl(url);
+    return settings.state.blacklistedRelays
+        .any((b) => _normalizeRelayUrl(b) == key);
   }
 
   /// Get all blacklisted relay URLs
@@ -712,7 +719,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   /// Order: [Default relays...] [Mostro relays...] [User relays...]
   List<MostroRelayInfo> get mostroRelaysWithStatus {
     final blacklistedUrls = settings.state.blacklistedRelays;
-    final activeRelays = state.map((r) => r.url).toSet();
+    final activeRelays = state.map((r) => _normalizeRelayUrl(r.url)).toSet();
     final allRelayInfos = <MostroRelayInfo>[];
     
     // 1. Get active Mostro and default relays
@@ -721,7 +728,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
         .map((r) => MostroRelayInfo(
               url: r.url,
               // Check if this relay is blacklisted (even if it's still in state)
-              isActive: !blacklistedUrls.contains(r.url),
+              isActive: !_isBlacklisted(r.url),
               isHealthy: r.isHealthy,
               source: r.source,
             ))
@@ -729,7 +736,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     
     // 2. Add blacklisted Mostro/default relays that are NOT in the active state
     final mostroBlacklistedRelays = blacklistedUrls
-        .where((url) => !activeRelays.contains(url))
+        .where((url) => !activeRelays.contains(_normalizeRelayUrl(url)))
         .map((url) => MostroRelayInfo(
               url: url,
               isActive: false,
@@ -748,7 +755,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
         .where((r) => r.source == RelaySource.user)
         .map((r) => MostroRelayInfo(
               url: r.url,
-              isActive: !blacklistedUrls.contains(r.url), // User relays can also be blacklisted
+              isActive: !_isBlacklisted(r.url), // User relays can also be blacklisted
               isHealthy: r.isHealthy,
               source: r.source,
             ))
@@ -763,12 +770,19 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
 
   /// Check if blacklisting this relay would leave the app without any active relays
   bool wouldLeaveNoActiveRelays(String urlToBlacklist) {
-    final currentActiveRelays = state.map((r) => r.url).toList();
-    final currentBlacklist = settings.state.blacklistedRelays;
-    
+    final currentActiveRelays =
+        state.map((r) => _normalizeRelayUrl(r.url)).toList();
+    final currentBlacklist =
+        settings.state.blacklistedRelays.map(_normalizeRelayUrl);
+
     // Simulate what would happen if we blacklist this URL
-    final wouldBeBlacklisted = [...currentBlacklist, urlToBlacklist];
-    final wouldRemainActive = currentActiveRelays.where((url) => !wouldBeBlacklisted.contains(url)).toList();
+    final wouldBeBlacklisted = {
+      ...currentBlacklist,
+      _normalizeRelayUrl(urlToBlacklist),
+    };
+    final wouldRemainActive = currentActiveRelays
+        .where((url) => !wouldBeBlacklisted.contains(url))
+        .toList();
     
     logger.d('Current active: ${currentActiveRelays.length}, Would remain: ${wouldRemainActive.length}');
     return wouldRemainActive.isEmpty;
@@ -778,7 +792,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   /// If active -> blacklist it and remove from active relays  
   /// If blacklisted -> remove from blacklist and trigger re-sync to add back
   Future<void> toggleMostroRelayBlacklist(String url) async {
-    final isCurrentlyBlacklisted = settings.state.blacklistedRelays.contains(url);
+    final isCurrentlyBlacklisted = _isBlacklisted(url);
     
     if (isCurrentlyBlacklisted) {
       // Remove from blacklist and trigger sync to add back

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -4,7 +4,6 @@ import 'package:dart_nostr/dart_nostr.dart';
 import 'package:dart_nostr/nostr/model/ease.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/config.dart';
-import 'package:mostro_mobile/core/test_environment.dart';
 import 'package:mostro_mobile/core/models/relay_list_event.dart';
 import 'package:mostro_mobile/features/settings/settings_notifier.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
@@ -41,7 +40,14 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   // Timestamp validation to ignore older events
   DateTime? _lastProcessedEventTime;
 
-  RelaysNotifier(this.settings, this.ref) : super([]) {
+  /// Validates user-entered relay URLs. Injectable so the policy wiring
+  /// (release builds never accept plain `ws://`) can be unit-tested.
+  final RelayUrlValidator _urlValidator;
+
+  RelaysNotifier(this.settings, this.ref, {RelayUrlValidator? urlValidator})
+      : _urlValidator = urlValidator ??
+            RelayUrlValidator(allowInsecure: Config.allowInsecureRelays),
+        super([]) {
     _loadRelays();
     _initMostroRelaySync();
     _initSettingsListener();
@@ -117,17 +123,11 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     await _saveRelays();
   }
 
-  RelayUrlValidator get _urlValidator =>
-      RelayUrlValidator(allowInsecure: TestEnvironment.allowInsecureRelays);
-
   /// Smart URL normalization - handles different input formats.
   /// Plain `ws://` and local hosts are accepted only when
-  /// [TestEnvironment.allowInsecureRelays] is true (debug builds or the
-  /// Mortsom test environment).
+  /// [Config.allowInsecureRelays] is true (non-release builds or the Mortsom
+  /// test environment), see [RelayUrlValidator].
   String? normalizeRelayUrl(String input) => _urlValidator.normalize(input);
-
-  /// Domain validation (protocol prefix optional).
-  bool isValidDomainFormat(String input) => _urlValidator.isValidHost(input);
 
   /// Test connectivity using proper Nostr protocol validation
   /// Sends REQ message and waits for EVENT + EOSE responses
@@ -310,28 +310,19 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     required String errorNotValid,
   }) async {
     // Step 1: Normalize URL
-    final normalizedUrl = normalizeRelayUrl(input);
+    final validation = _urlValidator.validate(input);
+    final normalizedUrl = validation.url;
     if (normalizedUrl == null) {
-      if (input.trim().toLowerCase().startsWith('ws://')) {
-        return RelayValidationResult(
-          success: false,
-          error: errorOnlySecure,
-        );
-      } else if (input.trim().toLowerCase().startsWith('http')) {
-        return RelayValidationResult(
-          success: false,
-          error: errorNoHttp,
-        );
-      } else {
-        return RelayValidationResult(
-          success: false,
-          error: errorInvalidDomain,
-        );
-      }
+      final error = switch (validation.rejection!) {
+        RelayUrlRejection.insecureScheme => errorOnlySecure,
+        RelayUrlRejection.httpScheme => errorNoHttp,
+        RelayUrlRejection.invalidHost => errorInvalidDomain,
+      };
+      return RelayValidationResult(success: false, error: error);
     }
 
-    // Step 2: Check for duplicates
-    if (state.any((relay) => relay.url == normalizedUrl)) {
+    // Step 2: Check for duplicates (stored URLs may predate normalization)
+    if (state.any((relay) => _normalizeRelayUrl(relay.url) == normalizedUrl)) {
       return RelayValidationResult(
         success: false,
         error: errorAlreadyExists,
@@ -349,10 +340,15 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
       );
     }
 
-    // Step 5: Remove from blacklist if present (user wants to manually add it)
-    if (settings.state.blacklistedRelays.contains(normalizedUrl)) {
-      await settings.removeFromBlacklist(normalizedUrl);
-      logger.i('Removed $normalizedUrl from blacklist - user manually added it');
+    // Step 5: Remove from blacklist if present (user wants to manually add it).
+    // Compare through the canonical key: stored entries may predate
+    // normalization.
+    final blacklisted = settings.state.blacklistedRelays
+        .where((url) => _normalizeRelayUrl(url) == normalizedUrl)
+        .toList();
+    for (final url in blacklisted) {
+      await settings.removeFromBlacklist(url);
+      logger.i('Removed $url from blacklist - user manually added it');
     }
 
     // Step 6: Add relay as user relay
@@ -833,12 +829,9 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
     }
   }
 
-  /// Normalize relay URL to prevent duplicates (removes trailing slash)
-  String _normalizeRelayUrl(String url) {
-    // Remove every trailing slash so `wss://relay//` and `wss://relay/`
-    // normalize to the same key as `wss://relay`.
-    return url.trim().replaceAll(RegExp(r'/+$'), '');
-  }
+  /// Canonical key used for every dedupe/blacklist comparison, shared with
+  /// the add-relay validation so both sides normalize the same way.
+  String _normalizeRelayUrl(String url) => RelayUrlValidator.canonicalKey(url);
 
   @override
   void dispose() {

--- a/test/core/automation/automation_contract_test.dart
+++ b/test/core/automation/automation_contract_test.dart
@@ -2,13 +2,14 @@
 // must stay present, unique and namespaced. Removing or renaming one is a
 // contract change (see docs/automation-contract.md) and must fail here.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/core/automation/automation_id.dart';
 import 'package:mostro_mobile/core/automation/automation_ids.dart';
+import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/core/test_environment.dart';
 import 'package:mostro_mobile/features/community/community.dart';
 import 'package:mostro_mobile/features/community/widgets/community_card.dart';
@@ -167,14 +168,24 @@ void main() {
       expect(TestEnvironment.enabled, TestEnvironment.defineEnabled);
       expect(TestEnvironment.disableBootstrapFallback,
           TestEnvironment.defineEnabled);
-      expect(TestEnvironment.allowInsecureRelays,
-          TestEnvironment.defineEnabled || kDebugMode);
+      expect(
+          TestEnvironment.allowInsecureRelays, TestEnvironment.defineEnabled);
     });
 
-    test('allows insecure relays in debug builds without arming', () {
-      // `flutter test` runs in debug mode, so this must hold here.
+    test('does not allow insecure relays on its own when not armed', () {
+      // The debug-build allowance lives in Config.allowInsecureRelays; the
+      // test-environment flag itself must stay tied to `enabled`.
       expect(TestEnvironment.enabled, isFalse);
-      expect(TestEnvironment.allowInsecureRelays, kDebugMode);
+      expect(TestEnvironment.allowInsecureRelays, isFalse);
+    });
+
+    test('Config.allowInsecureRelays follows the build mode when not armed',
+        () {
+      // `flutter test` is a non-release build, so the allowance comes from
+      // the build mode alone, never from the test environment.
+      expect(TestEnvironment.enabled, isFalse);
+      expect(Config.allowInsecureRelays, !kReleaseMode);
+      expect(Config.allowInsecureRelays, isTrue);
     });
 
     test('parses relay lists', () {

--- a/test/core/automation/automation_contract_test.dart
+++ b/test/core/automation/automation_contract_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/core/automation/automation_id.dart';
 import 'package:mostro_mobile/core/automation/automation_ids.dart';
@@ -166,8 +167,14 @@ void main() {
       expect(TestEnvironment.enabled, TestEnvironment.defineEnabled);
       expect(TestEnvironment.disableBootstrapFallback,
           TestEnvironment.defineEnabled);
-      expect(
-          TestEnvironment.allowInsecureRelays, TestEnvironment.defineEnabled);
+      expect(TestEnvironment.allowInsecureRelays,
+          TestEnvironment.defineEnabled || kDebugMode);
+    });
+
+    test('allows insecure relays in debug builds without arming', () {
+      // `flutter test` runs in debug mode, so this must hold here.
+      expect(TestEnvironment.enabled, isFalse);
+      expect(TestEnvironment.allowInsecureRelays, kDebugMode);
     });
 
     test('parses relay lists', () {

--- a/test/features/relays/relay_url_validator_test.dart
+++ b/test/features/relays/relay_url_validator_test.dart
@@ -32,6 +32,13 @@ void main() {
       expect(secure.normalize('http://relay.example.com'), isNull);
     });
 
+    test('strips trailing slashes', () {
+      expect(secure.normalize('wss://relay.example.com/'),
+          'wss://relay.example.com');
+      expect(secure.normalize('relay.example.com//'),
+          'wss://relay.example.com');
+    });
+
     test('rejects domains without a dot', () {
       expect(secure.normalize('localhost'), isNull);
       expect(secure.normalize('relay'), isNull);
@@ -70,6 +77,18 @@ void main() {
     test('still rejects malformed hosts', () {
       expect(insecure.normalize('ws://local host'), isNull);
       expect(insecure.normalize('ws://localhost:abc'), isNull);
+    });
+
+    test('rejects IPv4 octets above 255', () {
+      expect(insecure.normalize('ws://999.999.999.999:7000'), isNull);
+      expect(insecure.normalize('ws://10.0.256.1'), isNull);
+    });
+
+    test('rejects ports above 65535 or zero', () {
+      expect(insecure.normalize('ws://localhost:99999'), isNull);
+      expect(insecure.normalize('ws://127.0.0.1:65536'), isNull);
+      expect(insecure.normalize('ws://localhost:0'), isNull);
+      expect(insecure.normalize('ws://localhost:65535'), 'ws://localhost:65535');
     });
 
     test('bare localhost gets wss:// prefix (no implicit downgrade)', () {

--- a/test/features/relays/relay_url_validator_test.dart
+++ b/test/features/relays/relay_url_validator_test.dart
@@ -120,6 +120,30 @@ void main() {
       expect(insecure.normalize('ws://10.0.256.1'), isNull);
     });
 
+    test('accepts ws:// on loopback and the RFC 1918 ranges', () {
+      expect(insecure.normalize('ws://127.0.0.1'), 'ws://127.0.0.1');
+      expect(insecure.normalize('ws://10.0.2.2:7000'), 'ws://10.0.2.2:7000');
+      expect(insecure.normalize('ws://172.16.0.1:7000'),
+          'ws://172.16.0.1:7000');
+      expect(insecure.normalize('ws://172.31.255.255'), 'ws://172.31.255.255');
+      expect(insecure.normalize('ws://192.168.1.50:7000'),
+          'ws://192.168.1.50:7000');
+    });
+
+    test('rejects public IPv4 addresses: they are not local hosts', () {
+      expect(insecure.normalize('ws://8.8.8.8'), isNull);
+      expect(insecure.normalize('ws://203.0.113.10:7000'), isNull);
+      // Not acceptable over TLS either: the domain-only policy still holds
+      // for anything that is not a local host.
+      expect(insecure.normalize('wss://8.8.8.8'), isNull);
+      expect(insecure.normalize('wss://203.0.113.10:7000'), isNull);
+    });
+
+    test('rejects the addresses just outside 172.16.0.0/12', () {
+      expect(insecure.normalize('ws://172.15.0.1'), isNull);
+      expect(insecure.normalize('ws://172.32.0.1'), isNull);
+    });
+
     test('rejects ports above 65535 or zero', () {
       expect(insecure.normalize('ws://localhost:99999'), isNull);
       expect(insecure.normalize('ws://127.0.0.1:65536'), isNull);
@@ -148,6 +172,13 @@ void main() {
     test('ws:// to a public host is insecureScheme even when allowed', () {
       expect(reasonOf(insecure, 'ws://relay.example.com'),
           RelayUrlRejection.insecureScheme);
+    });
+
+    test('ws:// to a public IPv4 is invalidHost, not insecureScheme', () {
+      // An IP address is never a valid relay host, so blaming the scheme
+      // would suggest that wss:// towards it would work.
+      expect(reasonOf(insecure, 'ws://8.8.8.8'),
+          RelayUrlRejection.invalidHost);
     });
 
     test('ws:// with a bad port/octet is invalidHost when allowed', () {

--- a/test/features/relays/relay_url_validator_test.dart
+++ b/test/features/relays/relay_url_validator_test.dart
@@ -14,12 +14,26 @@ void main() {
       expect(secure.normalize('relay.example.com'), 'wss://relay.example.com');
     });
 
+    test('accepts a port on a named host', () {
+      expect(secure.normalize('wss://relay.example.com:8080'),
+          'wss://relay.example.com:8080');
+      expect(secure.normalize('relay.example.com:8080'),
+          'wss://relay.example.com:8080');
+      expect(secure.normalize('wss://relay.example.com:0'), isNull);
+      expect(secure.normalize('wss://relay.example.com:65536'), isNull);
+    });
+
     test('rejects ws:// URLs', () {
       expect(secure.normalize('ws://relay.example.com'), isNull);
     });
 
     test('rejects ws://localhost with port', () {
       expect(secure.normalize('ws://localhost:7000'), isNull);
+    });
+
+    test('rejects local hosts even over wss://', () {
+      expect(secure.normalize('wss://localhost:7000'), isNull);
+      expect(secure.normalize('wss://10.0.2.2:7000'), isNull);
     });
 
     test('rejects IP addresses', () {
@@ -32,11 +46,20 @@ void main() {
       expect(secure.normalize('http://relay.example.com'), isNull);
     });
 
+    test('accepts bare domains that merely start with "http"', () {
+      expect(secure.normalize('httprelay.example.com'),
+          'wss://httprelay.example.com');
+    });
+
+    test('rejects unknown schemes', () {
+      expect(secure.normalize('ftp://relay.example.com'), isNull);
+    });
+
     test('strips trailing slashes', () {
       expect(secure.normalize('wss://relay.example.com/'),
           'wss://relay.example.com');
-      expect(secure.normalize('relay.example.com//'),
-          'wss://relay.example.com');
+      expect(
+          secure.normalize('relay.example.com//'), 'wss://relay.example.com');
     });
 
     test('rejects domains without a dot', () {
@@ -61,13 +84,26 @@ void main() {
       expect(insecure.normalize('ws://127.0.0.1'), 'ws://127.0.0.1');
     });
 
-    test('accepts ws:// on public domains', () {
-      expect(insecure.normalize('ws://relay.example.com'),
-          'ws://relay.example.com');
+    test('rejects ws:// on public domains (plain text only to local hosts)',
+        () {
+      expect(insecure.normalize('ws://relay.example.com'), isNull);
+      expect(insecure.normalize('ws://host.docker.internal:7000'), isNull);
+    });
+
+    test('accepts wss:// on local hosts', () {
+      expect(
+          insecure.normalize('wss://localhost:7000'), 'wss://localhost:7000');
+      expect(insecure.normalize('wss://10.0.2.2:7000'), 'wss://10.0.2.2:7000');
+    });
+
+    test('accepts a port on a named host', () {
+      expect(insecure.normalize('wss://mostro-relay.local:7000'),
+          'wss://mostro-relay.local:7000');
     });
 
     test('trims and lowercases input', () {
-      expect(insecure.normalize('  WS://LocalHost:7000 '), 'ws://localhost:7000');
+      expect(
+          insecure.normalize('  WS://LocalHost:7000 '), 'ws://localhost:7000');
     });
 
     test('still rejects http(s) URLs', () {
@@ -88,7 +124,8 @@ void main() {
       expect(insecure.normalize('ws://localhost:99999'), isNull);
       expect(insecure.normalize('ws://127.0.0.1:65536'), isNull);
       expect(insecure.normalize('ws://localhost:0'), isNull);
-      expect(insecure.normalize('ws://localhost:65535'), 'ws://localhost:65535');
+      expect(
+          insecure.normalize('ws://localhost:65535'), 'ws://localhost:65535');
     });
 
     test('bare localhost gets wss:// prefix (no implicit downgrade)', () {
@@ -96,12 +133,81 @@ void main() {
     });
   });
 
-  group('RelayUrlValidator.isValidHost', () {
-    test('strips protocol prefixes before validating', () {
-      const secure = RelayUrlValidator(allowInsecure: false);
-      expect(secure.isValidHost('wss://relay.example.com'), isTrue);
-      expect(secure.isValidHost('https://relay.example.com'), isTrue);
-      expect(secure.isValidHost('ws://relay.example.com'), isTrue);
+  group('RelayUrlValidator.validate rejection reasons', () {
+    const secure = RelayUrlValidator(allowInsecure: false);
+    const insecure = RelayUrlValidator(allowInsecure: true);
+
+    RelayUrlRejection? reasonOf(RelayUrlValidator v, String input) =>
+        v.validate(input).rejection;
+
+    test('ws:// in secure mode is insecureScheme', () {
+      expect(reasonOf(secure, 'ws://localhost:7000'),
+          RelayUrlRejection.insecureScheme);
+    });
+
+    test('ws:// to a public host is insecureScheme even when allowed', () {
+      expect(reasonOf(insecure, 'ws://relay.example.com'),
+          RelayUrlRejection.insecureScheme);
+    });
+
+    test('ws:// with a bad port/octet is invalidHost when allowed', () {
+      // Plain text to localhost is allowed in this build, so blaming the
+      // scheme would be misleading: the port/octet is what is wrong.
+      expect(reasonOf(insecure, 'ws://localhost:99999'),
+          RelayUrlRejection.invalidHost);
+      expect(reasonOf(insecure, 'ws://localhost:0'),
+          RelayUrlRejection.invalidHost);
+      expect(
+          reasonOf(insecure, 'ws://10.0.256.1'), RelayUrlRejection.invalidHost);
+      expect(reasonOf(insecure, 'ws://1.2.3'), RelayUrlRejection.invalidHost);
+    });
+
+    test('ws:// with a bad port/octet is still insecureScheme when not allowed',
+        () {
+      expect(reasonOf(secure, 'ws://localhost:99999'),
+          RelayUrlRejection.insecureScheme);
+    });
+
+    test('http(s) is httpScheme', () {
+      expect(reasonOf(secure, 'https://relay.example.com'),
+          RelayUrlRejection.httpScheme);
+      expect(reasonOf(insecure, 'http://localhost:7000'),
+          RelayUrlRejection.httpScheme);
+    });
+
+    test('bad hosts are invalidHost', () {
+      expect(reasonOf(secure, 'relay'), RelayUrlRejection.invalidHost);
+      expect(
+          reasonOf(secure, 'wss://127.0.0.1'), RelayUrlRejection.invalidHost);
+      expect(reasonOf(secure, 'wss://relay.example.com:70000'),
+          RelayUrlRejection.invalidHost);
+    });
+
+    test('accepted results carry the URL and no rejection', () {
+      final result = secure.validate('Relay.Example.com/');
+      expect(result.isAccepted, isTrue);
+      expect(result.url, 'wss://relay.example.com');
+      expect(result.rejection, isNull);
+    });
+  });
+
+  group('RelayUrlValidator.canonicalKey', () {
+    test('trims, strips trailing slashes and lowercases scheme and host', () {
+      expect(RelayUrlValidator.canonicalKey('  WSS://Relay.Example.com// '),
+          'wss://relay.example.com');
+      expect(RelayUrlValidator.canonicalKey('Relay.Example.com/'),
+          'relay.example.com');
+    });
+
+    test('keeps the case of a path', () {
+      expect(RelayUrlValidator.canonicalKey('WSS://Relay.Example.com/Nostr/'),
+          'wss://relay.example.com/Nostr');
+    });
+
+    test('matches what normalize produces', () {
+      const v = RelayUrlValidator(allowInsecure: false);
+      const input = 'WSS://Relay.Example.com/';
+      expect(RelayUrlValidator.canonicalKey(input), v.normalize(input));
     });
   });
 }

--- a/test/features/relays/relay_url_validator_test.dart
+++ b/test/features/relays/relay_url_validator_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/relays/relay_url_validator.dart';
+
+void main() {
+  group('RelayUrlValidator.normalize (secure mode)', () {
+    const secure = RelayUrlValidator(allowInsecure: false);
+
+    test('keeps wss:// URLs as-is', () {
+      expect(secure.normalize('wss://relay.example.com'),
+          'wss://relay.example.com');
+    });
+
+    test('auto-adds wss:// prefix to bare domains', () {
+      expect(secure.normalize('relay.example.com'), 'wss://relay.example.com');
+    });
+
+    test('rejects ws:// URLs', () {
+      expect(secure.normalize('ws://relay.example.com'), isNull);
+    });
+
+    test('rejects ws://localhost with port', () {
+      expect(secure.normalize('ws://localhost:7000'), isNull);
+    });
+
+    test('rejects IP addresses', () {
+      expect(secure.normalize('wss://127.0.0.1'), isNull);
+      expect(secure.normalize('127.0.0.1:7000'), isNull);
+    });
+
+    test('rejects http(s) URLs', () {
+      expect(secure.normalize('https://relay.example.com'), isNull);
+      expect(secure.normalize('http://relay.example.com'), isNull);
+    });
+
+    test('rejects domains without a dot', () {
+      expect(secure.normalize('localhost'), isNull);
+      expect(secure.normalize('relay'), isNull);
+    });
+  });
+
+  group('RelayUrlValidator.normalize (insecure allowed)', () {
+    const insecure = RelayUrlValidator(allowInsecure: true);
+
+    test('accepts ws://localhost with port', () {
+      expect(insecure.normalize('ws://localhost:7000'), 'ws://localhost:7000');
+    });
+
+    test('accepts ws://localhost without port', () {
+      expect(insecure.normalize('ws://localhost'), 'ws://localhost');
+    });
+
+    test('accepts ws:// on IPv4 with port', () {
+      expect(insecure.normalize('ws://10.0.2.2:7000'), 'ws://10.0.2.2:7000');
+      expect(insecure.normalize('ws://127.0.0.1'), 'ws://127.0.0.1');
+    });
+
+    test('accepts ws:// on public domains', () {
+      expect(insecure.normalize('ws://relay.example.com'),
+          'ws://relay.example.com');
+    });
+
+    test('trims and lowercases input', () {
+      expect(insecure.normalize('  WS://LocalHost:7000 '), 'ws://localhost:7000');
+    });
+
+    test('still rejects http(s) URLs', () {
+      expect(insecure.normalize('http://localhost:7000'), isNull);
+    });
+
+    test('still rejects malformed hosts', () {
+      expect(insecure.normalize('ws://local host'), isNull);
+      expect(insecure.normalize('ws://localhost:abc'), isNull);
+    });
+
+    test('bare localhost gets wss:// prefix (no implicit downgrade)', () {
+      expect(insecure.normalize('localhost:7000'), 'wss://localhost:7000');
+    });
+  });
+
+  group('RelayUrlValidator.isValidHost', () {
+    test('strips protocol prefixes before validating', () {
+      const secure = RelayUrlValidator(allowInsecure: false);
+      expect(secure.isValidHost('wss://relay.example.com'), isTrue);
+      expect(secure.isValidHost('https://relay.example.com'), isTrue);
+      expect(secure.isValidHost('ws://relay.example.com'), isTrue);
+    });
+  });
+}

--- a/test/features/relays/relays_notifier_test.dart
+++ b/test/features/relays/relays_notifier_test.dart
@@ -99,4 +99,23 @@ void main() {
       });
     });
   });
+
+  group('RelaysNotifier blacklist matching', () {
+    testWidgets(
+        'does not persist relays whose legacy URL differs only in case or '
+        'trailing slash from a blacklist entry', (tester) async {
+      await withNotifier(tester, allowInsecure: false, body: (notifier) async {
+        await notifier.settings.addToBlacklist('wss://blocked.example.com');
+
+        // Legacy state entries stored before normalization existed.
+        await notifier.addRelay(Relay(url: 'wss://Blocked.Example.com/'));
+        await notifier.addRelay(Relay(url: 'wss://kept.example.com'));
+
+        expect(notifier.settings.state.relays, ['wss://kept.example.com']);
+        expect(
+            notifier.isRelayBlacklisted('wss://Blocked.Example.com//'), isTrue);
+        expect(notifier.isRelayBlacklisted('wss://kept.example.com'), isFalse);
+      });
+    });
+  });
 }

--- a/test/features/relays/relays_notifier_test.dart
+++ b/test/features/relays/relays_notifier_test.dart
@@ -1,9 +1,102 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/relays/relay.dart';
+import 'package:mostro_mobile/features/relays/relay_url_validator.dart';
+import 'package:mostro_mobile/features/relays/relays_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings_notifier.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+/// The notifier's relay sync needs providers that are not under test here;
+/// every access fails and is caught by the notifier, which keeps the URL
+/// validation path (the subject of these tests) fully usable.
+class _FakeRef extends Fake implements Ref {}
+
+/// Runs [body] against a notifier built with the given validator, then
+/// disposes it and lets its pending sync/retry timers elapse so the test
+/// binding's "timer still pending" invariant holds.
+Future<void> withNotifier(
+  WidgetTester tester, {
+  required bool allowInsecure,
+  required Future<void> Function(RelaysNotifier notifier) body,
+}) async {
+  final notifier = RelaysNotifier(
+    SettingsNotifier(SharedPreferencesAsync()),
+    _FakeRef(),
+    urlValidator: RelayUrlValidator(allowInsecure: allowInsecure),
+  );
+  try {
+    await body(notifier);
+  } finally {
+    notifier.dispose();
+    await tester.pump(const Duration(seconds: 30));
+  }
+}
 
 void main() {
-  group('RelaysNotifier', () {
-    // TODO: Re-enable these tests after implementing proper Ref mocking
-    // The RelaysNotifier now requires a Ref parameter for Mostro relay synchronization
-    // These tests need to be updated to provide proper mocks for the new sync functionality
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+  });
+
+  group('RelaysNotifier.normalizeRelayUrl wiring', () {
+    testWidgets('rejects ws:// when insecure relays are not allowed (release)',
+        (tester) async {
+      await withNotifier(tester, allowInsecure: false, body: (notifier) async {
+        expect(notifier.normalizeRelayUrl('ws://localhost:7000'), isNull);
+        expect(notifier.normalizeRelayUrl('wss://127.0.0.1:7000'), isNull);
+      });
+    });
+
+    testWidgets('accepts ws://localhost when insecure relays are allowed',
+        (tester) async {
+      await withNotifier(tester, allowInsecure: true, body: (notifier) async {
+        expect(notifier.normalizeRelayUrl('ws://localhost:7000'),
+            'ws://localhost:7000');
+        expect(notifier.normalizeRelayUrl('ws://relay.example.com'), isNull);
+      });
+    });
+  });
+
+  group('RelaysNotifier.addRelayWithSmartValidation', () {
+    const onlySecure = 'only-secure';
+    const noHttp = 'no-http';
+    const invalidDomain = 'invalid-domain';
+    const alreadyExists = 'already-exists';
+    const notValid = 'not-valid';
+
+    Future<RelayValidationResult> add(RelaysNotifier n, String input) =>
+        n.addRelayWithSmartValidation(
+          input,
+          errorOnlySecure: onlySecure,
+          errorNoHttp: noHttp,
+          errorInvalidDomain: invalidDomain,
+          errorAlreadyExists: alreadyExists,
+          errorNotValid: notValid,
+        );
+
+    testWidgets('maps each rejection reason to its own message',
+        (tester) async {
+      await withNotifier(tester, allowInsecure: true, body: (notifier) async {
+        expect(
+            (await add(notifier, 'ws://relay.example.com')).error, onlySecure);
+        expect((await add(notifier, 'http://localhost:7000')).error, noHttp);
+        expect((await add(notifier, 'wss://10.0.256.1')).error, invalidDomain);
+        expect((await add(notifier, 'relay')).error, invalidDomain);
+      });
+    });
+
+    testWidgets('detects duplicates through the canonical key', (tester) async {
+      await withNotifier(tester, allowInsecure: false, body: (notifier) async {
+        // Stored before trailing-slash/lowercase normalization existed.
+        notifier.state = [Relay(url: 'wss://Relay.Example.com/')];
+
+        final result = await add(notifier, 'wss://relay.example.com');
+
+        expect(result.success, isFalse);
+        expect(result.error, alreadyExists);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- `TestEnvironment.allowInsecureRelays` now holds in debug builds (`kDebugMode`) as well as in the Mortsom test environment; release builds keep rejecting `ws://`.
- Extracted URL normalization/validation from `RelaysNotifier` into a pure `RelayUrlValidator` so it can be unit tested directly. Public API of the notifier (`normalizeRelayUrl`, `isValidDomainFormat`) is unchanged.
- With insecure relays allowed, local hosts (`localhost`, IPv4, optional port) are accepted, e.g. `ws://localhost:7000`. Previously the domain check required a dot and no port, so this was rejected even inside the test environment.
- A bare host (`localhost:7000`) still gets a `wss://` prefix — it is never silently downgraded to `ws://`.
- Docs (`docs/automation-contract.md`) updated.

## Test plan
- [x] New `test/features/relays/relay_url_validator_test.dart` (19 cases, secure vs insecure mode)
- [x] `test/core/automation/automation_contract_test.dart` updated for the debug semantics
- [x] `flutter analyze` — no new issues (4 pre-existing: deprecated `containsSemantics`, missing `MockPushNotificationService` from stale mocks)
- [ ] CI full `flutter test` (locally `build_runner` fails to compile in my environment, so the mock-dependent suites could not be run here)
- [ ] Manual: `flutter run` (debug) → Settings → Relays → add `ws://localhost:7000` with a local relay running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer relay URL validation, normalization, and rejection messages.
  * Local `ws://` relay addresses are supported in test, debug, and profile builds when permitted.
  * Bare relay hosts default to secure `wss://` connections.
  * Duplicate detection and blacklist matching now recognize equivalent URL formats.

* **Bug Fixes**
  * Release builds restrict insecure relay connections appropriately.
  * Public `ws://` endpoints, invalid protocols, malformed hosts, and invalid ports are rejected consistently.
  * Private IPv4 ranges are handled correctly, including boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->