### PR TITLE
feat: dedicated payout invoice flow for settled orders

### DIFF
--- a/lib/data/models/enums/status.dart
+++ b/lib/data/models/enums/status.dart
@@ -43,6 +43,16 @@ enum Status {
         _ => false,
       };
 
+  /// Whether an add-invoice on this status asks for the payout of an already
+  /// settled order rather than the invoice a take requires.
+  ///
+  /// Both statuses mean the same thing: the hold invoice is settled and the
+  /// only thing left is paying the buyer. [paymentFailed] is where a payout
+  /// retry lands, [settledHoldInvoice] is the window between the release and
+  /// the payout, where the buyer may want to replace a wrong invoice.
+  bool get isPayoutInvoice =>
+      this == Status.paymentFailed || this == Status.settledHoldInvoice;
+
   @override
   String toString() {
     return value;

--- a/lib/features/notifications/utils/notification_data_extractor.dart
+++ b/lib/features/notifications/utils/notification_data_extractor.dart
@@ -44,7 +44,7 @@ class NotificationDataExtractor {
         
       case Action.addInvoice:
         final order = event.getPayload<Order>();
-        final isAfterPaymentFailure = order?.status == Status.settledHoldInvoice;
+        final isAfterPaymentFailure = order?.status.isPayoutInvoice ?? false;
         
         if (isAfterPaymentFailure) {
           final now = DateTime.now();

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -322,9 +322,10 @@ class OrderState {
         return Status.waitingBuyerInvoice;
       
       case Action.addInvoice:
-        // If current status is paymentFailed, maintain it for UI consistency
-        // Otherwise, transition to waitingBuyerInvoice for normal flow
-        if (status == Status.paymentFailed) {
+        // Mostro reuses this action to ask for a payout invoice after a failed
+        // payment, and only then does the payload carry settled-hold-invoice.
+        if (payloadStatus == Status.settledHoldInvoice ||
+            status == Status.paymentFailed) {
           return Status.paymentFailed;
         }
         return Status.waitingBuyerInvoice;

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -621,6 +621,12 @@ class OrderState {
         Action.paymentFailed: [
           Action.addInvoice,
         ],
+        // Mostro acked the new invoice (invoice-updated, no payload) and the
+        // payout is being retried. The swap is accepted between attempts, so
+        // keep the way in for a buyer whose second invoice is wrong too.
+        Action.invoiceUpdated: [
+          Action.addInvoice,
+        ],
       },
       Status.active: {
         Action.holdInvoicePaymentAccepted: [
@@ -721,6 +727,11 @@ class OrderState {
         // Released but not paid yet: let the buyer replace an invoice that is
         // not going to work instead of waiting for the payout to fail.
         Action.released: [
+          Action.addInvoice,
+        ],
+        // Same as the payment-failed row: the invoice-updated ack must not
+        // leave the buyer without a way back in.
+        Action.invoiceUpdated: [
           Action.addInvoice,
         ],
       },

--- a/lib/features/order/models/order_state.dart
+++ b/lib/features/order/models/order_state.dart
@@ -577,7 +577,6 @@ class OrderState {
       Status.settledHoldInvoice: {
         Action.addInvoice: [
           Action.addInvoice,
-          Action.cancel,
         ],
       },
     },
@@ -614,11 +613,14 @@ class OrderState {
         ],
       },
       Status.paymentFailed: {
+        // Only the invoice: the order is already settled, so Mostro rejects a
+        // cancel and there is nothing left to dispute.
         Action.addInvoice: [
-          // Only allow add invoice, no cancel or dispute during retrying
           Action.addInvoice,
         ],
-        Action.paymentFailed: [],
+        Action.paymentFailed: [
+          Action.addInvoice,
+        ],
       },
       Status.active: {
         Action.holdInvoicePaymentAccepted: [
@@ -715,7 +717,11 @@ class OrderState {
       Status.settledHoldInvoice: {
         Action.addInvoice: [
           Action.addInvoice,
-          Action.cancel,
+        ],
+        // Released but not paid yet: let the buyer replace an invoice that is
+        // not going to work instead of waiting for the payout to fail.
+        Action.released: [
+          Action.addInvoice,
         ],
       },
     },

--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -62,7 +62,9 @@ class _AddLightningInvoiceScreenState
         if (isPayoutInvoice(orderState.status)) {
           return PayoutInvoiceScreen(
             orderId: orderId,
-            order: orderPayload,
+            // The stream only matches messages whose payload is an Order; the
+            // notifier also keeps one carried by a PaymentRequest.
+            order: orderPayload ?? orderState.order,
           );
         }
         final amount = orderPayload?.amount;

--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -58,8 +58,9 @@ class _AddLightningInvoiceScreenState
         final orderPayload = mostroMessage?.getPayload<Order>();
         final orderState = ref.watch(orderNotifierProvider(orderId));
         // A settled order is not asking for the invoice a take requires, but
-        // for the payout one, which has its own screen.
-        if (isPayoutInvoice(orderState.status)) {
+        // for the payout one, which has its own screen. It deliberately ignores
+        // `lnAddress`: the address may be what broke the payout to begin with.
+        if (orderState.status.isPayoutInvoice) {
           return PayoutInvoiceScreen(
             orderId: orderId,
             // The stream only matches messages whose payload is an Order; the

--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/order/screens/payout_invoice_screen.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/features/wallet/providers/nwc_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
@@ -55,6 +56,15 @@ class _AddLightningInvoiceScreenState
     return mostroOrderAsync.when(
       data: (mostroMessage) {
         final orderPayload = mostroMessage?.getPayload<Order>();
+        final orderState = ref.watch(orderNotifierProvider(orderId));
+        // A settled order is not asking for the invoice a take requires, but
+        // for the payout one, which has its own screen.
+        if (isPayoutInvoice(orderState.status)) {
+          return PayoutInvoiceScreen(
+            orderId: orderId,
+            order: orderPayload,
+          );
+        }
         final amount = orderPayload?.amount;
         final fiatAmount = orderPayload?.fiatAmount.toString() ?? '0';
         final fiatCode = orderPayload?.fiatCode ?? '';
@@ -62,10 +72,8 @@ class _AddLightningInvoiceScreenState
         // Trade summary shown by every flow: trade type, who took the order,
         // amounts, order id and the counterpart reputation (when received).
         // Adding an invoice always means the user is the buyer, but not always
-        // the maker: taking a sell order and retrying after a failed payout
-        // land here too.
+        // the maker: taking a sell order lands here too.
         final session = ref.watch(sessionProvider(orderId));
-        final orderState = ref.watch(orderNotifierProvider(orderId));
         final header = InvoiceHeader(
           userIsSeller: session?.role == Role.seller,
           sats: amount ?? 0,

--- a/lib/features/order/screens/payout_invoice_screen.dart
+++ b/lib/features/order/screens/payout_invoice_screen.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mostro_mobile/core/app_theme.dart';
+import 'package:mostro_mobile/data/models/enums/status.dart';
+import 'package:mostro_mobile/data/models/order.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
+import 'package:mostro_mobile/features/wallet/providers/nwc_provider.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
+import 'package:mostro_mobile/shared/widgets/add_lightning_invoice_widget.dart';
+import 'package:mostro_mobile/shared/widgets/nwc_invoice_widget.dart';
+
+/// Whether this add-invoice asks for the payout of an already settled order
+/// rather than the invoice a take requires.
+///
+/// Both statuses mean the same thing: the hold invoice is settled and the only
+/// thing left is paying the buyer. `paymentFailed` is where a payout retry
+/// lands, `settledHoldInvoice` is the window between the release and the
+/// payout, where the buyer may want to replace a wrong invoice on their own.
+bool isPayoutInvoice(Status status) =>
+    status == Status.paymentFailed || status == Status.settledHoldInvoice;
+
+/// Invoice screen for collecting the sats of a settled order.
+///
+/// The trade itself is over, so this is not the add-invoice of a take: there is
+/// no counterpart to introduce, no Lightning address shortcut (it may be what
+/// broke the payout in the first place) and nothing left to cancel.
+class PayoutInvoiceScreen extends ConsumerStatefulWidget {
+  final String orderId;
+
+  /// Latest order snapshot, used for the amounts shown in the header.
+  final Order? order;
+
+  const PayoutInvoiceScreen({
+    super.key,
+    required this.orderId,
+    this.order,
+  });
+
+  @override
+  ConsumerState<PayoutInvoiceScreen> createState() =>
+      _PayoutInvoiceScreenState();
+}
+
+class _PayoutInvoiceScreenState extends ConsumerState<PayoutInvoiceScreen> {
+  final TextEditingController invoiceController = TextEditingController();
+
+  /// Set when the user falls back from the NWC wallet to typing an invoice.
+  bool _manualMode = false;
+
+  @override
+  void dispose() {
+    invoiceController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final order = widget.order;
+    final amount = order?.amount ?? 0;
+    final fiatAmount = order?.fiatAmount.toString() ?? '0';
+    final fiatCode = order?.fiatCode ?? '';
+    final orderIdValue = order?.id ?? widget.orderId;
+
+    final nwcState = ref.watch(nwcProvider);
+    final showNwcInvoice =
+        nwcState.status == NwcStatus.connected && !_manualMode && amount > 0;
+
+    final header = _PayoutHeader(
+      sats: amount,
+      fiatAmount: fiatAmount,
+      fiatCode: fiatCode,
+      orderId: orderIdValue,
+    );
+
+    return Scaffold(
+      backgroundColor: AppTheme.dark1,
+      appBar: OrderAppBar(title: S.of(context)!.collectYourSats),
+      body: Padding(
+        padding: EdgeInsets.fromLTRB(
+          16,
+          16,
+          16,
+          16 + MediaQuery.of(context).viewPadding.bottom,
+        ),
+        child: showNwcInvoice
+            ? Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  header,
+                  const SizedBox(height: 24),
+                  NwcInvoiceWidget(
+                    sats: amount,
+                    orderId: orderIdValue,
+                    onInvoiceConfirmed: (invoice) async {
+                      await _submitInvoice(invoice, amount);
+                    },
+                    onFallbackToManual: () {
+                      setState(() => _manualMode = true);
+                    },
+                  ),
+                ],
+              )
+            : AddLightningInvoiceWidget(
+                controller: invoiceController,
+                onSubmit: () async {
+                  final invoice = invoiceController.text.trim();
+                  if (invoice.isNotEmpty) {
+                    await _submitInvoice(invoice, amount);
+                  }
+                },
+                amount: amount,
+                fiatAmount: fiatAmount,
+                fiatCode: fiatCode,
+                orderId: orderIdValue,
+                header: header,
+              ),
+      ),
+    );
+  }
+
+  Future<void> _submitInvoice(String invoice, int? amount) async {
+    final orderNotifier =
+        ref.read(orderNotifierProvider(widget.orderId).notifier);
+    try {
+      await orderNotifier.sendInvoice(widget.orderId, invoice, amount);
+      if (mounted) context.go('/trade_detail/${widget.orderId}');
+    } catch (e) {
+      if (mounted) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          SnackBarHelper.showTopSnackBar(
+            context,
+            S.of(context)!.failedToUpdateInvoice(e.toString()),
+          );
+        });
+      }
+    }
+  }
+}
+
+/// Header of the payout screen: what will be paid and for which order. It says
+/// nothing about the counterpart or about a failed payment, because the screen
+/// is also reached while the payout is still on its way.
+class _PayoutHeader extends StatelessWidget {
+  final int sats;
+  final String fiatAmount;
+  final String fiatCode;
+  final String orderId;
+
+  const _PayoutHeader({
+    required this.sats,
+    required this.fiatAmount,
+    required this.fiatCode,
+    required this.orderId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    const bodyStyle = TextStyle(color: AppTheme.textPrimary, fontSize: 16);
+    final boldStyle = bodyStyle.copyWith(fontWeight: FontWeight.w600);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          s.payoutInvoiceInstruction(sats.toString(), fiatAmount, fiatCode),
+          style: bodyStyle,
+        ),
+        const SizedBox(height: 12),
+        // Text.rich (not RichText) so the line inherits the theme font
+        Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: '${s.orderIdLabel}: ', style: boldStyle),
+              TextSpan(text: orderId),
+            ],
+          ),
+          style: bodyStyle,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/order/screens/payout_invoice_screen.dart
+++ b/lib/features/order/screens/payout_invoice_screen.dart
@@ -59,17 +59,19 @@ class _PayoutInvoiceScreenState extends ConsumerState<PayoutInvoiceScreen> {
   @override
   Widget build(BuildContext context) {
     final order = widget.order;
-    final amount = order?.amount ?? 0;
+    // Only what is displayed falls back to zero; an unknown amount travels as
+    // null instead of claiming the payout is worth nothing.
+    final sats = order?.amount ?? 0;
     final fiatAmount = order?.fiatAmount.toString() ?? '0';
     final fiatCode = order?.fiatCode ?? '';
     final orderIdValue = order?.id ?? widget.orderId;
 
     final nwcState = ref.watch(nwcProvider);
     final showNwcInvoice =
-        nwcState.status == NwcStatus.connected && !_manualMode && amount > 0;
+        nwcState.status == NwcStatus.connected && !_manualMode && sats > 0;
 
     final header = _PayoutHeader(
-      sats: amount,
+      sats: sats,
       fiatAmount: fiatAmount,
       fiatCode: fiatCode,
       orderId: orderIdValue,
@@ -92,10 +94,10 @@ class _PayoutInvoiceScreenState extends ConsumerState<PayoutInvoiceScreen> {
                   header,
                   const SizedBox(height: 24),
                   NwcInvoiceWidget(
-                    sats: amount,
+                    sats: sats,
                     orderId: orderIdValue,
                     onInvoiceConfirmed: (invoice) async {
-                      await _submitInvoice(invoice, amount);
+                      await _submitInvoice(invoice, sats);
                     },
                     onFallbackToManual: () {
                       setState(() => _manualMode = true);
@@ -108,10 +110,10 @@ class _PayoutInvoiceScreenState extends ConsumerState<PayoutInvoiceScreen> {
                 onSubmit: () async {
                   final invoice = invoiceController.text.trim();
                   if (invoice.isNotEmpty) {
-                    await _submitInvoice(invoice, amount);
+                    await _submitInvoice(invoice, order?.amount);
                   }
                 },
-                amount: amount,
+                amount: sats,
                 fiatAmount: fiatAmount,
                 fiatCode: fiatCode,
                 orderId: orderIdValue,

--- a/lib/features/order/screens/payout_invoice_screen.dart
+++ b/lib/features/order/screens/payout_invoice_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
-import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
@@ -11,16 +10,6 @@ import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/utils/snack_bar_helper.dart';
 import 'package:mostro_mobile/shared/widgets/add_lightning_invoice_widget.dart';
 import 'package:mostro_mobile/shared/widgets/nwc_invoice_widget.dart';
-
-/// Whether this add-invoice asks for the payout of an already settled order
-/// rather than the invoice a take requires.
-///
-/// Both statuses mean the same thing: the hold invoice is settled and the only
-/// thing left is paying the buyer. `paymentFailed` is where a payout retry
-/// lands, `settledHoldInvoice` is the window between the release and the
-/// payout, where the buyer may want to replace a wrong invoice on their own.
-bool isPayoutInvoice(Status status) =>
-    status == Status.paymentFailed || status == Status.settledHoldInvoice;
 
 /// Invoice screen for collecting the sats of a settled order.
 ///
@@ -97,7 +86,9 @@ class _PayoutInvoiceScreenState extends ConsumerState<PayoutInvoiceScreen> {
                     sats: sats,
                     orderId: orderIdValue,
                     onInvoiceConfirmed: (invoice) async {
-                      await _submitInvoice(invoice, sats);
+                      // Same nullable amount as the manual path: only the
+                      // display falls back to zero, never what is submitted.
+                      await _submitInvoice(invoice, order?.amount);
                     },
                     onFallbackToManual: () {
                       setState(() => _manualMode = true);

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -15,6 +15,7 @@ import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/order/screens/payout_invoice_screen.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/shared/widgets/order_cards.dart';
 import 'package:mostro_mobile/features/trades/widgets/mostro_message_detail_widget.dart';
@@ -384,8 +385,12 @@ class TradeDetailScreen extends ConsumerWidget {
 
         case actions.Action.addInvoice:
           if (userRole == Role.buyer) {
+            // On a settled order the invoice is not part of the trade any
+            // more: it is the only way left to collect, so the label says so.
             widgets.add(_buildNostrButton(
-              S.of(context)!.addInvoiceButton,
+              isPayoutInvoice(tradeState.status)
+                  ? S.of(context)!.collectSatsButton
+                  : S.of(context)!.addInvoiceButton,
               action: actions.Action.addInvoice,
               backgroundColor: AppTheme.mostroGreen,
               onPressed: () => context.push('/add_invoice/$orderId'),

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -42,9 +42,11 @@ class TradeDetailScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tradeState = ref.watch(orderNotifierProvider(orderId));
     final originalOrder = ref.watch(eventProvider(orderId));
-    // If message is null or doesn't have an Order payload, show loading
+    // If message is null or doesn't have an Order payload, show loading.
+    // The public 38383 is only needed for the creator reputation below, and the
+    // book cache only holds the last 48h, so it must not gate the whole screen.
     final orderPayload = tradeState.order;
-    if (orderPayload == null || originalOrder == null) {
+    if (orderPayload == null) {
       return const Scaffold(
         backgroundColor: AppTheme.backgroundDark,
         body: Center(child: CircularProgressIndicator()),
@@ -77,7 +79,7 @@ class TradeDetailScreen extends ConsumerWidget {
                 _buildOrderId(context),
                 const SizedBox(height: 16),
                 // For pending orders created by the user, show creator's reputation
-                if (isPending && isCreator) ...[
+                if (isPending && isCreator && originalOrder != null) ...[
                   // TODO: Change this to use `orderPayload` after Order model is updated
                   // with rating information
                   _buildCreatorReputation(context, originalOrder),

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -15,7 +15,6 @@ import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
-import 'package:mostro_mobile/features/order/screens/payout_invoice_screen.dart';
 import 'package:mostro_mobile/features/order/widgets/order_app_bar.dart';
 import 'package:mostro_mobile/shared/widgets/order_cards.dart';
 import 'package:mostro_mobile/features/trades/widgets/mostro_message_detail_widget.dart';
@@ -388,7 +387,7 @@ class TradeDetailScreen extends ConsumerWidget {
             // On a settled order the invoice is not part of the trade any
             // more: it is the only way left to collect, so the label says so.
             widgets.add(_buildNostrButton(
-              isPayoutInvoice(tradeState.status)
+              tradeState.status.isPayoutInvoice
                   ? S.of(context)!.collectSatsButton
                   : S.of(context)!.addInvoiceButton,
               action: actions.Action.addInvoice,
@@ -578,11 +577,6 @@ class TradeDetailScreen extends ConsumerWidget {
 
         case actions.Action.sendDm:
           widgets.add(_buildContactButton(context));
-          break;
-
-        case actions.Action.paymentFailed:
-          // Payment failed - Mostro is still retrying, only show Close button
-          // No additional buttons (Add Invoice, Cancel, Dispute) should appear
           break;
 
         case actions.Action.holdInvoicePaymentCanceled:

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -672,6 +672,7 @@
     "yourSharedKey": "Dein geteilter Schlüssel (Shared Key):",
     "payInvoiceButton": "RECHNUNG BEZAHLEN",
     "addInvoiceButton": "RECHNUNG HINZUFÜGEN",
+    "collectSatsButton": "SATS EINLÖSEN",
     "release": "FREIGEBEN",
     "takeSell": "VERKAUF ANNEHMEN",
     "takeBuy": "KAUF ANNEHMEN",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -346,6 +346,21 @@
             }
         }
     },
+    "payoutInvoiceInstruction": "Füge eine Lightning-Rechnung über {sats} Sats hinzu, entsprechend {fiat_amount} {fiat_code}, um die Zahlung für deinen Kauf zu erhalten.",
+    "@payoutInvoiceInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "collectYourSats": "Deine Sats einlösen",
     "reputationReviewsCount": "{count, plural, =1{1 Bewertung} other{{count} Bewertungen}}",
     "@reputationReviewsCount": {
         "placeholders": {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -672,6 +672,7 @@
     "yourSharedKey": "Your Shared Key:",
     "payInvoiceButton": "PAY INVOICE",
     "addInvoiceButton": "ADD INVOICE",
+    "collectSatsButton": "COLLECT SATS",
     "release": "RELEASE",
     "takeSell": "TAKE SELL",
     "takeBuy": "TAKE BUY",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -346,6 +346,21 @@
             }
         }
     },
+    "payoutInvoiceInstruction": "Add a Lightning invoice for {sats} sats, equivalent to {fiat_amount} {fiat_code}, to receive the payment for your purchase.",
+    "@payoutInvoiceInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "collectYourSats": "Collect Your Sats",
     "reputationReviewsCount": "{count, plural, =1{1 review} other{{count} reviews}}",
     "@reputationReviewsCount": {
         "placeholders": {

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -521,6 +521,7 @@
     "yourSharedKey": "Tu clave compartida:",
     "payInvoiceButton": "PAGAR FACTURA",
     "addInvoiceButton": "AGREGAR FACTURA",
+    "collectSatsButton": "COBRAR SATS",
     "release": "LIBERAR",
     "takeSell": "TOMAR VENTA",
     "takeBuy": "TOMAR COMPRA",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -782,6 +782,21 @@
             }
         }
     },
+    "payoutInvoiceInstruction": "Agrega una factura Lightning de {sats} sats, equivalentes a {fiat_amount} {fiat_code}, para recibir el pago de tu compra.",
+    "@payoutInvoiceInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "collectYourSats": "Cobrar Tus Sats",
     "reputationReviewsCount": "{count, plural, =1{1 reseña} other{{count} reseñas}}",
     "@reputationReviewsCount": {
         "placeholders": {

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -346,6 +346,21 @@
             }
         }
     },
+    "payoutInvoiceInstruction": "Ajoutez une facture Lightning de {sats} sats, équivalant à {fiat_amount} {fiat_code}, pour recevoir le paiement de votre achat.",
+    "@payoutInvoiceInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "collectYourSats": "Encaisser vos sats",
     "reputationReviewsCount": "{count, plural, =1{1 avis} other{{count} avis}}",
     "@reputationReviewsCount": {
         "placeholders": {

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -672,6 +672,7 @@
     "yourSharedKey": "Votre clé partagée :",
     "payInvoiceButton": "PAYER LA FACTURE",
     "addInvoiceButton": "AJOUTER UNE FACTURE",
+    "collectSatsButton": "ENCAISSER LES SATS",
     "release": "LIBÉRER",
     "takeSell": "PRENDRE VENTE",
     "takeBuy": "PRENDRE ACHAT",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -551,6 +551,7 @@
     "yourSharedKey": "La tua chiave condivisa:",
     "payInvoiceButton": "PAGA FATTURA",
     "addInvoiceButton": "AGGIUNGI FATTURA",
+    "collectSatsButton": "RISCUOTI SATS",
     "release": "RILASCIA",
     "takeSell": "PRENDI VENDITA",
     "takeBuy": "PRENDI ACQUISTO",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -855,6 +855,21 @@
             }
         }
     },
+    "payoutInvoiceInstruction": "Aggiungi una fattura Lightning di {sats} sats, equivalenti a {fiat_amount} {fiat_code}, per ricevere il pagamento del tuo acquisto.",
+    "@payoutInvoiceInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "collectYourSats": "Riscuoti i Tuoi Sats",
     "reputationReviewsCount": "{count, plural, =1{1 recensione} other{{count} recensioni}}",
     "@reputationReviewsCount": {
         "placeholders": {

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -346,6 +346,21 @@
             }
         }
     },
+    "payoutInvoiceInstruction": "Adicione uma fatura Lightning de {sats} sats, equivalente a {fiat_amount} {fiat_code}, para receber o pagamento da sua compra.",
+    "@payoutInvoiceInstruction": {
+        "placeholders": {
+            "sats": {
+                "type": "String"
+            },
+            "fiat_amount": {
+                "type": "String"
+            },
+            "fiat_code": {
+                "type": "String"
+            }
+        }
+    },
+    "collectYourSats": "Receber Seus Sats",
     "reputationReviewsCount": "{count, plural, =1{1 avaliação} other{{count} avaliações}}",
     "@reputationReviewsCount": {
         "placeholders": {

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -672,6 +672,7 @@
     "yourSharedKey": "Sua Chave Compartilhada:",
     "payInvoiceButton": "PAGAR FATURA",
     "addInvoiceButton": "ADICIONAR FATURA",
+    "collectSatsButton": "RECEBER SATS",
     "release": "LIBERAR",
     "takeSell": "ACEITAR VENDA",
     "takeBuy": "ACEITAR COMPRA",

--- a/lib/shared/widgets/add_lightning_invoice_widget.dart
+++ b/lib/shared/widgets/add_lightning_invoice_widget.dart
@@ -7,7 +7,9 @@ import 'package:mostro_mobile/generated/l10n.dart';
 class AddLightningInvoiceWidget extends StatefulWidget {
   final TextEditingController controller;
   final VoidCallback onSubmit;
-  final VoidCallback onCancel;
+
+  /// Hidden when null: the payout flow has nothing left to cancel.
+  final VoidCallback? onCancel;
   final int amount;
   final String fiatAmount;
   final String fiatCode;
@@ -20,7 +22,7 @@ class AddLightningInvoiceWidget extends StatefulWidget {
     super.key,
     required this.controller,
     required this.onSubmit,
-    required this.onCancel,
+    this.onCancel,
     required this.amount,
     required this.fiatAmount,
     required this.fiatCode,
@@ -82,22 +84,24 @@ class _AddLightningInvoiceWidgetState extends State<AddLightningInvoiceWidget> {
           const SizedBox(height: 16),
           Row(
             children: [
-              Expanded(
-                child: TextButton(
-                  key: const Key('cancelInvoiceButton'),
-                  onPressed: widget.onCancel,
-                  child: Text(
-                    S.of(context)!.cancel,
-                    style: const TextStyle(
-                      color: AppTheme.textSecondary,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
+              if (widget.onCancel != null) ...[
+                Expanded(
+                  child: TextButton(
+                    key: const Key('cancelInvoiceButton'),
+                    onPressed: widget.onCancel,
+                    child: Text(
+                      S.of(context)!.cancel,
+                      style: const TextStyle(
+                        color: AppTheme.textSecondary,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      textAlign: TextAlign.center,
                     ),
-                    textAlign: TextAlign.center,
-                  ),
-                ).withAutomationId(AutomationIds.invoiceCancel),
-              ),
-              const SizedBox(width: 12),
+                  ).withAutomationId(AutomationIds.invoiceCancel),
+                ),
+                const SizedBox(width: 12),
+              ],
               Expanded(
                 child: ElevatedButton(
                   key: const Key('submitInvoiceButton'),

--- a/lib/shared/widgets/invoice_header.dart
+++ b/lib/shared/widgets/invoice_header.dart
@@ -12,8 +12,7 @@ import 'package:mostro_mobile/shared/widgets/order_cards.dart';
 /// It only ever is for the maker, at the handoff right after a take. Both
 /// invoice screens are also reached by takers — taking a buy order means
 /// paying the hold invoice, taking a sell one means adding an invoice — and
-/// by the buyer asked for a fresh invoice after a failed payout, and for
-/// them nobody took anything.
+/// for them nobody took anything.
 ///
 /// A sell order is published by its seller and a buy order by its buyer, so
 /// matching the order kind against the user's role identifies the maker.
@@ -47,8 +46,7 @@ class InvoiceHeader extends StatelessWidget {
   final UserInfo? reputation;
 
   /// Whether to open with the "someone took your order" line. False for
-  /// takers and for the post-payment-failure retry — see
-  /// [counterpartTookYourOrder].
+  /// takers — see [counterpartTookYourOrder].
   final bool takenByCounterpart;
 
   const InvoiceHeader({

--- a/test/data/models/enums_test.dart
+++ b/test/data/models/enums_test.dart
@@ -86,6 +86,17 @@ void main() {
 
       expect(terminalCount + liveCount, Status.values.length);
     });
+
+    test('isPayoutInvoice covers exactly the settled statuses', () {
+      expect(Status.settledHoldInvoice.isPayoutInvoice, isTrue);
+      expect(Status.paymentFailed.isPayoutInvoice, isTrue);
+
+      for (final status in Status.values.where(
+          (s) => s != Status.settledHoldInvoice && s != Status.paymentFailed)) {
+        expect(status.isPayoutInvoice, isFalse,
+            reason: '$status is not a payout invoice');
+      }
+    });
   });
 
   group('Role', () {

--- a/test/features/order/models/order_state_payout_retry_test.dart
+++ b/test/features/order/models/order_state_payout_retry_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models.dart';
+import 'package:mostro_mobile/data/enums.dart';
+import 'package:mostro_mobile/features/order/models/order_state.dart';
+
+/// add-invoice as Mostro sends it right after a take: the payload announces
+/// the order moving into waiting-buyer-invoice.
+MostroMessage<Order> _takeAddInvoiceMessage() => MostroMessage<Order>(
+      action: Action.addInvoice,
+      payload: const Order(
+        id: 'order-1',
+        kind: OrderType.sell,
+        status: Status.waitingBuyerInvoice,
+        amount: 500,
+        fiatCode: 'CUP',
+        fiatAmount: 333,
+        paymentMethod: 'Saldo móvil',
+      ),
+    );
+
+/// add-invoice as Mostro sends it when the payout failed: same action, but the
+/// order is already settled, which is what tells the two cases apart.
+MostroMessage<Order> _payoutRetryMessage() => MostroMessage<Order>(
+      action: Action.addInvoice,
+      payload: const Order(
+        id: 'order-1',
+        kind: OrderType.sell,
+        status: Status.settledHoldInvoice,
+        amount: 495,
+        fiatCode: 'CUP',
+        fiatAmount: 333,
+        paymentMethod: 'Saldo móvil',
+      ),
+    );
+
+void main() {
+  group('add-invoice after a failed payout', () {
+    test('is detected from the payload without the payment-failed notice', () {
+      // The buyer never got the payment-failed DM: it is only sent on the first
+      // failure and the app may have been closed, reinstalled or restored.
+      final state = OrderState(
+        status: Status.settledHoldInvoice,
+        action: Action.released,
+        order: _payoutRetryMessage().getPayload<Order>(),
+      );
+
+      final updated = state.updateWith(_payoutRetryMessage());
+
+      expect(updated.status, equals(Status.paymentFailed));
+    });
+
+    test('is still detected when the payment-failed notice did arrive', () {
+      final state = OrderState(
+        status: Status.paymentFailed,
+        action: Action.paymentFailed,
+        order: _payoutRetryMessage().getPayload<Order>(),
+      );
+
+      final updated = state.updateWith(_payoutRetryMessage());
+
+      expect(updated.status, equals(Status.paymentFailed));
+    });
+
+    test('does not hijack the add-invoice that follows a take', () {
+      final state = OrderState(
+        status: Status.pending,
+        action: Action.newOrder,
+        order: _takeAddInvoiceMessage().getPayload<Order>(),
+      );
+
+      final updated = state.updateWith(_takeAddInvoiceMessage());
+
+      expect(updated.status, equals(Status.waitingBuyerInvoice));
+    });
+  });
+}

--- a/test/features/order/models/order_state_settled_actions_test.dart
+++ b/test/features/order/models/order_state_settled_actions_test.dart
@@ -42,12 +42,46 @@ void main() {
       expect(actions, contains(Action.addInvoice));
     });
 
+    test('the invoice survives the invoice-updated ack', () {
+      // Mostro acks the new invoice with invoice-updated and no payload, so the
+      // status is kept and only the action changes. Without a row for it the
+      // buyer would lose the button until the next payment-failed.
+      for (final state in [
+        _state(Status.paymentFailed, Action.invoiceUpdated),
+        _state(Status.settledHoldInvoice, Action.invoiceUpdated),
+      ]) {
+        expect(state.getActions(Role.buyer), contains(Action.addInvoice),
+            reason: '${state.status} / ${state.action}');
+      }
+    });
+
+    test('the whole payout retry sequence keeps the invoice reachable', () {
+      // released -> add-invoice (settled payload) -> invoice-updated ack.
+      var state = _state(Status.settledHoldInvoice, Action.released);
+      expect(state.getActions(Role.buyer), contains(Action.addInvoice));
+
+      state = state.updateWith(MostroMessage<Order>(
+        action: Action.addInvoice,
+        payload: _settledOrder(),
+      ));
+      expect(state.status, equals(Status.paymentFailed));
+      expect(state.getActions(Role.buyer), contains(Action.addInvoice));
+
+      state = state.updateWith(MostroMessage<Order>(
+        action: Action.invoiceUpdated,
+      ));
+      expect(state.status, equals(Status.paymentFailed));
+      expect(state.getActions(Role.buyer), contains(Action.addInvoice));
+    });
+
     test('cancel is never offered: Mostro rejects it on a settled order', () {
       for (final state in [
         _state(Status.settledHoldInvoice, Action.released),
         _state(Status.settledHoldInvoice, Action.addInvoice),
         _state(Status.paymentFailed, Action.addInvoice),
         _state(Status.paymentFailed, Action.paymentFailed),
+        _state(Status.paymentFailed, Action.invoiceUpdated),
+        _state(Status.settledHoldInvoice, Action.invoiceUpdated),
       ]) {
         expect(state.getActions(Role.buyer), isNot(contains(Action.cancel)),
             reason: '${state.status} / ${state.action}');

--- a/test/features/order/models/order_state_settled_actions_test.dart
+++ b/test/features/order/models/order_state_settled_actions_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models.dart';
+import 'package:mostro_mobile/data/enums.dart';
+import 'package:mostro_mobile/features/order/models/order_state.dart';
+
+Order _settledOrder() => const Order(
+      id: 'order-1',
+      kind: OrderType.sell,
+      status: Status.settledHoldInvoice,
+      amount: 495,
+      fiatCode: 'CUP',
+      fiatAmount: 333,
+      paymentMethod: 'Saldo móvil',
+    );
+
+OrderState _state(Status status, Action action) => OrderState(
+      status: status,
+      action: action,
+      order: _settledOrder(),
+    );
+
+void main() {
+  group('buyer actions once the order is settled', () {
+    test('the invoice is offered while the payout is still on its way', () {
+      final actions = _state(Status.settledHoldInvoice, Action.released)
+          .getActions(Role.buyer);
+
+      expect(actions, contains(Action.addInvoice));
+    });
+
+    test('the invoice is offered after the payment-failed notice', () {
+      final actions = _state(Status.paymentFailed, Action.paymentFailed)
+          .getActions(Role.buyer);
+
+      expect(actions, contains(Action.addInvoice));
+    });
+
+    test('the invoice is offered when Mostro asks for a new one', () {
+      final actions = _state(Status.paymentFailed, Action.addInvoice)
+          .getActions(Role.buyer);
+
+      expect(actions, contains(Action.addInvoice));
+    });
+
+    test('cancel is never offered: Mostro rejects it on a settled order', () {
+      for (final state in [
+        _state(Status.settledHoldInvoice, Action.released),
+        _state(Status.settledHoldInvoice, Action.addInvoice),
+        _state(Status.paymentFailed, Action.addInvoice),
+        _state(Status.paymentFailed, Action.paymentFailed),
+      ]) {
+        expect(state.getActions(Role.buyer), isNot(contains(Action.cancel)),
+            reason: '${state.status} / ${state.action}');
+        expect(state.getActions(Role.seller), isNot(contains(Action.cancel)),
+            reason: '${state.status} / ${state.action}');
+      }
+    });
+  });
+}

--- a/test/features/order/screens/payout_invoice_screen_test.dart
+++ b/test/features/order/screens/payout_invoice_screen_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:mostro_mobile/data/models/enums/status.dart';
+import 'package:mostro_mobile/features/order/screens/payout_invoice_screen.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/widgets/add_lightning_invoice_widget.dart';
+
+void main() {
+  group('isPayoutInvoice', () {
+    test('is true once the hold invoice is settled', () {
+      expect(isPayoutInvoice(Status.settledHoldInvoice), isTrue);
+      expect(isPayoutInvoice(Status.paymentFailed), isTrue);
+    });
+
+    test('is false for the invoice a take asks for', () {
+      expect(isPayoutInvoice(Status.waitingBuyerInvoice), isFalse);
+      expect(isPayoutInvoice(Status.waitingPayment), isFalse);
+      expect(isPayoutInvoice(Status.active), isFalse);
+      expect(isPayoutInvoice(Status.pending), isFalse);
+    });
+  });
+
+  group('AddLightningInvoiceWidget cancel button', () {
+    Widget harness(Widget child) => MaterialApp(
+          localizationsDelegates: const [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: Scaffold(body: child),
+        );
+
+    testWidgets('is hidden when no cancel callback is given', (tester) async {
+      await tester.pumpWidget(harness(AddLightningInvoiceWidget(
+        controller: TextEditingController(),
+        onSubmit: () {},
+        amount: 1000,
+        fiatAmount: '10',
+        fiatCode: 'USD',
+        orderId: 'order-1',
+      )));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cancelInvoiceButton')), findsNothing);
+      expect(find.byKey(const Key('submitInvoiceButton')), findsOneWidget);
+    });
+
+    testWidgets('is shown when a cancel callback is given', (tester) async {
+      await tester.pumpWidget(harness(AddLightningInvoiceWidget(
+        controller: TextEditingController(),
+        onSubmit: () {},
+        onCancel: () {},
+        amount: 1000,
+        fiatAmount: '10',
+        fiatCode: 'USD',
+        orderId: 'order-1',
+      )));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cancelInvoiceButton')), findsOneWidget);
+    });
+  });
+}

--- a/test/features/trades/screens/trade_detail_screen_test.dart
+++ b/test/features/trades/screens/trade_detail_screen_test.dart
@@ -1,0 +1,166 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart' as actions;
+import 'package:mostro_mobile/data/models/enums/order_type.dart';
+import 'package:mostro_mobile/data/models/enums/status.dart';
+import 'package:mostro_mobile/data/models/mostro_message.dart';
+import 'package:mostro_mobile/data/models/order.dart';
+import 'package:mostro_mobile/features/order/models/order_state.dart';
+import 'package:mostro_mobile/features/order/notifiers/order_notifier.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/trades/screens/trade_detail_screen.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/services/mostro_service.dart';
+import 'package:mostro_mobile/services/nostr_service.dart';
+import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/time_provider.dart';
+import 'package:mostro_mobile/shared/providers/mostro_database_provider.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:sembast/sembast_memory.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+/// Nostr that is up but has nothing to say, so the real
+/// `orderRepositoryProvider` builds without scheduling its readiness retry
+/// timer and the order book cache stays empty — which is the whole point of
+/// these tests: no public 38383 event for the order.
+class _SilentNostrService extends NostrService {
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Stream<NostrEvent> subscribeToEvents(NostrRequest request) =>
+      const Stream.empty();
+}
+
+/// Mostro service that skips `init()`: the screen never talks to it, but
+/// [OrderNotifier] reads it while constructing.
+class _IdleMostroService extends MostroService {
+  _IdleMostroService(super.ref);
+}
+
+/// [OrderNotifier] with a fixed state. `sync()` and `subscribe()` are the two
+/// hooks its constructor calls, so overriding them keeps the storage and the
+/// message stream out of the test.
+class _FixedOrderNotifier extends OrderNotifier {
+  _FixedOrderNotifier(super.orderId, super.ref, OrderState fixedState) {
+    state = fixedState;
+  }
+
+  @override
+  Future<void> sync() async {}
+
+  @override
+  void subscribe() {}
+}
+
+Order _order(Status status) => Order(
+      id: 'order-1',
+      kind: OrderType.sell,
+      status: status,
+      amount: 495,
+      fiatCode: 'CUP',
+      fiatAmount: 333,
+      paymentMethod: 'Saldo móvil',
+    );
+
+void main() {
+  const orderId = 'order-1';
+
+  late Database db;
+
+  setUp(() async {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    // Empty stores are enough: the screen reads no session and no message.
+    db = await databaseFactoryMemory.openDatabase('trade_detail_test.db');
+  });
+
+  tearDown(() async => db.close());
+
+  Future<void> pumpDetail(WidgetTester tester, OrderState tradeState) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(SharedPreferencesAsync()),
+        mostroDatabaseProvider.overrideWithValue(db),
+        nostrServiceProvider.overrideWithValue(_SilentNostrService()),
+        mostroServiceProvider.overrideWith((ref) => _IdleMostroService(ref)),
+        orderNotifierProvider.overrideWith(
+          (ref, id) => _FixedOrderNotifier(id, ref, tradeState),
+        ),
+        mostroMessageHistoryProvider(orderId)
+            .overrideWith((ref) => Stream.value(const <MostroMessage>[])),
+        // A real one ticks on a Timer and would hang pumpAndSettle.
+        countdownTimeProvider.overrideWith(
+          (ref) => Stream.value(DateTime.fromMillisecondsSinceEpoch(0)),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        home: TradeDetailScreen(orderId: orderId),
+      ),
+    ));
+    await tester.pump();
+  }
+
+  group('TradeDetailScreen without the public 38383 event', () {
+    // Regression: the screen used to require the public event, which the order
+    // book only caches for 48h. A settled, canceled or old order left it stuck
+    // on a spinner with no app bar and no way out.
+    testWidgets('renders a settled order the book no longer caches',
+        (tester) async {
+      await pumpDetail(
+        tester,
+        OrderState(
+          status: Status.settledHoldInvoice,
+          action: actions.Action.released,
+          order: _order(Status.settledHoldInvoice),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text(orderId), findsOneWidget);
+    });
+
+    testWidgets('drops the creator reputation instead of the whole screen',
+        (tester) async {
+      // Pending order: the only place the public event was ever used.
+      await pumpDetail(
+        tester,
+        OrderState(
+          status: Status.pending,
+          action: actions.Action.newOrder,
+          order: _order(Status.pending),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text(orderId), findsOneWidget);
+    });
+
+    testWidgets('still waits while the trade state has no order', (tester) async {
+      await pumpDetail(
+        tester,
+        OrderState(
+          status: Status.pending,
+          action: actions.Action.newOrder,
+          order: null,
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+  });
+}

--- a/test/shared/widgets/add_lightning_invoice_widget_test.dart
+++ b/test/shared/widgets/add_lightning_invoice_widget_test.dart
@@ -1,26 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:mostro_mobile/data/models/enums/status.dart';
-import 'package:mostro_mobile/features/order/screens/payout_invoice_screen.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 import 'package:mostro_mobile/shared/widgets/add_lightning_invoice_widget.dart';
 
 void main() {
-  group('isPayoutInvoice', () {
-    test('is true once the hold invoice is settled', () {
-      expect(isPayoutInvoice(Status.settledHoldInvoice), isTrue);
-      expect(isPayoutInvoice(Status.paymentFailed), isTrue);
-    });
-
-    test('is false for the invoice a take asks for', () {
-      expect(isPayoutInvoice(Status.waitingBuyerInvoice), isFalse);
-      expect(isPayoutInvoice(Status.waitingPayment), isFalse);
-      expect(isPayoutInvoice(Status.active), isFalse);
-      expect(isPayoutInvoice(Status.pending), isFalse);
-    });
-  });
-
   group('AddLightningInvoiceWidget cancel button', () {
     Widget harness(Widget child) => MaterialApp(
           localizationsDelegates: const [


### PR DESCRIPTION
## Problem

Once Mostro settles the hold invoice, the buyer may still need to supply a new
Lightning invoice: either the payout failed after exhausting its retries, or
they realise the invoice/address they gave is not going to work. The app reused
the add-invoice screen from the take handoff for that, and the mismatch shows:

- It announced "A seller has taken your buy order" and displayed the
  counterpart's reputation, neither of which has anything to do with collecting
  a payout. Worse, it did so only for the maker, so the same moment looked
  different depending on the role.
- It offered a Cancel button that Mostro rejects with `NotAllowedByStatus` once
  the order is settled (`cancel.rs`), so the user got a `cant-do` and nothing
  else.
- It re-offered the Lightning address shortcut, which may be exactly what broke
  the payout.
- And in most of those states the order detail showed no button at all, so
  there was no way into the screen to begin with.

On top of that, the retry was detected from the previous `payment-failed`
notice, which the daemon only sends on the *first* failure. A closed, restored
or reinstalled app never saw it and treated the retry as a fresh take.

## Changes

1. **`fix(trades): don't block order details waiting for the public event`** —
   the screen required the public 38383 event, which the order book only caches
   for 48h, but uses it solely for the creator reputation card of a pending
   order. A settled, canceled or old order left it stuck on a spinner with no
   app bar and no way out. Prerequisite here, since the new flow navigates to
   the order detail after submitting.
2. **`fix(order): detect the payout add-invoice from the message payload`** —
   the daemon only sends this action with a `settled-hold-invoice` payload when
   it is asking for a payout invoice, so the message identifies the case on its
   own.
3. **`feat(order): dedicated screen to collect the sats of a settled order`** —
   new screen: neutral wording, no counterpart context, no Lightning address
   shortcut, nothing to cancel. Reached both after a failed payout and while
   the payment is still on its way, so it never claims that something failed.
   The failure notice stays on the order detail, where it is conditional and
   already translated.
4. **`feat(trades): keep the invoice available while the order is settled`** —
   FSM rows for `released` and `payment-failed`, which offered no action at
   all, and `cancel` dropped from `settled-hold-invoice` for both roles.


## Not included

A contextual message for the `cant-do` Mostro returns when an invoice is submitted while a payout attempt is in flight. The window is short and self-clearing (the marker is released on both success and failure), so the worst case is a generic error and a retry. Worth its own PR, together with the other context-free `cant-do` messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated payout invoice screen for settled orders.
  - Supports automatic invoice generation or manual invoice entry.
  - Added “Collect Your Sats” guidance and payout details.
  - Cancel controls now appear only when cancellation is available.

- **Bug Fixes**
  - Improved handling of payment-failed and payout-retry states.
  - Buyers can retry or add invoices across supported payout statuses.
  - Sellers can no longer cancel settled hold-invoice actions.

- **Localization**
  - Added payout and sats-collection translations in English, German, Spanish, French, Italian, and Portuguese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->