### PR TITLE
fix(disputes): reload dispute chats when the app returns to foreground

### DIFF
--- a/lib/services/lifecycle_manager.dart
+++ b/lib/services/lifecycle_manager.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
+import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
 import 'package:mostro_mobile/features/trades/providers/trades_provider.dart';
 import 'package:mostro_mobile/shared/providers/background_service_provider.dart';
@@ -81,6 +82,12 @@ class LifecycleManager extends WidgetsBindingObserver {
       logger.i("Reloading chat rooms");
       final chatRooms = ref.read(chatRoomsNotifierProvider.notifier);
       await chatRooms.reloadAllChats();
+
+      // Reload dispute chats: the background service persists admin messages
+      // to disk while the app sleeps, but an already-initialized notifier
+      // never re-reads storage nor re-opens its relay subscription on its own
+      logger.i("Reloading dispute chats");
+      ref.invalidate(disputeChatNotifierProvider);
 
       // Force UI update for trades
       logger.i("Invalidating providers to refresh UI");

--- a/test/features/disputes/dispute_chat_reload_test.dart
+++ b/test/features/disputes/dispute_chat_reload_test.dart
@@ -1,0 +1,197 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/dispute.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart' as actions;
+import 'package:mostro_mobile/data/models/enums/status.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/data/repositories/event_storage.dart';
+import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
+import 'package:mostro_mobile/features/order/models/order_state.dart';
+import 'package:mostro_mobile/features/order/notifiers/order_notifier.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/services/mostro_service.dart';
+import 'package:mostro_mobile/services/nostr_service.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/shared/providers/mostro_database_provider.dart';
+import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
+import 'package:sembast/sembast_memory.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../../mocks.mocks.dart';
+
+/// Nostr that is up but delivers nothing: the dispute chat notifier can open
+/// its live subscription without a network.
+class _SilentNostrService extends NostrService {
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Stream<NostrEvent> subscribeToEvents(NostrRequest request) =>
+      const Stream.empty();
+}
+
+/// Mostro service that skips `init()`; read by [OrderNotifier]'s constructor.
+class _IdleMostroService extends MostroService {
+  _IdleMostroService(super.ref);
+}
+
+/// [OrderNotifier] pinned to a fixed state carrying the dispute.
+class _FixedOrderNotifier extends OrderNotifier {
+  _FixedOrderNotifier(super.orderId, super.ref, OrderState fixedState) {
+    state = fixedState;
+  }
+
+  @override
+  Future<void> sync() async {}
+
+  @override
+  void subscribe() {}
+}
+
+/// Session notifier pinned to a fixed session list; never touches storage.
+class _FixedSessionNotifier extends SessionNotifier {
+  _FixedSessionNotifier(Ref ref, List<Session> sessions)
+      : super(
+          ref,
+          MockSessionStorage(),
+          Settings(
+            relays: [],
+            fullPrivacyMode: false,
+            mostroPublicKey: 'test',
+          ),
+        ) {
+    state = sessions;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const orderId = 'order-1';
+  const disputeId = 'dispute-1';
+
+  final tradeKey = NostrKeyPairs(
+    private:
+        '0000000000000000000000000000000000000000000000000000000000000001',
+  );
+  final adminKey = NostrKeyPairs(
+    private:
+        '0000000000000000000000000000000000000000000000000000000000000003',
+  );
+
+  late Session session;
+  late EventStorage eventStorage;
+  late Database db;
+  late ProviderContainer container;
+
+  setUp(() async {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+
+    session = Session(
+      masterKey: tradeKey,
+      tradeKey: tradeKey,
+      keyIndex: 1,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+      orderId: orderId,
+    )..setAdminPeer(adminKey.public);
+
+    db = await newDatabaseFactoryMemory().openDatabase('dispute_reload.db');
+    eventStorage = EventStorage(db: db);
+
+    final orderState = OrderState(
+      status: Status.dispute,
+      action: actions.Action.disputeInitiatedByYou,
+      order: null,
+      dispute: Dispute(disputeId: disputeId, orderId: orderId),
+    );
+
+    container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(SharedPreferencesAsync()),
+        mostroDatabaseProvider.overrideWithValue(db),
+        nostrServiceProvider.overrideWithValue(_SilentNostrService()),
+        mostroServiceProvider.overrideWith((ref) => _IdleMostroService(ref)),
+        eventStorageProvider.overrideWithValue(eventStorage),
+        sessionNotifierProvider
+            .overrideWith((ref) => _FixedSessionNotifier(ref, [session])),
+        orderNotifierProvider.overrideWith(
+          (ref, id) => _FixedOrderNotifier(id, ref, orderState),
+        ),
+      ],
+    );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await db.close();
+  });
+
+  /// Simulate the background service persisting an accepted admin envelope
+  /// to disk (its notification path) while the foreground app sleeps.
+  Future<NostrEvent> persistAdminMessageFromBackground(String text) async {
+    final chatKeys = ChatKeys.fromSharedKey(session.adminSharedKey!);
+    final rumor = NostrEventExtensions.createChatRumor(
+      senderKeys: adminKey,
+      content: text,
+    );
+    final wrapped = await rumor.chatWrap(chatKeys);
+    await eventStorage.putItem(
+      wrapped.id!,
+      wrapped.disputeChatRecord(disputeId),
+    );
+    return rumor;
+  }
+
+  test(
+      'invalidating the dispute chat family reloads admin messages the '
+      'background service persisted while the notifier was alive', () async {
+    // Arrange: notifier initialized before the messages arrive
+    container.read(disputeChatNotifierProvider(disputeId).notifier);
+    await pumpEventQueue();
+    expect(
+      container.read(disputeChatNotifierProvider(disputeId)).messages,
+      isEmpty,
+    );
+
+    // Background service stores three admin messages on disk; the alive
+    // notifier has no way to see them (this is the reported bug scenario)
+    final rumor1 = await persistAdminMessageFromBackground('admin message 1');
+    final rumor2 = await persistAdminMessageFromBackground('admin message 2');
+    final rumor3 = await persistAdminMessageFromBackground('admin message 3');
+    await pumpEventQueue();
+    expect(
+      container.read(disputeChatNotifierProvider(disputeId)).messages,
+      isEmpty,
+      reason: 'an already-initialized notifier does not re-read storage',
+    );
+
+    // Act: what LifecycleManager now does on foreground resume
+    container.invalidate(disputeChatNotifierProvider);
+    container.read(disputeChatNotifierProvider(disputeId).notifier);
+    await pumpEventQueue(times: 100);
+
+    // Assert: the messages persisted by the background service are visible
+    final messages =
+        container.read(disputeChatNotifierProvider(disputeId)).messages;
+    expect(messages, hasLength(3));
+    expect(
+      messages.map((m) => m.id),
+      containsAll([rumor1.id, rumor2.id, rumor3.id]),
+    );
+    expect(
+      messages.map((m) => m.content),
+      containsAll(['admin message 1', 'admin message 2', 'admin message 3']),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes admin dispute-chat messages not appearing in the foreground app until a full restart.

### Root cause

While the app is backgrounded, the background notification service receives kind-14 admin envelopes, decrypts them, **persists them to disk** (`_processAdminDm`), and shows push notifications — its comment explicitly says the foreground should "load the message from disk instead of depending on a relay refetch".

However, on foreground resume, `LifecycleManager._switchToForeground()` refreshed orders, P2P chat rooms, and trades — but never the dispute chat. `DisputeChatNotifier` only reads storage once in its lifetime (guarded by `_isInitialized`), and its direct relay subscription goes stale across the background/foreground cycle. If the user had already opened the dispute before backgrounding, the notifier stayed alive with stale state: messages sat on disk, invisible, until an app restart recreated the notifier.

Reported symptom matched exactly: three push notifications arrived, the open dispute showed nothing, and after killing/reopening the app the three admin messages appeared.

### Fix

Invalidate the `disputeChatNotifierProvider` family on foreground resume, next to the existing chat rooms reload. Alive notifiers are recreated: they reload background-persisted messages from disk and re-open their relay subscription with the persisted cursor. This is the same pattern `RestoreManager` already uses after a restore.

## Test plan

- [x] New regression test `test/features/disputes/dispute_chat_reload_test.dart`: an initialized notifier does not see three admin messages the background service persisted to disk (documents the gap), and the resume-time family invalidation surfaces all three from storage.
- [x] `flutter test` — 1044 tests passing
- [x] `flutter analyze` — no new issues
- [ ] Manual: open a dispute chat, background the app, have the admin send messages (push arrives), resume the app → messages appear without restarting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dispute chats now refresh correctly when the app returns to the foreground.
  * Persisted administrator messages are reloaded, ensuring previously received dispute messages appear in the chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->