### PR TITLE
fix(settings): the settings back control carries its automation identifier

### DIFF
--- a/docs/automation-contract.md
+++ b/docs/automation-contract.md
@@ -13,6 +13,14 @@ owners.
 Every actionable control and business-critical state carries a stable
 identifier from `lib/core/automation/automation_ids.dart`, attached with the
 `.withAutomationId()` extension (`lib/core/automation/automation_id.dart`).
+
+**Declaring an identifier is not attaching it.** A shell identifier such as
+`appbar.back` belongs to every screen that offers that control, and a screen
+that builds its own `AppBar` owns the job of naming its leading button. The
+contract test checks that identifiers are declared, unique and namespaced --
+it cannot see which screens attached them -- so a screen that forgets one
+leaves the suite green and the driver with no way out. `settings` shipped
+that way: the only exit from the screen was invisible to accessibility.
 Flutter exposes it as `Semantics.identifier`, which Android surfaces as the
 accessibility `resource-id`; drivers locate it with a UiAutomator
 `resourceId("<id>")` selector. Identifiers are namespaced

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -64,7 +64,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           icon:
               const HeroIcon(HeroIcons.arrowLeft, color: AppTheme.textPrimary),
           onPressed: () => context.pop(),
-        ),
+        ).withAutomationId(AutomationIds.appBarBack),
         title: Text(
           S.of(context)!.settings,
           style: const TextStyle(


### PR DESCRIPTION
## The problem

The settings screen builds its own `AppBar`, and its leading `IconButton`
carried no automation identifier. Every other screen that can be navigated
into exposes `appbar.back`: the shared `MostroAppBar` attaches it, and so
does the key management screen. On settings, the only way out was invisible
to accessibility.

That is enough to stop the automation suite. Mortsom reaches settings
through the drawer to select the Mostro node and add the test relay, and
then cannot leave — its unwind finds neither `appbar.back` nor a bottom bar
and gives up:

```
[FAIL] alice node-and-relay  automation-contract: could not return to the
       order book within 4 back steps: `order.add.fab` did not appear
```

Found while running the harness end to end against a local Polar/regtest
network. With this change both actors complete `mortsom app setup` and go on
to the scenario.

## Why the contract test did not catch it

`test/core/automation/automation_contract_test.dart` checks that identifiers
are declared, unique and namespaced. It cannot see which screens *attach*
them. `appbar.back` was declared and used elsewhere, so the suite stayed
green while one screen had no identified way out.

`docs/automation-contract.md` now says so, because it is the part that is
easy to get wrong: declaring an identifier is not attaching it, and a screen
that builds its own `AppBar` owns naming its leading button.

A test that asserts per-screen attachment would be the real fix for the
class, and needs pumping each screen with its providers — worth doing, but
larger than this and left out deliberately.

## Test plan

- [x] `flutter analyze lib/features/settings/settings_screen.dart` — clean
- [x] `flutter test test/core/automation/automation_contract_test.dart` — 13 passing
- [x] Built and installed on an emulator; `mortsom app setup` reaches
      `node-and-relay ok` for both actors, where it previously failed
- [ ] No visual change intended: the extension applies at the end of the
      expression and does not wrap or re-nest the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automation support for the Settings screen by adding an accessible identifier to its back button.
  - Settings now has a reliably discoverable exit control for automated interactions.

- **Documentation**
  - Clarified that screens must attach their own control identifiers.
  - Documented limitations of declaration checks when controls are not attached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->