### PR TITLE
feat(communities): add Argentina and Brasil trusted communities

### DIFF
--- a/lib/core/config/communities.dart
+++ b/lib/core/config/communities.dart
@@ -22,6 +22,24 @@ class CommunityConfig {
   });
 }
 
+/// Country flag from a region label like '\u{1F1E7}\u{1F1F7} Brasil', when it starts with one.
+String? regionFlag(String? region) {
+  if (region == null || region.isEmpty) return null;
+  final first = region.split(' ').first;
+  final runes = first.runes.toList();
+  final isFlag =
+      runes.isNotEmpty && runes.every((r) => r >= 0x1F1E6 && r <= 0x1F1FF);
+  return isFlag ? first : null;
+}
+
+/// Appends the region flag to a Nostr profile name that does not carry it,
+/// so every community reads the same way regardless of its kind 0 name.
+String nameWithRegionFlag(String name, String? region) {
+  final flag = regionFlag(region);
+  if (flag == null || name.contains(flag)) return name;
+  return '$name $flag';
+}
+
 /// Default Mostro node pubkey (used when user skips community selection).
 const String defaultMostroPubkey =
     '82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390';
@@ -68,6 +86,23 @@ const List<CommunityConfig> trustedCommunities = [
         '000009ee1e4b1dc7add19ab30e4ef854d7b562e208b62686fd9002b50b24dabb',
     region: '\u{1F1FB}\u{1F1EA} Venezuela',
     social: [SocialLink(type: 'telegram', url: 'https://t.me/MostroVzla')],
+  ),
+  CommunityConfig(
+    pubkey:
+        'b3626fe91b602bdbca3673bec0855221f41dc8f6d0e4027e51eaa525d68d87f2',
+    region: '\u{1F1E6}\u{1F1F7} Argentina',
+    social: [
+      SocialLink(type: 'telegram', url: 'https://t.me/lacryptaok'),
+      SocialLink(type: 'x', url: 'https://x.com/LaCryptaOk'),
+    ],
+  ),
+  CommunityConfig(
+    pubkey:
+        '00037abd44e7a846689e230d5446abcd0d56a344fa81fff85c09d1929feda486',
+    region: '\u{1F1E7}\u{1F1F7} Brasil',
+    social: [
+      SocialLink(type: 'telegram', url: 'https://t.me/+GyVD_uH9-Gw0OGRh'),
+    ],
   ),
   CommunityConfig(
     pubkey: defaultMostroPubkey,

--- a/lib/features/community/community.dart
+++ b/lib/features/community/community.dart
@@ -44,8 +44,13 @@ class Community {
     );
   }
 
-  /// Display name: kind 0 name, or region as fallback.
-  String get displayName => name ?? region;
+  /// Display name: kind 0 name, or region as fallback. The region flag is
+  /// appended when the profile name does not already carry it.
+  String get displayName {
+    final profileName = name;
+    if (profileName == null || profileName.isEmpty) return region;
+    return nameWithRegionFlag(profileName, region);
+  }
 
   /// Copy with updated metadata fields.
   Community copyWith({

--- a/lib/features/mostro/mostro_node.dart
+++ b/lib/features/mostro/mostro_node.dart
@@ -1,3 +1,5 @@
+import 'package:mostro_mobile/core/config/communities.dart';
+
 /// Sentinel value to explicitly clear an optional field in [MostroNode.withMetadata].
 const String _clearField = '__clear__';
 
@@ -10,6 +12,10 @@ class MostroNode {
   final bool isTrusted;
   final DateTime? addedAt;
 
+  /// Region label from the trusted config, e.g. '\u{1F1E7}\u{1F1F7} Brasil'.
+  /// Null for custom nodes.
+  final String? region;
+
   MostroNode({
     required this.pubkey,
     this.name,
@@ -18,6 +24,7 @@ class MostroNode {
     this.about,
     this.isTrusted = false,
     this.addedAt,
+    this.region,
   });
 
   /// Sentinel value to explicitly clear a metadata field.
@@ -30,7 +37,13 @@ class MostroNode {
   /// Returns true if [value] is a valid 64-character hex public key.
   static bool isValidHexPubkey(String value) => hexPubkeyRegex.hasMatch(value);
 
-  String get displayName => name ?? pubkey;
+  /// Display name: profile name with the region flag appended when the
+  /// Nostr profile name does not already carry it, or the pubkey as fallback.
+  String get displayName {
+    final current = name;
+    if (current == null || current.isEmpty) return pubkey;
+    return nameWithRegionFlag(current, region);
+  }
 
   /// Returns a copy with updated metadata fields.
   /// - Pass a value to set it.
@@ -50,6 +63,7 @@ class MostroNode {
       about: about == _clearField ? null : (about ?? this.about),
       isTrusted: isTrusted,
       addedAt: addedAt,
+      region: region,
     );
   }
 
@@ -62,6 +76,7 @@ class MostroNode {
       'about': about,
       'isTrusted': isTrusted,
       'addedAt': addedAt?.millisecondsSinceEpoch,
+      'region': region,
     };
   }
 
@@ -76,6 +91,7 @@ class MostroNode {
       addedAt: json['addedAt'] != null
           ? DateTime.fromMillisecondsSinceEpoch(json['addedAt'] as int)
           : null,
+      region: json['region'] as String?,
     );
   }
 

--- a/lib/features/mostro/mostro_nodes_notifier.dart
+++ b/lib/features/mostro/mostro_nodes_notifier.dart
@@ -22,6 +22,7 @@ class MostroNodesNotifier extends StateNotifier<List<MostroNode>> {
         pubkey: entry['pubkey']!,
         name: entry['name'],
         isTrusted: true,
+        region: entry['name'],
       );
     }).toList();
 

--- a/test/features/community/community_ui_test.dart
+++ b/test/features/community/community_ui_test.dart
@@ -57,6 +57,29 @@ void main() {
       expect(community(name: 'Mostro AR').displayName, 'Mostro AR');
     });
 
+    test('appends the region flag when the profile name lacks it', () {
+      Community flagged({String? name}) => Community(
+            pubkey: _pubkey,
+            region: '\u{1F1E7}\u{1F1F7} Brasil',
+            name: name,
+          );
+
+      expect(flagged(name: 'Mostro Brasil').displayName,
+          'Mostro Brasil \u{1F1E7}\u{1F1F7}');
+      expect(flagged(name: 'Mostro Brasil \u{1F1E7}\u{1F1F7}').displayName,
+          'Mostro Brasil \u{1F1E7}\u{1F1F7}');
+      expect(flagged().displayName, '\u{1F1E7}\u{1F1F7} Brasil');
+    });
+
+    test('leaves the name untouched when the region has no flag', () {
+      expect(community(name: 'Mostro AR').displayName, 'Mostro AR');
+      expect(
+        Community(pubkey: _pubkey, region: '\u{1F310} Default', name: 'Mostro')
+            .displayName,
+        'Mostro',
+      );
+    });
+
     test('starts with no metadata and no trade info', () {
       final c = community();
 

--- a/test/features/mostro/mostro_node_test.dart
+++ b/test/features/mostro/mostro_node_test.dart
@@ -48,6 +48,21 @@ void main() {
       expect(node.displayName, 'My Node');
     });
 
+    test('displayName appends the region flag when the name lacks it', () {
+      final node = MostroNode(
+        pubkey: 'abcde12345fghij67890',
+        name: 'Mostro Brasil',
+        isTrusted: true,
+        region: '\u{1F1E7}\u{1F1F7} Brasil',
+      );
+      expect(node.displayName, 'Mostro Brasil \u{1F1E7}\u{1F1F7}');
+
+      final alreadyFlagged = node.withMetadata(
+        name: 'Mostro Brasil \u{1F1E7}\u{1F1F7}',
+      );
+      expect(alreadyFlagged.displayName, 'Mostro Brasil \u{1F1E7}\u{1F1F7}');
+    });
+
     test('displayName returns pubkey when no name', () {
       final node = MostroNode(pubkey: 'abcde12345fghij67890');
       expect(node.displayName, 'abcde12345fghij67890');


### PR DESCRIPTION
- Add MostrAR (Argentina) with Telegram and X links
- Add Mostro Brasil with Telegram link
- Both placed before the default Mostro entry
- Append the region flag to the display name in the community cards and the Mostro node selector when the Nostr profile name does not already include it