### PR TITLE
feat(notifications): open the chat when a chat notification is tapped

### DIFF
--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -66,6 +66,40 @@ Future<String?> getNotificationLaunchOrderId() async {
   return null;
 }
 
+/// Payload `type` marking a peer-to-peer (buyer <-> seller) chat message.
+const String peerChatPayloadType = 'peer_chat';
+
+/// Payload `type` marking an admin/solver DM, which belongs to a dispute chat.
+const String adminDmPayloadType = 'admin_dm';
+
+/// Builds the notification payload for a notification about [orderId].
+///
+/// Chat actions get a structured JSON payload so the tap handler can open the
+/// conversation itself; every other action keeps the legacy plain orderId
+/// payload, which resolves to the trade detail screen.
+String buildNotificationPayload({
+  required mostro_action.Action action,
+  required String? orderId,
+  required String? disputeId,
+}) {
+  if (action == mostro_action.Action.chatMessage) {
+    return jsonEncode({
+      'type': peerChatPayloadType,
+      'orderId': orderId,
+    });
+  }
+
+  if (action == mostro_action.Action.sendDm) {
+    return jsonEncode({
+      'type': adminDmPayloadType,
+      'orderId': orderId,
+      'disputeId': disputeId,
+    });
+  }
+
+  return orderId ?? '';
+}
+
 /// Resolves the navigation route from a notification payload string.
 ///
 /// Returns the route path to navigate to. Pure function, no side effects.
@@ -84,7 +118,14 @@ String resolveNotificationRoute(String? payload) {
     final orderId = decoded['orderId'] as String?;
     final disputeId = decoded['disputeId'] as String?;
 
-    if (type == 'admin_dm' && orderId != null) {
+    // Chat notifications open the conversation they belong to.
+    if (type == peerChatPayloadType && orderId != null) {
+      return '/chat_room/$orderId';
+    }
+
+    if (type == adminDmPayloadType && orderId != null) {
+      // Solver (dispute) chat when the session knows its dispute; otherwise
+      // the trade detail is the only place the user can reach it from.
       if (disputeId != null) {
         return '/dispute_details/$disputeId';
       }
@@ -172,14 +213,13 @@ Future<void> showLocalNotification(NostrEvent event) async {
       ),
     );
 
-    // Build payload: JSON for admin DMs, plain orderId for standard notifications
-    final notificationPayload = notificationData.action == mostro_action.Action.sendDm
-        ? jsonEncode({
-            'type': 'admin_dm',
-            'orderId': mostroMessage.id,
-            'disputeId': matchingSession?.disputeId,
-          })
-        : mostroMessage.id;
+    // Build payload: JSON for chat notifications (so the tap opens the
+    // conversation), plain orderId for standard trade notifications.
+    final notificationPayload = buildNotificationPayload(
+      action: notificationData.action,
+      orderId: mostroMessage.id,
+      disputeId: matchingSession?.disputeId,
+    );
 
     // Unique id per event so each notification is independent: dismissing one
     // does not suppress the heads-up of the next (which was the observed bug

--- a/lib/features/notifications/widgets/notification_item.dart
+++ b/lib/features/notifications/widgets/notification_item.dart
@@ -9,6 +9,7 @@ import 'package:mostro_mobile/features/notifications/widgets/notification_type_i
 import 'package:mostro_mobile/features/notifications/widgets/notification_content.dart';
 import 'package:mostro_mobile/features/notifications/widgets/notification_menu.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
 
 class NotificationItem extends ConsumerWidget {
@@ -105,9 +106,14 @@ class NotificationItem extends ConsumerWidget {
         case mostro_action.Action.cooperativeCancelNoFiatByPeer:
         case mostro_action.Action.cooperativeCancelFiatSentByYou:
         case mostro_action.Action.cooperativeCancelFiatSentByPeer:
-        case mostro_action.Action.sendDm:
-        case mostro_action.Action.chatMessage:
           context.push('/trade_detail/${notification.orderId}');
+          break;
+        case mostro_action.Action.chatMessage:
+          // Peer-to-peer chat message: open the conversation itself.
+          context.push('/chat_room/${notification.orderId}');
+          break;
+        case mostro_action.Action.sendDm:
+          _handleSolverDmTap(context, ref);
           break;
         case mostro_action.Action.cantDo:
         case mostro_action.Action.rateReceived:
@@ -140,6 +146,21 @@ class NotificationItem extends ConsumerWidget {
           _showBondSlashedDialog(context);
           break;
       }
+    }
+  }
+
+  /// Opens the solver (dispute) chat for an admin DM. Falls back to the trade
+  /// detail when the session does not know its dispute id yet, since the
+  /// dispute chat cannot be addressed without it.
+  void _handleSolverDmTap(BuildContext context, WidgetRef ref) {
+    final orderId = notification.orderId;
+    if (orderId == null) return;
+
+    final disputeId = ref.read(sessionProvider(orderId))?.disputeId;
+    if (disputeId != null && disputeId.isNotEmpty) {
+      context.push('/dispute_details/$disputeId');
+    } else {
+      context.push('/trade_detail/$orderId');
     }
   }
 

--- a/test/features/notifications/services/background_notification_dm_detection_test.dart
+++ b/test/features/notifications/services/background_notification_dm_detection_test.dart
@@ -251,11 +251,75 @@ void main() {
       expect(resolveNotificationRoute(payload), '/notifications');
     });
 
-    test('routes P2P chat notification (plain orderId) to trade detail', () {
+    test('routes peer_chat notification to the P2P chat room', () {
+      final payload = jsonEncode({
+        'type': 'peer_chat',
+        'orderId': 'order-chat-1',
+      });
+      expect(resolveNotificationRoute(payload), '/chat_room/order-chat-1');
+    });
+
+    test('routes peer_chat without orderId to notifications', () {
+      final payload = jsonEncode({'type': 'peer_chat'});
+      expect(resolveNotificationRoute(payload), '/notifications');
+    });
+
+    test('routes admin_dm with disputeId to the solver chat', () {
+      final payload = jsonEncode({
+        'type': 'admin_dm',
+        'orderId': 'order-chat-2',
+        'disputeId': 'dispute-chat-2',
+      });
+      expect(
+        resolveNotificationRoute(payload),
+        '/dispute_details/dispute-chat-2',
+      );
+    });
+
+    test('legacy plain orderId payload still opens the trade detail', () {
       expect(
         resolveNotificationRoute('p2p-chat-order-id'),
         '/trade_detail/p2p-chat-order-id',
       );
+    });
+  });
+
+  group('buildNotificationPayload', () {
+    test('peer chat messages carry the peer_chat type', () {
+      final payload = buildNotificationPayload(
+        action: Action.chatMessage,
+        orderId: 'order-1',
+        disputeId: null,
+      );
+      expect(jsonDecode(payload), {
+        'type': 'peer_chat',
+        'orderId': 'order-1',
+      });
+      expect(resolveNotificationRoute(payload), '/chat_room/order-1');
+    });
+
+    test('admin DMs carry the admin_dm type with the disputeId', () {
+      final payload = buildNotificationPayload(
+        action: Action.sendDm,
+        orderId: 'order-2',
+        disputeId: 'dispute-2',
+      );
+      expect(jsonDecode(payload), {
+        'type': 'admin_dm',
+        'orderId': 'order-2',
+        'disputeId': 'dispute-2',
+      });
+      expect(resolveNotificationRoute(payload), '/dispute_details/dispute-2');
+    });
+
+    test('non-chat actions keep the plain orderId payload', () {
+      final payload = buildNotificationPayload(
+        action: Action.fiatSentOk,
+        orderId: 'order-3',
+        disputeId: null,
+      );
+      expect(payload, 'order-3');
+      expect(resolveNotificationRoute(payload), '/trade_detail/order-3');
     });
   });
 

--- a/test/features/notifications/widgets/notification_item_tap_test.dart
+++ b/test/features/notifications/widgets/notification_item_tap_test.dart
@@ -1,3 +1,4 @@
+import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter/material.dart' hide Action;
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,7 +10,11 @@ import 'package:mostro_mobile/data/repositories/notifications_history_repository
 import 'package:mostro_mobile/features/notifications/widgets/notification_content.dart';
 import 'package:mostro_mobile/features/notifications/widgets/notification_item.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/shared/providers/notifications_history_repository_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 
 /// Minimal repository fake: the tap handler only calls markAsRead.
 class _FakeNotificationsRepository implements NotificationsRepository {
@@ -65,6 +70,94 @@ NotificationModel _cantDo() => NotificationModel(
       data: const {},
     );
 
+NotificationModel _chatMessage(String orderId) => NotificationModel(
+      id: 'n-chat',
+      type: NotificationType.system,
+      action: Action.chatMessage,
+      title: 'notification_chat_message_title',
+      message: 'notification_chat_message_message',
+      timestamp: DateTime.now(),
+      orderId: orderId,
+      data: const {},
+    );
+
+NotificationModel _solverDm(String orderId) => NotificationModel(
+      id: 'n-dm',
+      type: NotificationType.system,
+      action: Action.sendDm,
+      title: 'notification_admin_dm_title',
+      message: 'notification_admin_dm_message',
+      timestamp: DateTime.now(),
+      orderId: orderId,
+      data: const {},
+    );
+
+Session _session({required String orderId, String? disputeId}) => Session(
+      masterKey: NostrKeyPairs(private: NostrUtils.generatePrivateKey()),
+      tradeKey: NostrKeyPairs(private: NostrUtils.generatePrivateKey()),
+      keyIndex: 1,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+      orderId: orderId,
+      disputeId: disputeId,
+    );
+
+/// Router harness that records the destination of a tap instead of building
+/// the real (provider-heavy) destination screens.
+Widget _wrapWithRouter(
+  NotificationModel notification, {
+  required List<String> visited,
+  Session? session,
+}) {
+  Widget probe(String label, GoRouterState state) {
+    visited.add(state.uri.toString());
+    return Scaffold(body: Text(label));
+  }
+
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) =>
+            Scaffold(body: NotificationItem(notification: notification)),
+      ),
+      GoRoute(
+        path: '/chat_room/:orderId',
+        builder: (_, state) => probe('chat_room', state),
+      ),
+      GoRoute(
+        path: '/dispute_details/:disputeId',
+        builder: (_, state) => probe('dispute_details', state),
+      ),
+      GoRoute(
+        path: '/trade_detail/:orderId',
+        builder: (_, state) => probe('trade_detail', state),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      notificationsRepositoryProvider
+          .overrideWithValue(_FakeNotificationsRepository()),
+      if (session != null)
+        sessionProvider(session.orderId!).overrideWith((ref) => session),
+    ],
+    child: MaterialApp.router(
+      localizationsDelegates: const [
+        S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      locale: const Locale('en'),
+      routerConfig: router,
+    ),
+  );
+}
+
 Widget _wrap(NotificationModel notification) {
   return ProviderScope(
     overrides: [
@@ -106,6 +199,60 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+
+  group('NotificationItem chat notifications open the chat', () {
+    testWidgets('a peer chat message opens the P2P chat room', (tester) async {
+      final visited = <String>[];
+      await tester.pumpWidget(
+        _wrapWithRouter(_chatMessage('order-chat'), visited: visited),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(NotificationContent), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(visited, ['/chat_room/order-chat']);
+    });
+
+    testWidgets('a solver DM opens the dispute chat when a dispute is known',
+        (tester) async {
+      final visited = <String>[];
+      await tester.pumpWidget(
+        _wrapWithRouter(
+          _solverDm('order-dispute'),
+          visited: visited,
+          session: _session(
+            orderId: 'order-dispute',
+            disputeId: 'dispute-42',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(NotificationContent), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(visited, ['/dispute_details/dispute-42']);
+    });
+
+    testWidgets('a solver DM falls back to the trade detail without a dispute',
+        (tester) async {
+      final visited = <String>[];
+      await tester.pumpWidget(
+        _wrapWithRouter(
+          _solverDm('order-nodispute'),
+          visited: visited,
+          session: _session(orderId: 'order-nodispute'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(NotificationContent), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(visited, ['/trade_detail/order-nodispute']);
     });
   });
 }


### PR DESCRIPTION
## Problem

Tapping a chat notification did not open the chat. Both chat kinds landed on the trade detail screen:

- **P2P chat** (`Action.chatMessage`) built a plain-orderId payload, which `resolveNotificationRoute` maps to `/trade_detail/:orderId`.
- **Solver/dispute chat** (`Action.sendDm`) already had a JSON payload, but the in-app notification list ignored it and pushed `/trade_detail/:orderId` too.

## Change

Chat notifications now carry a structured payload and route to the conversation itself:

| Action | Payload | Route |
|---|---|---|
| `chatMessage` | `{"type":"peer_chat","orderId":…}` | `/chat_room/:orderId` |
| `sendDm` | `{"type":"admin_dm","orderId":…,"disputeId":…}` | `/dispute_details/:disputeId` (→ `DisputeChatScreen`) |
| everything else | plain `orderId` (unchanged) | `/trade_detail/:orderId` |

Payload construction was extracted into `buildNotificationPayload()` so the payload and the route resolution are covered by the same tests.

The in-app notification list (`NotificationItem`) follows the same dispatch: `chatMessage` opens the P2P chat room, `sendDm` resolves the dispute id from the session and opens the solver chat, falling back to the trade detail when the session has no dispute id yet.

Backward compatible: the legacy plain-orderId payload still resolves to the trade detail, so notifications posted before this change keep working. Both screens already render graceful error states when the session or peer is missing.

## Test plan

- [x] `flutter analyze` — no new issues (the 2 remaining are pre-existing `containsSemantics` deprecations in `automation_contract_test.dart`)
- [x] `flutter test` — 1109 passing
- [x] New unit tests for `buildNotificationPayload` + `resolveNotificationRoute` (`peer_chat`, `admin_dm` with/without dispute, legacy payload)
- [x] New widget tests asserting `NotificationItem` navigates to `/chat_room`, `/dispute_details`, and the no-dispute fallback (verified RED before the fix)
- [ ] Manual: receive a P2P message with the app backgrounded, tap the notification → chat room opens
- [ ] Manual: receive a solver message on a disputed order, tap the notification → dispute chat opens
- [ ] Manual: same two flows from a cold start (app terminated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification taps now open the relevant chat room for peer messages.
  * Admin direct-message notifications open dispute details when available, or trade details as a fallback.
  * Notification payloads now support more precise routing while preserving existing behavior for standard notifications.

* **Bug Fixes**
  * Improved notification navigation when dispute information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->