### PR TITLE
perf: reuse the shared SubscriptionManager in RelaysNotifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ The app follows a specific initialization order in `appInitializerProvider`:
 - SessionNotifier must complete initialization before SubscriptionManager setup
 - SubscriptionManager uses `fireImmediately: false` to prevent premature execution
 - Proper sequence ensures orders appear consistently in UI across app restarts
+- There is exactly **one** `SubscriptionManager`, owned by `subscriptionManagerProvider`. `RelaysNotifier` borrows it (`ref.read`) for the kind 10002 relay-list stream and must never construct its own instance nor dispose the shared one — a private copy re-issues every orders/chat/dispute REQ on every relay (regression test: `test/features/relays/relays_notifier_subscription_manager_test.dart`). Because `RelaysNotifier` is read during bootstrap, the shared manager may be created before `SessionNotifier.init()`; that is safe since `init()` always emits state, which the manager's session listener turns into the initial subscriptions
 
 ## Timeout Detection & Orphan Session Prevention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ The app follows a specific initialization order in `appInitializerProvider`:
 - SubscriptionManager uses `fireImmediately: false` to prevent premature execution
 - Proper sequence ensures orders appear consistently in UI across app restarts
 - There is exactly **one** `SubscriptionManager`, owned by `subscriptionManagerProvider`. `RelaysNotifier` borrows it (`ref.read`) for the kind 10002 relay-list stream and must never construct its own instance nor dispose the shared one — a private copy re-issues every orders/chat/dispute REQ on every relay (regression test: `test/features/relays/relays_notifier_subscription_manager_test.dart`). Because `RelaysNotifier` is read during bootstrap, the shared manager may be created before `SessionNotifier.init()`; that is safe since `init()` always emits state, which the manager's session listener turns into the initial subscriptions
+- `SubscriptionType.relayList` is the one subscription `SubscriptionManager` cannot rebuild from sessions (`_createFilterForType` returns null for it), so it is tracked separately: `subscribeToMostroRelayList()` remembers the pubkey and `subscribeAll()` restores the REQ. Backgrounding goes through `suspend()`/`resume()` rather than `unsubscribeAll()`/`subscribeAll()`, so a late relay-sync retry cannot re-open a REQ while the background service owns connectivity (regression test: `test/features/subscriptions/subscription_manager_relay_list_lifecycle_test.dart`)
 
 ## Timeout Detection & Orphan Session Prevention
 

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -7,6 +7,7 @@ import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/core/models/relay_list_event.dart';
 import 'package:mostro_mobile/features/settings/settings_notifier.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 import 'relay.dart';
@@ -29,7 +30,12 @@ class RelayValidationResult {
 class RelaysNotifier extends StateNotifier<List<Relay>> {
   final SettingsNotifier settings;
   final Ref ref;
-  SubscriptionManager? _subscriptionManager;
+  /// The app-wide manager owned by [subscriptionManagerProvider]. This
+  /// notifier only borrows its relay-list stream; it must never build its
+  /// own instance (that duplicated every orders/chat/dispute REQ on every
+  /// relay) nor dispose the shared one.
+  SubscriptionManager get _subscriptionManager =>
+      ref.read(subscriptionManagerProvider);
   StreamSubscription<RelayListEvent>? _relayListSubscription;
   Timer? _settingsWatchTimer;
   Timer? _retryTimer;
@@ -385,10 +391,8 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   /// Initialize Mostro relay synchronization
   void _initMostroRelaySync() {
     try {
-      _subscriptionManager = SubscriptionManager(ref);
-      
       // Subscribe to relay list events
-      _relayListSubscription = _subscriptionManager!.relayList.listen(
+      _relayListSubscription = _subscriptionManager.relayList.listen(
         (relayListEvent) {
           _handleMostroRelayListUpdate(relayListEvent);
         },
@@ -418,7 +422,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
       logger.i('Syncing relays with Mostro instance: $mostroPubkey');
       
       // Cancel any existing relay list subscription before creating new one
-      _subscriptionManager?.unsubscribeFromMostroRelayList();
+      _subscriptionManager.unsubscribeFromMostroRelayList();
       
       // Clean existing Mostro relays from state to prevent contamination
       await _cleanMostroRelaysFromState();
@@ -428,7 +432,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
         await _waitForNostrService();
         
         // Subscribe to the new Mostro instance
-        _subscriptionManager?.subscribeToMostroRelayList(mostroPubkey);
+        _subscriptionManager.subscribeToMostroRelayList(mostroPubkey);
         logger.i('Successfully subscribed to relay list events for Mostro: $mostroPubkey');
         
         // Schedule a retry in case the subscription doesn't work immediately
@@ -454,7 +458,7 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
       try {
         if (settings.state.mostroPublicKey == mostroPubkey) {
           logger.i('Retrying relay sync for Mostro: $mostroPubkey');
-          _subscriptionManager?.subscribeToMostroRelayList(mostroPubkey);
+          _subscriptionManager.subscribeToMostroRelayList(mostroPubkey);
         }
       } catch (e) {
         logger.w('Retry sync failed: $e');
@@ -850,7 +854,6 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   @override
   void dispose() {
     _relayListSubscription?.cancel();
-    _subscriptionManager?.dispose();
     _settingsWatchTimer?.cancel();
     _retryTimer?.cancel();  // Cancel retry timer to prevent leak
     super.dispose();

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -47,6 +47,23 @@ class SubscriptionManager {
   Stream<NostrEvent> get disputeChat => _disputeChatController.stream;
   Stream<RelayListEvent> get relayList => _relayListController.stream;
 
+  /// Session-derived subscription types. [SubscriptionType.relayList] is
+  /// driven by the configured Mostro instance rather than by sessions, so the
+  /// session-driven paths must leave it alone — tearing it down there stops
+  /// relay discovery for the rest of the app's life.
+  static Iterable<SubscriptionType> get _sessionSubscriptionTypes =>
+      SubscriptionType.values.where((t) => t != SubscriptionType.relayList);
+
+  /// Last Mostro pubkey asked for on the relay-list stream. [subscribeAll]
+  /// rebuilds every other subscription from sessions, but the relay list has
+  /// no session to rebuild it from, so it has to be remembered here.
+  String? _relayListPubkey;
+
+  /// True between [suspend] and [resume]: the app is backgrounded and the
+  /// background service owns the filters. Work scheduled before the switch
+  /// (a relay sync retry, say) must not re-open a REQ behind its back.
+  bool _isSuspended = false;
+
   SubscriptionManager(this.ref) {
     _initSessionListener();
     // Ensure resources are released with provider/container lifecycle
@@ -139,13 +156,13 @@ class SubscriptionManager {
       return;
     }
 
-    for (final type in SubscriptionType.values) {
+    for (final type in _sessionSubscriptionTypes) {
       unawaited(_updateSubscription(type, sessions));
     }
   }
 
   void _clearAllSubscriptions() {
-    for (final type in SubscriptionType.values) {
+    for (final type in _sessionSubscriptionTypes) {
       unsubscribeByType(type);
     }
   }
@@ -375,6 +392,32 @@ class SubscriptionManager {
     unsubscribeAll();
     final currentSessions = ref.read(sessionNotifierProvider);
     _updateAllSubscriptions(currentSessions);
+    _restoreRelayListSubscription();
+  }
+
+  /// Brings the app's subscriptions down for backgrounding. Separate from
+  /// [unsubscribeAll] so that pending callbacks cannot re-open a REQ while the
+  /// background service owns the filters.
+  void suspend() {
+    _isSuspended = true;
+    unsubscribeAll();
+  }
+
+  /// Brings the app's subscriptions back up on foreground, relay list included.
+  void resume() {
+    _isSuspended = false;
+    subscribeAll();
+  }
+
+  /// Re-opens the relay-list subscription after a teardown that cannot rebuild
+  /// it from sessions. No-op when nothing ever asked for one, while suspended,
+  /// or when one is already open.
+  void _restoreRelayListSubscription() {
+    final mostroPubkey = _relayListPubkey;
+    if (mostroPubkey == null || _isSuspended) return;
+    if (_subscriptions.containsKey(SubscriptionType.relayList)) return;
+    logger.i('Restoring relay list subscription for Mostro: $mostroPubkey');
+    subscribeToMostroRelayList(mostroPubkey);
   }
 
   void unsubscribeAll() {
@@ -386,6 +429,14 @@ class SubscriptionManager {
   /// Subscribes to kind 10002 relay list events from a specific Mostro instance.
   /// This is used to automatically sync relays with the configured Mostro instance.
   void subscribeToMostroRelayList(String mostroPubkey) {
+    // Remembered even while suspended, so [resume] can re-open it.
+    _relayListPubkey = mostroPubkey;
+    if (_isSuspended) {
+      logger.i(
+          'App is backgrounded; deferring relay list subscription for Mostro: $mostroPubkey');
+      return;
+    }
+
     try {
       final filter = NostrFilter(
         kinds: [10002],
@@ -444,6 +495,7 @@ class SubscriptionManager {
 
   /// Unsubscribes from Mostro relay list events
   void unsubscribeFromMostroRelayList() {
+    _relayListPubkey = null;
     unsubscribeByType(SubscriptionType.relayList);
     logger.i('Unsubscribed from Mostro relay list');
   }

--- a/lib/services/lifecycle_manager.dart
+++ b/lib/services/lifecycle_manager.dart
@@ -66,7 +66,10 @@ class LifecycleManager extends WidgetsBindingObserver {
       await Future.delayed(const Duration(milliseconds: 500));
 
       final subscriptionManager = ref.read(subscriptionManagerProvider);
-      subscriptionManager.subscribeAll();
+      // resume() rather than subscribeAll(): the relay-list subscription is
+      // not derived from sessions, so subscribeAll() alone cannot bring it
+      // back after _switchToBackground() tore it down.
+      subscriptionManager.resume();
 
       // Reinitialize the mostro service
       logger.i("Reinitializing MostroService");
@@ -132,7 +135,7 @@ class LifecycleManager extends WidgetsBindingObserver {
           logger.e('Failed to persist background filters: $e');
         }
 
-        subscriptionManager.unsubscribeAll();
+        subscriptionManager.suspend();
 
         // Transfer active subscriptions to background service
         final backgroundService = ref.read(backgroundServiceProvider);
@@ -142,6 +145,9 @@ class LifecycleManager extends WidgetsBindingObserver {
         backgroundService.subscribe(activeFilters);
       } else {
         _isInBackground = true;
+        // Still suspend: a pending relay sync retry must not re-open a REQ
+        // while the background service owns connectivity.
+        subscriptionManager.suspend();
         logger.w("No active subscriptions to transfer to background service");
         // Clear any previously persisted filters to prevent stale subscriptions
         // on service revival

--- a/test/features/relays/relays_notifier_subscription_manager_test.dart
+++ b/test/features/relays/relays_notifier_subscription_manager_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/core/config.dart';
+import 'package:mostro_mobile/core/models/relay_list_event.dart';
+import 'package:mostro_mobile/features/relays/relay.dart';
+import 'package:mostro_mobile/features/relays/relays_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../../mocks.mocks.dart';
+
+/// Regression guard: `RelaysNotifier` must consume the app-wide
+/// `subscriptionManagerProvider` instead of constructing its own
+/// `SubscriptionManager`. A private instance duplicated every orders/chat/
+/// dispute REQ on every relay (and every history replay) for the lifetime of
+/// the app, since nothing consumed those streams.
+void main() {
+  late StreamController<RelayListEvent> relayListController;
+  late MockSubscriptionManagerSpy sharedManager;
+  late ProviderContainer container;
+
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    relayListController = StreamController<RelayListEvent>.broadcast();
+    sharedManager = MockSubscriptionManagerSpy();
+    when(sharedManager.relayList)
+        .thenAnswer((_) => relayListController.stream);
+    container = ProviderContainer(overrides: [
+      sharedPreferencesProvider
+          .overrideWithValue(SharedPreferencesAsync()),
+      subscriptionManagerProvider.overrideWithValue(sharedManager),
+    ]);
+  });
+
+  /// The notifier's deferred sync polls NostrService for up to 10 s and then
+  /// schedules a 10 s retry; let those timers elapse so the test binding's
+  /// "no pending timers" invariant holds.
+  Future<void> tearDownContainer(WidgetTester tester) async {
+    container.dispose();
+    await relayListController.close();
+    await tester.pump(const Duration(seconds: 30));
+  }
+
+  testWidgets(
+      'applies relay lists received through the shared SubscriptionManager',
+      (tester) async {
+    // Arrange
+    container.read(relaysProvider);
+    await tester.pump();
+
+    // Act
+    relayListController.add(RelayListEvent(
+      relays: const ['wss://relay.mostro.test'],
+      publishedAt: DateTime.now(),
+      authorPubkey: Config.mostroPubKey,
+    ));
+    await tester.pump();
+
+    // Assert
+    final relays = container.read(relaysProvider);
+    expect(
+      relays.where((r) => r.url == 'wss://relay.mostro.test'),
+      hasLength(1),
+      reason: 'the relay list must be consumed from the shared manager, '
+          'not from a privately constructed SubscriptionManager',
+    );
+    expect(
+      relays.firstWhere((r) => r.url == 'wss://relay.mostro.test').source,
+      RelaySource.mostro,
+    );
+
+    await tearDownContainer(tester);
+  });
+
+  testWidgets('does not dispose the shared SubscriptionManager it borrows',
+      (tester) async {
+    // Arrange
+    container.read(relaysProvider);
+    await tester.pump();
+
+    // Act
+    await tearDownContainer(tester);
+
+    // Assert
+    verifyNever(sharedManager.dispose());
+  });
+}

--- a/test/features/subscriptions/subscription_manager_relay_list_lifecycle_test.dart
+++ b/test/features/subscriptions/subscription_manager_relay_list_lifecycle_test.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+
+import '../../mocks.mocks.dart';
+
+/// The relay-list subscription is the one subscription `SubscriptionManager`
+/// cannot rebuild from sessions: `_createFilterForType` returns null for it and
+/// `subscribeAll()` therefore leaves it closed. That was harmless while
+/// `RelaysNotifier` owned a private manager, but once it borrows the app-wide
+/// one, `LifecycleManager` tears it down on every background switch.
+class _FixedSettingsNotifier extends SettingsNotifier {
+  _FixedSettingsNotifier() : super(MockSharedPreferencesAsync()) {
+    state = Settings(
+      relays: const [],
+      fullPrivacyMode: false,
+      mostroPublicKey: 'mostro-pubkey',
+    );
+  }
+}
+
+/// Session list the manager can read without touching storage.
+class _FakeSessionNotifier extends SessionNotifier {
+  _FakeSessionNotifier(Ref ref)
+      : super(ref, MockSessionStorage(), MockSettings()) {
+    state = const [];
+  }
+
+  void emit(List<Session> sessions) => state = sessions;
+}
+
+void main() {
+  const pubkey = 'mostro-pubkey';
+
+  late MockNostrService nostrService;
+  late MockOpenOrdersRepository orderRepository;
+  late ProviderContainer container;
+  late _FakeSessionNotifier sessions;
+  late SubscriptionManager manager;
+  var nextSubscriptionId = 0;
+
+  setUp(() {
+    nostrService = MockNostrService();
+    orderRepository = MockOpenOrdersRepository();
+
+    nextSubscriptionId = 0;
+    when(nostrService.subscribeToEvents(any)).thenAnswer((invocation) {
+      // The real service stamps the id while serialising the REQ; without one
+      // Subscription.cancel() throws on `subscriptionId!`.
+      final request = invocation.positionalArguments.first as NostrRequest;
+      request.subscriptionId ??= 'sub-${nextSubscriptionId++}';
+      return const Stream<NostrEvent>.empty();
+    });
+    when(nostrService.unsubscribe(any)).thenAnswer((_) async {});
+    when(orderRepository.mostroInstanceStream)
+        .thenAnswer((_) => const Stream<NostrEvent>.empty());
+    when(orderRepository.mostroInstance).thenReturn(null);
+
+    container = ProviderContainer(overrides: [
+      nostrServiceProvider.overrideWithValue(nostrService),
+      orderRepositoryProvider.overrideWithValue(orderRepository),
+      settingsProvider.overrideWith((ref) => _FixedSettingsNotifier()),
+      sessionNotifierProvider.overrideWith((ref) {
+        sessions = _FakeSessionNotifier(ref);
+        return sessions;
+      }),
+    ]);
+  });
+
+  tearDown(() {
+    // Release the REQs while the container can still resolve NostrService;
+    // SubscriptionManager.dispose() runs after the container is torn down.
+    manager.unsubscribeAll();
+    container.dispose();
+  });
+
+  SubscriptionManager buildManager() {
+    // Materialise the session notifier before the manager listens to it.
+    container.read(sessionNotifierProvider);
+    manager = container.read(subscriptionManagerProvider);
+    return manager;
+  }
+
+  bool hasRelayList(SubscriptionManager m) =>
+      m.hasActiveSubscription(SubscriptionType.relayList);
+
+  group('relay-list subscription across the lifecycle', () {
+    // Regression test for the P1 raised on #683: `subscribeAll()` cannot
+    // rebuild the relay list, so a plain background/foreground cycle left the
+    // app permanently deaf to kind 10002 updates.
+    test('survives a background/foreground cycle', () {
+      buildManager();
+      manager.subscribeToMostroRelayList(pubkey);
+      expect(hasRelayList(manager), isTrue);
+
+      manager.suspend();
+      expect(hasRelayList(manager), isFalse,
+          reason: 'backgrounding must release the REQ');
+
+      manager.resume();
+      expect(hasRelayList(manager), isTrue,
+          reason: 'foreground recovery must re-open the relay list');
+    });
+
+    test('survives a bare subscribeAll (relay health recovery)', () {
+      buildManager();
+      manager.subscribeToMostroRelayList(pubkey);
+
+      manager.subscribeAll();
+
+      expect(hasRelayList(manager), isTrue);
+    });
+
+    // Sessions are unrelated to relay discovery; losing every session must not
+    // stop the app from learning about relays.
+    test('survives the session list going empty', () async {
+      buildManager();
+      manager.subscribeToMostroRelayList(pubkey);
+
+      sessions.emit([]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(hasRelayList(manager), isTrue);
+    });
+
+    // Raised by CodeRabbit on #683: the retry timer in `RelaysNotifier` can
+    // fire after the app has been backgrounded.
+    test('a pending retry while backgrounded does not re-open the REQ', () {
+      buildManager();
+      manager.subscribeToMostroRelayList(pubkey);
+      manager.suspend();
+
+      // What RelaysNotifier._scheduleRetrySync() does 10 s later.
+      manager.subscribeToMostroRelayList(pubkey);
+
+      expect(hasRelayList(manager), isFalse,
+          reason: 'the background service owns connectivity while suspended');
+
+      manager.resume();
+      expect(hasRelayList(manager), isTrue,
+          reason: 'the deferred request must still be honoured on resume');
+    });
+
+    test('an explicit unsubscribe is not undone by a later resume', () {
+      buildManager();
+      manager.subscribeToMostroRelayList(pubkey);
+      manager.unsubscribeFromMostroRelayList();
+
+      manager.suspend();
+      manager.resume();
+
+      expect(hasRelayList(manager), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`RelaysNotifier` constructed its **own** `SubscriptionManager` (`relays_notifier.dart:388`) just to listen to the kind 10002 relay-list stream. That constructor registers the session listener and opens the orders/chat/disputeChat REQs on every relay, so:

- every subscription was issued **twice** on every relay, and re-issued twice on every session change (each one a full gift-wrap history replay, since the orders filter has no `since`);
- nothing consumed the duplicate `orders`/`chat`/`disputeChat` streams — pure wasted parsing on the main isolate;
- the private copy was tied to `relaysProvider`, so `LifecycleManager` never unsubscribed it when the app went to background.

This is item **1.1** of the performance plan (users reporting the app getting slow to respond).

## Changes

- `RelaysNotifier` now borrows the app-wide instance via `ref.read(subscriptionManagerProvider)` and no longer disposes it (the provider owns it).
- New regression test `test/features/relays/relays_notifier_subscription_manager_test.dart`: a `RelayListEvent` pushed through the shared manager must land in `relaysProvider` state, and disposing the notifier must not dispose the shared manager. The first assertion fails on `main`.
- `CLAUDE.md`: documents the single-owner rule and why it is safe for the shared manager to be created during bootstrap (`SessionNotifier.init()` always emits, and the manager's session listener builds the initial subscriptions).

## Init-order note

Because `RelaysNotifier` is read during bootstrap, the shared manager is now created before `appInitializerProvider` reads it (that read becomes a no-op). Side effects are identical to what the orphan instance already caused (session listener, `orderRepositoryProvider` creation); only the duplicate disappears.

## Test plan

- [x] New regression test: RED on `main`, GREEN here
- [x] `flutter test test/features/relays/ test/services/mostro_service_test.dart` — 84/84
- [x] `flutter analyze` — no new issues
- [x] Full `flutter test` — only pre-existing failures in `dispute_resolution_message_test.dart` caused by stale local `lib/generated/` (pass after `flutter gen-l10n`; unrelated)
- [ ] Manual: count REQs per relay on cold start (should halve) and confirm relay-list sync (Settings → Relays) still discovers the Mostro relays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay updates by using the app-wide subscription manager consistently.
  * Prevented relay notifications from accidentally disposing shared subscription resources.

* **Tests**
  * Added coverage confirming relay-list events are received and processed correctly.
  * Added regression checks for preserving shared subscription manager availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->