### PR TITLE
perf: build AppTheme.theme once instead of per access

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -88,7 +88,12 @@ class AppTheme {
       EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0);
   static const EdgeInsets largeMargin = EdgeInsets.all(20.0);
 
-  static ThemeData get theme {
+  /// Built once: `ThemeData` is immutable and this is read on every rebuild
+  /// of the root `MaterialApp`, the drawer and the reactive buttons. A getter
+  /// rebuilt the whole theme (plus ~20 `GoogleFonts` descriptors) per access.
+  static final ThemeData theme = _buildTheme();
+
+  static ThemeData _buildTheme() {
     return ThemeData(
       hoverColor: dark1,
       primaryColor: mostroGreen,
@@ -235,7 +240,7 @@ class AppTheme {
   }
 
   // helpers for shadows
-  static List<BoxShadow> get cardShadow => [
+  static final List<BoxShadow> cardShadow = List.unmodifiable([
         BoxShadow(
           color: Colors.black.withValues(alpha: 0.7),
           blurRadius: 15,
@@ -248,14 +253,14 @@ class AppTheme {
           offset: const Offset(0, -1),
           spreadRadius: 0,
         ),
-      ];
+      ]);
 
-  static List<BoxShadow> get buttonShadow => [
+  static final List<BoxShadow> buttonShadow = List.unmodifiable([
         BoxShadow(
           color: Colors.black.withValues(alpha: 0.4),
           blurRadius: 6,
           offset: const Offset(0, 3),
           spreadRadius: -2,
         ),
-      ];
+      ]);
 }

--- a/test/core/app_theme_test.dart
+++ b/test/core/app_theme_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mostro_mobile/core/app_theme.dart';
+
+/// `AppTheme.theme` is read on every rebuild of the root `MaterialApp`, the
+/// drawer, reactive buttons and several screens. It used to be a getter that
+/// built a full `ThemeData` (with ~20 `GoogleFonts` descriptor allocations)
+/// on each access; the theme is immutable, so it must be built once.
+void main() {
+  setUpAll(() {
+    // Building the theme registers GoogleFonts faces; give it a binding and
+    // keep it off the network (the faces ship as bundled assets).
+    TestWidgetsFlutterBinding.ensureInitialized();
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('AppTheme memoization', () {
+    test('theme is built once and reused across accesses', () {
+      // Arrange
+      final first = AppTheme.theme;
+
+      // Act
+      final second = AppTheme.theme;
+
+      // Assert
+      expect(identical(first, second), isTrue,
+          reason: 'AppTheme.theme must return the same ThemeData instance');
+      expect(identical(first.textTheme, second.textTheme), isTrue);
+    });
+
+    test('card and button shadows are shared instances', () {
+      expect(identical(AppTheme.cardShadow, AppTheme.cardShadow), isTrue);
+      expect(identical(AppTheme.buttonShadow, AppTheme.buttonShadow), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`AppTheme.theme` was a **getter** that assembled a full `ThemeData` — including ~20 `GoogleFonts.robotoCondensed()` text styles, each allocating a descriptor and kicking off a `loadFontIfNecessary` future — on **every access**. It has 15 call sites on hot paths: the root `MaterialApp` (2× per build), `CustomDrawerOverlay` (3× per build, and it lives inside Home/Trades/Chat so it rebuilds with every order event), `MostroReactiveButton` (up to 4× per build) and field initializers in `TakeOrderScreen`/`TradeDetailScreen`.

`ThemeData` is immutable, so it is now built once (`static final`). `cardShadow`/`buttonShadow` were getters allocating a new list per card build; they are now shared unmodifiable lists (their two call sites only pass them to `boxShadow`).

This is item **1.2** of the performance plan (users reporting the app getting slow to respond). Call sites are left untouched on purpose: `AppTheme.theme.textTheme` is now a plain field access.

## Changes

- `lib/core/app_theme.dart`: `theme` → `static final` built by `_buildTheme()`; `cardShadow`/`buttonShadow` → `static final List.unmodifiable`.
- `test/core/app_theme_test.dart`: pins both memoizations by identity (fails on `main`).

## Test plan

- [x] New test: RED on `main`, GREEN here
- [x] `flutter analyze` — no new issues
- [x] Full `flutter test` — 1161/1161
- [ ] Manual: open the app, navigate Home → Trades → Chat → a trade detail; visuals unchanged (same fonts, shadows, button styles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur