### PR TITLE
perf: switch bottom nav tabs with go instead of push

### DIFF
--- a/lib/shared/widgets/bottom_nav_bar.dart
+++ b/lib/shared/widgets/bottom_nav_bar.dart
@@ -179,7 +179,10 @@ class BottomNavBar extends ConsumerWidget {
 
     final currentLocation = GoRouterState.of(context).uri.toString();
     if (currentLocation != nextRoute) {
-      context.push(nextRoute);
+      // Tabs are root destinations: replace the page instead of pushing it.
+      // Pushed tabs stayed mounted (maintainState) and kept rebuilding on
+      // every order/chat event, one live screen per tap.
+      context.go(nextRoute);
     }
   }
 }

--- a/test/shared/widgets/bottom_nav_bar_test.dart
+++ b/test/shared/widgets/bottom_nav_bar_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:mostro_mobile/generated/l10n.dart';
+import 'package:mostro_mobile/shared/widgets/bottom_nav_bar.dart';
+
+/// The three bottom tabs are root destinations. Switching between them must
+/// replace the current page, not push on top of it: pushed tabs stay mounted
+/// (`maintainState`) and keep rebuilding on every order/chat event, so after
+/// N taps N live screens were doing the work of one.
+void main() {
+  late GoRouter router;
+
+  Widget tab(String name) => Scaffold(
+        body: Center(child: Text(name)),
+        bottomNavigationBar: const BottomNavBar(),
+      );
+
+  Future<void> pumpApp(WidgetTester tester) async {
+    router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(path: '/', builder: (_, __) => tab('home')),
+        GoRoute(path: '/order_book', builder: (_, __) => tab('trades')),
+        GoRoute(path: '/chat_list', builder: (_, __) => tab('chats')),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapTab(WidgetTester tester, IconData icon) async {
+    await tester.tap(find.byIcon(icon));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('switching tabs replaces the root page instead of stacking',
+      (tester) async {
+    // Arrange
+    await pumpApp(tester);
+    expect(router.canPop(), isFalse);
+
+    // Act
+    await tapTab(tester, LucideIcons.zap);
+    expect(find.text('trades'), findsOneWidget);
+    await tapTab(tester, LucideIcons.messageSquare);
+    expect(find.text('chats'), findsOneWidget);
+    await tapTab(tester, LucideIcons.book);
+
+    // Assert
+    expect(find.text('home'), findsOneWidget);
+    expect(router.state.uri.toString(), '/');
+    expect(router.canPop(), isFalse,
+        reason: 'tab navigation must not leave previous tabs on the stack');
+    expect(find.text('trades', skipOffstage: false), findsNothing,
+        reason: 'a replaced tab must be unmounted, not kept offstage');
+  });
+
+  testWidgets('tapping the active tab is a no-op', (tester) async {
+    await pumpApp(tester);
+
+    await tapTab(tester, LucideIcons.book);
+
+    expect(router.state.uri.toString(), '/');
+    expect(router.canPop(), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

`BottomNavBar._onItemTapped` used `context.push(nextRoute)` for the three root tabs (Order Book / My Trades / Chat). Root routes are `CustomTransitionPage`s with the default `maintainState: true`, so every previously visited tab stayed **mounted offstage** and kept rebuilding on every order/chat event — each with its own `CustomDrawerOverlay`, notification-bell `AnimationController` and `ref.watch` on `filteredOrdersProvider` / `sortedChatRoomsProvider` / `timeProvider`. After N tab taps, N live screens were doing the work of one.

This is item **1.3** of the performance plan (users reporting the app getting slow to respond). It is the "simple" variant; a `StatefulShellRoute` + `IndexedStack` would be the follow-up if we want controlled keep-alive.

## Changes

- `lib/shared/widgets/bottom_nav_bar.dart`: `context.push` → `context.go` for tab switches. Every other navigation to a root tab in the app already uses `go` (`order_app_bar.dart`, `trade_detail_screen.dart`, payment screens); the bottom bar was the outlier. Detail routes (e.g. `/chat_room/:id` from `chat_list_item.dart`) keep `push`.
- `test/shared/widgets/bottom_nav_bar_test.dart`: after Home → Trades → Chat → Home, `router.canPop()` is false and the replaced tab is unmounted (not offstage); tapping the active tab is a no-op. Fails on `main`.

## Behaviour change

Android **back** after switching tabs no longer returns to the previous tab — from a root tab it leaves the app, which is the standard behaviour for root destinations and already what happens when reaching `/` via `context.go('/')` from the payment screens. Flagging it so reviewers can decide whether cross-tab back history matters; if it does, the shell-route variant is the answer.

## Test plan

- [x] New widget test: RED on `main`, GREEN here
- [x] `flutter analyze` — no new issues
- [x] Full `flutter test` — 1161/1161
- [ ] Manual (Android): switch tabs repeatedly, confirm only the visible screen is alive (DevTools widget inspector) and that back from a root tab exits the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur