### PR TITLE
perf: honour log level and remove per-call logging cost

### DIFF
--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -62,6 +62,11 @@ class Config {
   // Debug mode
   static bool get isDebug => !kReleaseMode;
 
+  /// Console logging and full log verbosity. Deliberately [kDebugMode] and not
+  /// [isDebug]: profile builds are for performance measurement and must not
+  /// pay for per-call stack-trace capture and console formatting.
+  static bool get verboseLogging => kDebugMode;
+
   /// Whether the add-relay validation accepts plain `ws://` towards local
   /// hosts (`localhost`, IPv4). True in the Mortsom test environment and in
   /// any non-release build (debug and profile); never in release builds.

--- a/lib/services/logger_service.dart
+++ b/lib/services/logger_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:isolate';
 import 'dart:ui';
 import 'package:flutter/foundation.dart';
@@ -37,22 +38,29 @@ void initIsolateLogReceiver() {
 
 SendPort? get isolateLogSenderPort => _isolateLogSender;
 
+// Precompiled once: cleanMessage runs for every stored log line and used to
+// build 14 RegExp objects per call.
+final List<(RegExp, String)> _sanitizers = [
+  (RegExp(r'\x1B\[[0-9;]*[a-zA-Z]'), ''),
+  (RegExp(r'\[\d+m'), ''),
+  (RegExp(r'\[38;5;\d+m'), ''),
+  (RegExp(r'\[39m'), ''),
+  (RegExp(r'\[2m'), ''),
+  (RegExp(r'\[22m'), ''),
+  (RegExp(r'[┌┐└┘├┤─│┬┴┼╭╮╰╯╔╗╚╝╠╣═║╦╩╬━┃┄├]'), ''),
+  (RegExp(r'[\u{1F300}-\u{1F9FF}]', unicode: true), ''),
+  (RegExp(r'nsec[0-9a-z]+'), '[PRIVATE_KEY]'),
+  (RegExp(r'"privateKey"\s*:\s*"[^"]*"'), '"privateKey":"[REDACTED]"'),
+  (RegExp(r'"mnemonic"\s*:\s*"[^"]*"'), '"mnemonic":"[REDACTED]"'),
+  (RegExp(r'[^A-Za-z0-9\s.:,!?\-_/\[\]]'), ' '),
+  (RegExp(r'\s+'), ' '),
+];
+
 String cleanMessage(String message) {
   var cleaned = message;
-  cleaned = cleaned
-      .replaceAll(RegExp(r'\x1B\[[0-9;]*[a-zA-Z]'), '')
-      .replaceAll(RegExp(r'\[\d+m'), '')
-      .replaceAll(RegExp(r'\[38;5;\d+m'), '')
-      .replaceAll(RegExp(r'\[39m'), '')
-      .replaceAll(RegExp(r'\[2m'), '')
-      .replaceAll(RegExp(r'\[22m'), '')
-      .replaceAll(RegExp(r'[┌┐└┘├┤─│┬┴┼╭╮╰╯╔╗╚╝╠╣═║╦╩╬━┃┄├]'), '')
-      .replaceAll(RegExp(r'[\u{1F300}-\u{1F9FF}]', unicode: true), '')
-      .replaceAll(RegExp(r'nsec[0-9a-z]+'), '[PRIVATE_KEY]')
-      .replaceAll(RegExp(r'"privateKey"\s*:\s*"[^"]*"'), '"privateKey":"[REDACTED]"')
-      .replaceAll(RegExp(r'"mnemonic"\s*:\s*"[^"]*"'), '"mnemonic":"[REDACTED]"')
-      .replaceAll(RegExp(r'[^A-Za-z0-9\s.:,!?\-_/\[\]]'), ' ')
-      .replaceAll(RegExp(r'\s+'), ' ');
+  for (final (pattern, replacement) in _sanitizers) {
+    cleaned = cleaned.replaceAll(pattern, replacement);
+  }
   return cleaned.trim();
 }
 
@@ -149,14 +157,29 @@ class MemoryLogOutput extends LogOutput with ChangeNotifier {
   List<LogEntry> getAllLogs() => List.unmodifiable(_buffer);
 
   void clear() {
+    _notifyTimer?.cancel();
+    _notifyTimer = null;
     _buffer.clear();
     notifyListeners();
+  }
+
+  /// Listener notifications are coalesced: one per [notifyInterval] instead
+  /// of one per line. LogsNotifier copies the whole buffer on every
+  /// notification, so per-line notifications made each log line O(buffer).
+  static const Duration notifyInterval = Duration(milliseconds: 250);
+  Timer? _notifyTimer;
+
+  void _scheduleNotify() {
+    _notifyTimer ??= Timer(notifyInterval, () {
+      _notifyTimer = null;
+      notifyListeners();
+    });
   }
 
   void addEntry(LogEntry entry) {
     _buffer.add(entry);
     _maintainBufferSize();
-    notifyListeners();
+    _scheduleNotify();
   }
 
   void _maintainBufferSize() {
@@ -254,35 +277,57 @@ class SimplePrinter extends LogPrinter {
   }
 }
 
-class _ProductionOptimizedFilter extends LogFilter {
+/// Gate for every log call. In non-verbose (release) builds nothing is
+/// processed unless the user enabled in-app logging, and even then the
+/// configured [level] is honoured — the previous filter ignored it, so
+/// enabling logging turned every `logger.d` on a hot path into stack-trace
+/// capture plus sanitising work.
+class MostroLogFilter extends LogFilter {
+  MostroLogFilter({bool? verbose}) : verbose = verbose ?? Config.verboseLogging;
+
+  final bool verbose;
+
   @override
   bool shouldLog(LogEvent event) {
-    if (Config.isDebug) {
-      return true;
-    }
-
-    return MemoryLogOutput.isLoggingEnabled;
+    if (!verbose && !MemoryLogOutput.isLoggingEnabled) return false;
+    final minLevel = level ?? Level.trace;
+    return event.level.index >= minLevel.index;
   }
 }
 
-Logger? _cachedLogger;
-
-Logger get logger {
-  _cachedLogger ??= Logger(
-    printer: PrettyPrinter(
+/// The pretty console printer captures and formats a stack trace per call; it
+/// is pure cost when there is no console attached, so non-verbose builds use
+/// a printer that emits nothing (the in-memory sink reads `event.origin`).
+LogPrinter buildLogPrinter({bool? verbose}) {
+  if (verbose ?? Config.verboseLogging) {
+    return PrettyPrinter(
       methodCount: 2,
       errorMethodCount: 8,
       lineLength: 120,
       colors: true,
       printEmojis: true,
       dateTimeFormat: DateTimeFormat.onlyTimeAndSinceStart,
-    ),
+    );
+  }
+  return _NoopPrinter();
+}
+
+class _NoopPrinter extends LogPrinter {
+  @override
+  List<String> log(LogEvent event) => const [];
+}
+
+Logger? _cachedLogger;
+
+Logger get logger {
+  _cachedLogger ??= Logger(
+    printer: buildLogPrinter(),
     output: _MultiOutput(
       MemoryLogOutput.instance,
-      Config.isDebug ? ConsoleOutput() : null,
+      Config.verboseLogging ? ConsoleOutput() : null,
     ),
-    level: Config.isDebug ? Level.debug : Level.warning,
-    filter: _ProductionOptimizedFilter(),
+    level: Config.verboseLogging ? Level.debug : Level.warning,
+    filter: MostroLogFilter(),
   );
   return _cachedLogger!;
 }

--- a/lib/services/logger_service.dart
+++ b/lib/services/logger_service.dart
@@ -312,9 +312,19 @@ LogPrinter buildLogPrinter({bool? verbose}) {
   return _NoopPrinter();
 }
 
+/// Emits a single constant sentinel line instead of formatting anything.
+///
+/// It cannot return an empty list: `Logger.log` only forwards to the
+/// configured `LogOutput` when the printer produced at least one line
+/// (`logger/src/logger.dart`, `if (output.isNotEmpty)`), so an empty result
+/// would starve [MemoryLogOutput] and leave the in-app Logs screen empty in
+/// release builds. The line itself is never read — [MemoryLogOutput] rebuilds
+/// the entry from `event.origin`, and no console output is attached in
+/// non-verbose builds — so a `const` list keeps the no-formatting, no-stack-
+/// capture, zero-allocation behaviour.
 class _NoopPrinter extends LogPrinter {
   @override
-  List<String> log(LogEvent event) => const [];
+  List<String> log(LogEvent event) => const [''];
 }
 
 Logger? _cachedLogger;

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -43,6 +43,11 @@ class NostrService {
       configured.isEmpty ? Config.discoveryRelays : configured;
 
   Future<void> init(Settings settings) async {
+    if (!Config.verboseLogging) {
+      // dart_nostr ships with logging enabled and builds 2-3 full-payload
+      // strings per relay frame for dart:developer.log.
+      _nostr.disableLogs();
+    }
     final relays = effectiveRelays(settings.relays);
     if (settings.relays.isEmpty) {
       logger.w(

--- a/lib/services/nwc/nwc_client.dart
+++ b/lib/services/nwc/nwc_client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:dart_nostr/dart_nostr.dart';
+import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/services/nostr_service.dart';
 import 'package:mostro_mobile/services/nwc/nwc_connection.dart';
@@ -89,6 +90,11 @@ class NwcClient {
     required NostrService nostrService,
     this.requestTimeout = const Duration(seconds: 30),
   }) : _nostrService = nostrService {
+    if (!Config.verboseLogging) {
+      // dart_nostr ships with logging enabled and builds full-payload strings
+      // per relay frame for dart:developer.log.
+      _nostr.disableLogs();
+    }
     _keyPair = NostrUtils.generateKeyPairFromPrivateKey(connection.secret);
     _clientPubkey = _keyPair.public;
   }

--- a/test/services/logger_service_test.dart
+++ b/test/services/logger_service_test.dart
@@ -41,10 +41,46 @@ void main() {
   });
 
   group('buildLogPrinter', () {
-    test('non-verbose printer produces no output lines', () {
+    test('non-verbose printer does not format the event', () {
+      // Arrange
       final printer = buildLogPrinter(verbose: false);
 
-      expect(printer.log(event(Level.error)), isEmpty);
+      // Act
+      final lines = printer.log(event(Level.error));
+
+      // Assert: a single blank sentinel, no message, level or stack trace.
+      expect(lines, ['']);
+      expect(lines.join(), isEmpty);
+    });
+
+    test('non-verbose logging still reaches the in-app Logs screen', () {
+      // Arrange: the release wiring. `Logger.log` drops the event before it
+      // ever reaches the output when the printer returns no lines, so an
+      // empty printer would leave the Logs screen permanently blank.
+      MemoryLogOutput.isLoggingEnabled = true;
+      MemoryLogOutput.instance.clear();
+      addTearDown(() {
+        MemoryLogOutput.instance.clear();
+        MemoryLogOutput.isLoggingEnabled = false;
+      });
+
+      final releaseLogger = Logger(
+        printer: buildLogPrinter(verbose: false),
+        output: MemoryLogOutput.instance,
+        level: Level.warning,
+        filter: MostroLogFilter(verbose: false)..level = Level.warning,
+      );
+
+      // Act
+      releaseLogger.e('boom');
+      releaseLogger.w('careful');
+      releaseLogger.i('below the configured level');
+
+      // Assert
+      expect(MemoryLogOutput.instance.logCount, 2);
+      final captured = MemoryLogOutput.instance.getAllLogs();
+      expect(captured.map((e) => e.message), ['boom', 'careful']);
+      expect(captured.map((e) => e.level), [Level.error, Level.warning]);
     });
 
     test('verbose printer is the pretty console printer', () {

--- a/test/services/logger_service_test.dart
+++ b/test/services/logger_service_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:mostro_mobile/services/logger_service.dart';
+
+/// The logger sits on every hot path (several calls per incoming event). These
+/// tests pin the cost controls: the release filter must honour the configured
+/// level, the release printer must not format (no stack capture), message
+/// sanitising must keep redacting, and the in-memory sink must coalesce
+/// listener notifications instead of firing one per line.
+void main() {
+  LogEvent event(Level level) => LogEvent(level, 'msg');
+
+  group('MostroLogFilter', () {
+    test('release build honours the configured level once logging is on', () {
+      // Arrange
+      final filter = MostroLogFilter(verbose: false)..level = Level.warning;
+      MemoryLogOutput.isLoggingEnabled = true;
+      addTearDown(() => MemoryLogOutput.isLoggingEnabled = false);
+
+      // Act / Assert
+      expect(filter.shouldLog(event(Level.debug)), isFalse);
+      expect(filter.shouldLog(event(Level.info)), isFalse);
+      expect(filter.shouldLog(event(Level.warning)), isTrue);
+      expect(filter.shouldLog(event(Level.error)), isTrue);
+    });
+
+    test('release build logs nothing while logging is off', () {
+      final filter = MostroLogFilter(verbose: false)..level = Level.warning;
+      MemoryLogOutput.isLoggingEnabled = false;
+
+      expect(filter.shouldLog(event(Level.error)), isFalse);
+    });
+
+    test('verbose (debug) build lets every configured level through', () {
+      final filter = MostroLogFilter(verbose: true)..level = Level.debug;
+      MemoryLogOutput.isLoggingEnabled = false;
+
+      expect(filter.shouldLog(event(Level.debug)), isTrue);
+      expect(filter.shouldLog(event(Level.trace)), isFalse);
+    });
+  });
+
+  group('buildLogPrinter', () {
+    test('non-verbose printer produces no output lines', () {
+      final printer = buildLogPrinter(verbose: false);
+
+      expect(printer.log(event(Level.error)), isEmpty);
+    });
+
+    test('verbose printer is the pretty console printer', () {
+      expect(buildLogPrinter(verbose: true), isA<PrettyPrinter>());
+    });
+  });
+
+  group('cleanMessage', () {
+    test('still redacts secrets and strips ANSI/box characters', () {
+      final cleaned = cleanMessage(
+        '\x1B[38;5;12m│ key nsec1abcdef "privateKey": "deadbeef" ┌──┐',
+      );
+
+      expect(cleaned, contains('[PRIVATE_KEY]'));
+      // The final sanitizer strips quote characters, so assert on the
+      // redaction marker rather than the exact JSON literal.
+      expect(cleaned, contains('[REDACTED]'));
+      expect(cleaned, isNot(contains('nsec1')));
+      expect(cleaned, isNot(contains('deadbeef')));
+      expect(cleaned, isNot(contains('│')));
+    });
+  });
+
+  group('MemoryLogOutput notifications', () {
+    late int notifications;
+    void onChange() => notifications++;
+
+    setUp(() {
+      MemoryLogOutput.isLoggingEnabled = true;
+      MemoryLogOutput.instance.clear();
+      MemoryLogOutput.instance.addListener(onChange);
+      notifications = 0;
+    });
+
+    tearDown(() {
+      MemoryLogOutput.instance.removeListener(onChange);
+      MemoryLogOutput.instance.clear();
+      MemoryLogOutput.isLoggingEnabled = false;
+    });
+
+    LogEntry entry(String m) => LogEntry(
+          timestamp: DateTime.now(),
+          level: Level.info,
+          message: m,
+          service: 'test',
+          line: '1',
+        );
+
+    testWidgets('a burst of entries notifies listeners once', (tester) async {
+      // Act
+      MemoryLogOutput.instance.addEntry(entry('a'));
+      MemoryLogOutput.instance.addEntry(entry('b'));
+      MemoryLogOutput.instance.addEntry(entry('c'));
+
+      // Assert: nothing synchronously, one notification after the window
+      expect(notifications, 0);
+      await tester.pump(MemoryLogOutput.notifyInterval);
+      expect(notifications, 1);
+      expect(MemoryLogOutput.instance.logCount, 3);
+    });
+
+    testWidgets('clear notifies immediately and cancels a pending burst',
+        (tester) async {
+      MemoryLogOutput.instance.addEntry(entry('a'));
+
+      MemoryLogOutput.instance.clear();
+
+      expect(notifications, 1);
+      await tester.pump(MemoryLogOutput.notifyInterval);
+      expect(notifications, 1);
+      expect(MemoryLogOutput.instance.logCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Item **1.4** of the performance plan. The logging pipeline sat on every hot path (several `logger.*` calls per incoming relay event, ~730 call sites) and had four cost leaks:

1. `_ProductionOptimizedFilter.shouldLog` never consulted the configured level — the release `Level.warning` was dead code. Enabling in-app logging from Settings let **every** `logger.d/i` through the full pipeline.
2. The `PrettyPrinter` captured and formatted a stack trace **per call**, even in release where no console consumes its output (the memory sink reads `event.origin`).
3. `cleanMessage` built 13 `RegExp` objects per stored line.
4. `MemoryLogOutput` called `notifyListeners()` per line, making `LogsNotifier` copy the whole 1000-entry buffer per log line once the Logs screen had been visited.

Additionally `dart_nostr` ships with internal logging enabled and builds 2–3 full-payload strings per relay frame for `dart:developer.log` — never disabled anywhere.

## Changes

- `MostroLogFilter` (public, `verbose` injectable): release processes nothing while in-app logging is off, and honours the configured level once it is on.
- `buildLogPrinter`: `PrettyPrinter` only in `kDebugMode`; a no-op printer otherwise.
- `cleanMessage`: precompiled sanitizer list (same redaction behaviour, pinned by test).
- `MemoryLogOutput`: listener notifications coalesced to one per 250 ms (`notifyInterval`); `clear()` notifies immediately.
- `Config.verboseLogging => kDebugMode` — deliberately **not** `Config.isDebug` (`!kReleaseMode`): profile builds are for performance measurement and must stay quiet, and `isDebug` is left untouched because `allowInsecureRelays` depends on it.
- `NostrService.init` / `NwcClient` constructor call `disableLogs()` on their `Nostr` instances outside debug.

## Test plan

- [x] New `test/services/logger_service_test.dart` (RED on `main`): level honoured in release, nothing while logging off, no-op printer, redaction regression, notification coalescing
- [x] `logs_screen_test.dart` — 12/12 (Logs screen unaffected by coalescing)
- [x] `flutter analyze` — no new issues
- [x] Full `flutter test` — 1167/1167
- [ ] Manual: release build → Settings → enable logging → Logs screen fills with WARN/ERROR only; debug build unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur