### PR TITLE
perf: debounce background switch and ignore inactive lifecycle blips

### DIFF
--- a/lib/services/lifecycle_manager.dart
+++ b/lib/services/lifecycle_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -18,33 +19,54 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class LifecycleManager extends WidgetsBindingObserver {
   final Ref ref;
+  final bool _isMobilePlatform;
   bool _isInBackground = false;
+  Timer? _backgroundDebounce;
 
-  LifecycleManager(this.ref) {
+  /// A background switch is expensive (unsubscribe everything, start the
+  /// background service) and the matching resume redoes cold-start work, so
+  /// it only runs once the app has stayed away for this long. A quick resume
+  /// cancels it.
+  static const Duration backgroundDebounce = Duration(seconds: 2);
+
+  @visibleForTesting
+  bool get isInBackground => _isInBackground;
+
+  LifecycleManager(this.ref, {bool? isMobilePlatform})
+      : _isMobilePlatform =
+            isMobilePlatform ?? (Platform.isAndroid || Platform.isIOS) {
     WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) async {
-    if (Platform.isAndroid || Platform.isIOS) {
-      switch (state) {
-        case AppLifecycleState.resumed:
-          // App is in foreground
-          if (_isInBackground) {
-            await _switchToForeground();
-          }
-          break;
-        case AppLifecycleState.paused:
-        case AppLifecycleState.inactive:
-        case AppLifecycleState.detached:
-          // App is in background
-          if (!_isInBackground) {
-            await _switchToBackground();
-          }
-          break;
-        default:
-          break;
-      }
+    if (!_isMobilePlatform) return;
+    switch (state) {
+      case AppLifecycleState.resumed:
+        _backgroundDebounce?.cancel();
+        _backgroundDebounce = null;
+        if (_isInBackground) {
+          await _switchToForeground();
+        }
+        break;
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.detached:
+        // Schedule, don't switch: paused can be a blip (app switcher glance).
+        if (!_isInBackground && _backgroundDebounce == null) {
+          _backgroundDebounce = Timer(backgroundDebounce, () {
+            _backgroundDebounce = null;
+            if (!_isInBackground) {
+              _switchToBackground();
+            }
+          });
+        }
+        break;
+      case AppLifecycleState.inactive:
+        // Fires for the notification shade, permission/biometric dialogs and
+        // the app switcher on Android. Never a reason to tear down
+        // subscriptions and start the background service.
+        break;
     }
   }
 
@@ -161,6 +183,7 @@ class LifecycleManager extends WidgetsBindingObserver {
   }
 
   void dispose() {
+    _backgroundDebounce?.cancel();
     WidgetsBinding.instance.removeObserver(this);
   }
 }

--- a/lib/services/lifecycle_manager.dart
+++ b/lib/services/lifecycle_manager.dart
@@ -66,6 +66,16 @@ class LifecycleManager extends WidgetsBindingObserver {
         // Fires for the notification shade, permission/biometric dialogs and
         // the app switcher on Android. Never a reason to tear down
         // subscriptions and start the background service.
+        //
+        // A pending switch is cancelled here, not only on `resumed`: the
+        // return path is paused -> hidden -> inactive -> resumed, and the app
+        // can sit in `inactive` past the deadline behind a permission or
+        // biometric dialog. Letting the timer fire there would run the whole
+        // teardown while the app is already coming back, which is exactly the
+        // churn the debounce exists to avoid. Nothing is stranded by this:
+        // leaving `inactive` outwards delivers `hidden`, which reschedules.
+        _backgroundDebounce?.cancel();
+        _backgroundDebounce = null;
         break;
     }
   }

--- a/test/services/lifecycle_manager_test.dart
+++ b/test/services/lifecycle_manager_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/services/lifecycle_manager.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../mocks.mocks.dart';
+
+/// On Android, `AppLifecycleState.inactive` fires for the notification shade,
+/// permission/biometric dialogs and the app switcher. Treating it as
+/// "backgrounded" made each blip cost a full unsubscribe + background-service
+/// start, and the matching resume redid cold-start work (subscribeAll, order
+/// book reload, full chat history re-decrypt) — the main "slow after being
+/// open a while" driver. Only a sustained paused/hidden/detached state may
+/// switch to background, after a debounce that a quick resume cancels.
+void main() {
+  late MockSubscriptionManagerSpy manager;
+  late ProviderContainer container;
+  late LifecycleManager lifecycle;
+
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    manager = MockSubscriptionManagerSpy();
+    when(manager.getActiveFilters(any)).thenReturn([]);
+    container = ProviderContainer(overrides: [
+      subscriptionManagerProvider.overrideWithValue(manager),
+    ]);
+  });
+
+  tearDown(() {
+    lifecycle.dispose();
+    container.dispose();
+  });
+
+  LifecycleManager build() => LifecycleManager(
+        _RefAdapter(container),
+        isMobilePlatform: true,
+      );
+
+  Future<void> settle(WidgetTester tester) async {
+    await tester.pump(LifecycleManager.backgroundDebounce);
+    await tester.pump();
+  }
+
+  testWidgets('inactive does not switch to background', (tester) async {
+    lifecycle = build();
+
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.inactive);
+    await settle(tester);
+
+    expect(lifecycle.isInBackground, isFalse);
+    verifyNever(manager.unsubscribeAll());
+  });
+
+  testWidgets('paused switches to background after the debounce',
+      (tester) async {
+    lifecycle = build();
+
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.paused);
+    expect(lifecycle.isInBackground, isFalse,
+        reason: 'the switch must wait for the debounce window');
+    await settle(tester);
+
+    expect(lifecycle.isInBackground, isTrue);
+  });
+
+  testWidgets('a quick resume cancels a pending background switch',
+      (tester) async {
+    lifecycle = build();
+
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.paused);
+    await tester.pump(const Duration(milliseconds: 100));
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.resumed);
+    await settle(tester);
+
+    expect(lifecycle.isInBackground, isFalse);
+    verifyNever(manager.unsubscribeAll());
+    verifyNever(manager.subscribeAll());
+  });
+}
+
+/// Minimal Ref façade over a container for unit-testing the manager.
+class _RefAdapter implements Ref {
+  _RefAdapter(this.container);
+
+  @override
+  final ProviderContainer container;
+
+  @override
+  T read<T>(ProviderListenable<T> provider) => container.read(provider);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}

--- a/test/services/lifecycle_manager_test.dart
+++ b/test/services/lifecycle_manager_test.dart
@@ -68,6 +68,47 @@ void main() {
     expect(lifecycle.isInBackground, isTrue);
   });
 
+  testWidgets(
+      'a return that stalls in inactive cancels the pending background switch',
+      (tester) async {
+    // The return path is paused -> hidden -> inactive -> resumed, and the app
+    // can sit in `inactive` for a while behind a permission or biometric
+    // dialog. If the debounce fires there, the whole teardown runs while the
+    // app is already foregrounding.
+    lifecycle = build();
+
+    // Arrange: backgrounded, switch pending but not yet fired.
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.paused);
+    await tester.pump(LifecycleManager.backgroundDebounce -
+        const Duration(milliseconds: 100));
+
+    // Act: the user comes back, then a dialog holds the app in `inactive`
+    // well past the original deadline.
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.hidden);
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.inactive);
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pump();
+
+    // Assert
+    expect(lifecycle.isInBackground, isFalse);
+    verifyNever(manager.unsubscribeAll());
+  });
+
+  testWidgets('leaving inactive outwards reschedules the switch',
+      (tester) async {
+    // Cancelling on `inactive` must not strand the manager in the foreground:
+    // going further out delivers `hidden`, which schedules again.
+    lifecycle = build();
+
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.inactive);
+    await tester.pump(const Duration(milliseconds: 100));
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.hidden);
+    lifecycle.didChangeAppLifecycleState(AppLifecycleState.paused);
+    await settle(tester);
+
+    expect(lifecycle.isInBackground, isTrue);
+  });
+
   testWidgets('a quick resume cancels a pending background switch',
       (tester) async {
     lifecycle = build();


### PR DESCRIPTION
## Summary

Item **1.6** of the performance plan. `LifecycleManager` treated `AppLifecycleState.inactive` as "the app went to background". On Android, `inactive` fires for the notification shade, permission/biometric dialogs and the app switcher, so each blip cost:

- prefs write + `unsubscribeAll()` + background-service start (50 ms poll up to 5 s), and
- on the matching resume: a 500 ms fixed sleep, `subscribeAll()` (full gift-wrap history replay — the orders filter has no `since`), a 48 h order-book `reloadData()`, `reloadAllChats()` (full history re-decrypt on the UI isolate) and two provider invalidations.

This is the strongest candidate for the reported "gets slow after being open a while".

## Changes

- `inactive` no longer triggers anything.
- `paused` / `hidden` / `detached` schedule the background switch behind a **2 s debounce** (`LifecycleManager.backgroundDebounce`); a quick `resumed` cancels it, so brief app-switcher glances no longer pay the full cycle.
- Platform gate injectable (`isMobilePlatform`) + `@visibleForTesting isInBackground`, so the manager is now unit-testable off-device.
- The 500 ms post-stop sleep in `_switchToForeground` is deliberately **kept**: `_stopService()` is fire-and-forget (`service.invoke('stop')`), so the sleep still covers a real race with the background isolate. Making the resume incremental is plan item 4.2.

## Test plan

- [x] New `test/services/lifecycle_manager_test.dart` (RED on `main`): `inactive` is a no-op; `paused` switches only after the debounce; a quick resume cancels the pending switch (verified against a spy `SubscriptionManager`)
- [x] Full `flutter test` — 1162/1162
- [x] `flutter analyze` — no new issues
- [ ] Manual (Android): pull down the notification shade / open a permission dialog repeatedly — logs must show no background/foreground transitions; leave the app for >2 s — transition happens once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur