### PR TITLE
perf: value equality for Settings and scoped settings watchers

### DIFF
--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -144,9 +144,12 @@ class _MostroAppState extends ConsumerState<MostroApp> {
           });
         });
 
-        // Watch both system locale and settings for changes
+        // Watch both system locale and the language override. Only the
+        // language matters here; watching the whole Settings object rebuilt
+        // MaterialApp.router on every relay sync write.
         final systemLocale = ref.watch(systemLocaleProvider);
-        final settings = ref.watch(settingsProvider);
+        final selectedLanguage =
+            ref.watch(settingsProvider.select((s) => s.selectedLanguage));
 
         // Initialize router if not already done
         _router ??= createRouter(ref);
@@ -201,8 +204,8 @@ class _MostroAppState extends ConsumerState<MostroApp> {
             );
           },
           // Use language override from settings if available, otherwise let callback handle detection
-          locale: settings.selectedLanguage != null
-              ? Locale(settings.selectedLanguage!)
+          locale: selectedLanguage != null
+              ? Locale(selectedLanguage)
               : systemLocale,
           localizationsDelegates: const [
             S.delegate,

--- a/lib/features/disputes/providers/dispute_providers.dart
+++ b/lib/features/disputes/providers/dispute_providers.dart
@@ -11,8 +11,8 @@ import 'package:mostro_mobile/features/order/providers/order_notifier_provider.d
 /// Provider for the dispute repository
 final disputeRepositoryProvider = Provider.autoDispose<DisputeRepository>((ref) {
   final nostrService = ref.watch(nostrServiceProvider);
-  final settings = ref.watch(settingsProvider);
-  final mostroPubkey = settings.mostroPublicKey;
+  final mostroPubkey =
+      ref.watch(settingsProvider.select((s) => s.mostroPublicKey));
   
   return DisputeRepository(nostrService, mostroPubkey, ref);
 });

--- a/lib/features/mostro/widgets/mostro_node_selector.dart
+++ b/lib/features/mostro/widgets/mostro_node_selector.dart
@@ -36,7 +36,8 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
   @override
   Widget build(BuildContext context) {
     ref.watch(mostroNodesProvider);
-    final currentPubkey = ref.watch(settingsProvider).mostroPublicKey;
+    final currentPubkey =
+        ref.watch(settingsProvider.select((s) => s.mostroPublicKey));
     final notifier = ref.read(mostroNodesProvider.notifier);
     final trustedNodes = notifier.trustedNodes;
     final customNodes = notifier.customNodes;

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -1,4 +1,6 @@
-class Settings {
+import 'package:equatable/equatable.dart';
+
+class Settings extends Equatable {
   final bool fullPrivacyMode;
   final List<String> relays;
   final String mostroPublicKey;
@@ -14,7 +16,7 @@ class Settings {
   final bool notificationVibrationEnabled;
   final int? sessionExpirationHours;
 
-  Settings({
+  const Settings({
     required this.relays,
     required this.fullPrivacyMode,
     required this.mostroPublicKey,
@@ -29,6 +31,25 @@ class Settings {
     this.notificationVibrationEnabled = true,
     this.sessionExpirationHours,
   });
+
+  /// Value equality (deep on lists): the relay sync rewrites settings twice
+  /// per kind 10002 event; without this every write rebuilt each watcher.
+  @override
+  List<Object?> get props => [
+        fullPrivacyMode,
+        relays,
+        mostroPublicKey,
+        defaultFiatCode,
+        selectedLanguage,
+        defaultLightningAddress,
+        blacklistedRelays,
+        userRelays,
+        isLoggingEnabled,
+        pushNotificationsEnabled,
+        notificationSoundEnabled,
+        notificationVibrationEnabled,
+        sessionExpirationHours,
+      ];
 
   Settings copyWith({
     List<String>? relays,

--- a/lib/features/settings/settings_notifier.dart
+++ b/lib/features/settings/settings_notifier.dart
@@ -18,12 +18,16 @@ class SettingsNotifier extends StateNotifier<Settings> {
   FCMService? _fcmService;
 
   /// Set push notification services for integration
-  void setPushServices(PushNotificationService? pushService, FCMService? fcmService) {
+  void setPushServices(
+      PushNotificationService? pushService, FCMService? fcmService) {
     _pushService = pushService;
     _fcmService = fcmService;
   }
 
   SettingsNotifier(this._prefs, {this.ref}) : super(_defaultSettings());
+
+  @override
+  bool updateShouldNotify(Settings old, Settings current) => old != current;
 
   static Settings _defaultSettings() {
     return Settings(
@@ -62,23 +66,23 @@ class SettingsNotifier extends StateNotifier<Settings> {
 
   Future<void> updateMostroInstance(String newValue) async {
     final oldPubkey = state.mostroPublicKey;
-    
+
     if (oldPubkey != newValue) {
       logger.i('Mostro change detected: $oldPubkey → $newValue');
-      
+
       // COMPLETE RESET: Clear blacklist and user relays when changing Mostro
       state = state.copyWith(
         mostroPublicKey: newValue,
         blacklistedRelays: const [], // Clear blacklist
-        userRelays: const [],         // Clear user relays
+        userRelays: const [], // Clear user relays
       );
-      
+
       logger.i('Reset blacklist and user relays for new Mostro instance');
     } else {
       // Only update pubkey if it's the same (without reset)
       state = state.copyWith(mostroPublicKey: newValue);
     }
-    
+
     await _saveToPrefs();
   }
 
@@ -140,7 +144,8 @@ class SettingsNotifier extends StateNotifier<Settings> {
   }
 
   /// Get all blacklisted relay URLs
-  List<String> get blacklistedRelays => List<String>.from(state.blacklistedRelays);
+  List<String> get blacklistedRelays =>
+      List<String>.from(state.blacklistedRelays);
 
   /// Clear all blacklisted relays (reset to allow all auto-sync)
   Future<void> clearBlacklist() async {
@@ -152,7 +157,8 @@ class SettingsNotifier extends StateNotifier<Settings> {
   }
 
   /// Update user relays list (user-added relays with metadata)
-  Future<void> updateUserRelays(List<Map<String, dynamic>> newUserRelays) async {
+  Future<void> updateUserRelays(
+      List<Map<String, dynamic>> newUserRelays) async {
     state = state.copyWith(userRelays: newUserRelays);
     await _saveToPrefs();
     logger.i('Updated user relays: ${newUserRelays.length} relays');

--- a/lib/shared/providers/exchange_service_provider.dart
+++ b/lib/shared/providers/exchange_service_provider.dart
@@ -9,10 +9,13 @@ import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
 
 final exchangeServiceProvider = Provider<ExchangeService>((ref) {
   final nostrService = ref.watch(nostrServiceProvider);
-  final settings = ref.watch(settingsProvider);
+  // Select: recreating this service on unrelated settings writes dropped its
+  // 1 h rate cache and refetched every watched currency over the relays.
+  final mostroPubkey =
+      ref.watch(settingsProvider.select((s) => s.mostroPublicKey));
   return NostrExchangeService(
     nostrService: nostrService,
-    mostroPubkey: settings.mostroPublicKey,
+    mostroPubkey: mostroPubkey,
   );
 });
 

--- a/test/features/settings/settings_equality_test.dart
+++ b/test/features/settings/settings_equality_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+/// `Settings` is watched at the root `MaterialApp` and by service providers.
+/// The relay sync writes it twice per kind 10002 event, so without value
+/// equality every sync rebuilt the whole app shell, and the exchange service
+/// was recreated — dropping its 1 h rate cache and refetching over relays.
+void main() {
+  Settings base() => Settings(
+        relays: const ['wss://relay.a'],
+        fullPrivacyMode: false,
+        mostroPublicKey: 'pk1',
+        blacklistedRelays: const ['wss://bad'],
+        userRelays: const [
+          {'url': 'wss://mine', 'source': 'user'},
+        ],
+      );
+
+  group('Settings value equality', () {
+    test('equal field values compare equal, including lists', () {
+      expect(base(), base());
+      expect(base().hashCode, base().hashCode);
+    });
+
+    test('copyWith of an unrelated field breaks equality', () {
+      expect(base(), isNot(base().copyWith(isLoggingEnabled: true)));
+      expect(base(), isNot(base().copyWith(mostroPublicKey: 'pk2')));
+      expect(
+        base(),
+        isNot(base().copyWith(relays: const ['wss://relay.b'])),
+      );
+    });
+  });
+
+  group('exchangeServiceProvider scoping', () {
+    test('an unrelated settings change keeps the same service instance',
+        () async {
+      // Arrange
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(SharedPreferencesAsync()),
+      ]);
+      addTearDown(container.dispose);
+      final before = container.read(exchangeServiceProvider);
+
+      // Act: toggling logging must not touch the exchange service
+      await container
+          .read(settingsProvider.notifier)
+          .updateLoggingEnabled(true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(
+        identical(before, container.read(exchangeServiceProvider)),
+        isTrue,
+        reason: 'recreating the service drops its 1 h rate cache and '
+            'refetches every watched currency over the relays',
+      );
+    });
+  });
+}

--- a/test/features/settings/settings_equality_test.dart
+++ b/test/features/settings/settings_equality_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_notifier.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/storage_providers.dart';
@@ -14,19 +15,41 @@ import 'package:shared_preferences_platform_interface/shared_preferences_async_p
 /// was recreated — dropping its 1 h rate cache and refetching over relays.
 void main() {
   Settings base() => Settings(
-        relays: const ['wss://relay.a'],
+        relays: ['wss://relay.a'],
         fullPrivacyMode: false,
         mostroPublicKey: 'pk1',
-        blacklistedRelays: const ['wss://bad'],
-        userRelays: const [
+        blacklistedRelays: ['wss://bad'],
+        userRelays: [
           {'url': 'wss://mine', 'source': 'user'},
         ],
       );
 
   group('Settings value equality', () {
     test('equal field values compare equal, including lists', () {
-      expect(base(), base());
+      final first = base();
+      final second = base();
+
+      expect(identical(first.relays, second.relays), isFalse);
+      expect(identical(first.blacklistedRelays, second.blacklistedRelays),
+          isFalse);
+      expect(identical(first.userRelays, second.userRelays), isFalse);
+      expect(identical(first.userRelays.single, second.userRelays.single),
+          isFalse);
+      expect(first, second);
       expect(base().hashCode, base().hashCode);
+    });
+
+    test('value-equal replacements do not notify settings listeners', () async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      final notifier = SettingsNotifier(SharedPreferencesAsync());
+      addTearDown(notifier.dispose);
+      var notifications = 0;
+      notifier.addListener((_) => notifications++, fireImmediately: false);
+
+      await notifier.updateRelays(<String>[]);
+
+      expect(notifications, 0);
     });
 
     test('copyWith of an unrelated field breaks equality', () {


### PR DESCRIPTION
## Summary

Item **1.7** of the performance plan. The relay sync writes `Settings` twice per incoming kind 10002 event (`relays_notifier.dart:103,107`), and `Settings` had no `operator ==`, so every write notified **every** watcher:

- the root builder rebuilt `MaterialApp.router` (`app.dart:149`);
- `exchangeServiceProvider` was recreated → its 1 h rate cache dropped → every live `exchangeRateProvider(currency)` refetched over the relays (waits EOSE, up to 10 s) or HTTP;
- `disputeRepositoryProvider` and `MostroNodeSelector` rebuilt on unrelated changes.

## Changes

- `Settings` extends `Equatable` (deep list equality; `const` constructor) — this also short-circuits identical rewrites for the remaining full watchers.
- `.select()` scoping where a single field is consumed:
  - root app → `selectedLanguage`
  - `exchangeServiceProvider` → `mostroPublicKey`
  - `disputeRepositoryProvider` → `mostroPublicKey`
  - `MostroNodeSelector` → `mostroPublicKey`
- Screens that render many settings fields (settings/logs/language selector, etc.) deliberately keep the full watch.

## Test plan

- [x] New `test/features/settings/settings_equality_test.dart` (RED on `main`): value equality incl. lists; `copyWith` breaks it; an unrelated settings change keeps the identical `ExchangeService` instance
- [x] Full `flutter test` — 1162/1162
- [x] `flutter analyze` — no new issues
- [ ] Manual: change language in Settings (app rebuilds), toggle logging (exchange rate widget must not flash/refetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary app and service updates when unrelated settings change.
  * Improved settings handling so equivalent values are recognized consistently.
  * Preserved exchange-rate caching when unrelated settings are updated.

* **Tests**
  * Added coverage for settings equality, list comparisons, copied settings, and exchange-service stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->