### PR TITLE
perf: timer hygiene for settings poll, countdown and NWC health

### DIFF
--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -535,16 +535,14 @@ class _CountdownWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Watch the countdown time provider for real-time updates
-    final timeAsync = ref.watch(countdownTimeProvider);
+    // The provider is only a 1 s rebuild ticker; its DateTime is never read
+    // (_buildCountDownTime calls DateTime.now() itself). Rendering is not
+    // gated on the AsyncValue: now that the provider is autoDispose its first
+    // frame after every screen entry is `loading`, and gating would flash a
+    // spinner over the countdown on each visit instead of only the first.
+    ref.watch(countdownTimeProvider);
 
-    return timeAsync.when(
-      data: (currentTime) {
-        return _buildCountDownTime(context, ref, order);
-      },
-      loading: () => const CircularProgressIndicator(),
-      error: (error, stack) => const SizedBox.shrink(),
-    );
+    return _buildCountDownTime(context, ref, order);
   }
 
   Widget _buildCountDownTime(

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -656,7 +656,15 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
         settingsProvider.select((s) => s.mostroPublicKey),
         (previous, next) {
           if (previous == next) return;
-          if (previous != null && previous.isNotEmpty && next.isNotEmpty) {
+          if (next.isEmpty) {
+            // The instance was cleared. This still has to tear the previous
+            // instance down: syncWithMostroInstance() returns early on an
+            // empty pubkey, before it unsubscribes or prunes, so routing this
+            // to the "initial load" branch would strand the old relays and
+            // their kind 10002 REQ with no instance behind them.
+            logger.i('Mostro pubkey cleared: $previous -> (none)');
+            _cleanAllRelaysAndResync();
+          } else if (previous != null && previous.isNotEmpty) {
             logger.i('Detected REAL Mostro pubkey change: $previous -> $next');
             // Full reset: clear all relays and perform a fresh sync
             _cleanAllRelaysAndResync();
@@ -676,6 +684,11 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   Future<void> _cleanAllRelaysAndResync() async {
     try {
       logger.i('Cleaning all relays and performing fresh sync...');
+
+      // Drop the previous instance's kind 10002 REQ here rather than relying
+      // on syncWithMostroInstance(), which never runs it when the new pubkey
+      // is empty. Idempotent, so the resync path re-running it is harmless.
+      _subscriptionManager.unsubscribeFromMostroRelayList();
 
       // Clear the whole list. Bootstrap relays (NostrService level) keep
       // connectivity while the new instance's relay list is discovered.

--- a/lib/features/relays/relays_notifier.dart
+++ b/lib/features/relays/relays_notifier.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/core/config.dart';
 import 'package:mostro_mobile/core/models/relay_list_event.dart';
 import 'package:mostro_mobile/features/settings/settings_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
@@ -31,7 +32,6 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   final Ref ref;
   SubscriptionManager? _subscriptionManager;
   StreamSubscription<RelayListEvent>? _relayListSubscription;
-  Timer? _settingsWatchTimer;
   Timer? _retryTimer;
   
   // Hash-based deduplication to prevent processing identical relay lists
@@ -644,31 +644,28 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
 
   /// Initialize settings listener to watch for Mostro pubkey changes
   void _initSettingsListener() {
-    // Watch settings changes and re-sync when Mostro pubkey changes
-    String? currentPubkey = settings.state.mostroPublicKey;
-    
-    // Use a simple timer to periodically check for changes
-    // This avoids circular dependency issues with provider watching
-    _settingsWatchTimer = Timer.periodic(const Duration(seconds: 5), (timer) {
-      final newPubkey = settings.state.mostroPublicKey;
-      
-      // Only reset if there's a REAL change (both values are non-empty and different)
-      if (newPubkey != currentPubkey && 
-          currentPubkey != null && 
-          newPubkey.isNotEmpty && 
-          currentPubkey!.isNotEmpty) {
-        logger.i('Detected REAL Mostro pubkey change: $currentPubkey -> $newPubkey');
-        currentPubkey = newPubkey;
-        
-        // Full reset: clear all relays and perform a fresh sync
-        _cleanAllRelaysAndResync();
-      } else if (newPubkey != currentPubkey) {
-        // Just update the tracking variable without reset (initial load)
-        logger.i('Initial Mostro pubkey load: $newPubkey');
-        currentPubkey = newPubkey;
-        syncWithMostroInstance();
-      }
-    });
+    // React to Mostro pubkey changes; replaces a 5 s polling timer that ran
+    // for the app's whole life. try/catch keeps construction usable with
+    // fake refs in unit tests (same pattern as _initMostroRelaySync).
+    try {
+      ref.listen<String>(
+        settingsProvider.select((s) => s.mostroPublicKey),
+        (previous, next) {
+          if (previous == next) return;
+          if (previous != null && previous.isNotEmpty && next.isNotEmpty) {
+            logger.i('Detected REAL Mostro pubkey change: $previous -> $next');
+            // Full reset: clear all relays and perform a fresh sync
+            _cleanAllRelaysAndResync();
+          } else {
+            // Initial load: sync without wiping state
+            logger.i('Initial Mostro pubkey load: $next');
+            syncWithMostroInstance();
+          }
+        },
+      );
+    } catch (e) {
+      logger.w('Settings listener unavailable (test environment?): $e');
+    }
   }
 
   /// Clean all relays and perform fresh sync with new Mostro
@@ -851,7 +848,6 @@ class RelaysNotifier extends StateNotifier<List<Relay>> {
   void dispose() {
     _relayListSubscription?.cancel();
     _subscriptionManager?.dispose();
-    _settingsWatchTimer?.cancel();
     _retryTimer?.cancel();  // Cancel retry timer to prevent leak
     super.dispose();
   }

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -1007,38 +1007,36 @@ class _CountdownWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Watch the countdown time provider for real-time updates
-    final timeAsync = ref.watch(countdownTimeProvider);
+    // The provider is only a 1 s rebuild ticker; its DateTime is never read
+    // (_buildCountDownTime calls DateTime.now() itself). Rendering is not
+    // gated on the AsyncValue: now that the provider is autoDispose its first
+    // frame after every screen entry is `loading`, and gating would blank the
+    // countdown on each visit instead of only the first.
+    ref.watch(countdownTimeProvider);
     final messagesAsync = ref.watch(mostroMessageHistoryProvider(orderId));
 
-    return timeAsync.when(
-      data: (currentTime) {
-        return messagesAsync.maybeWhen(
-          data: (messages) {
-            final countdownWidget = _buildCountDownTime(
-              context,
-              ref,
-              tradeState,
-              messages,
-              expiresAtTimestamp,
-            );
-
-            if (countdownWidget != null) {
-              return Column(
-                children: [
-                  countdownWidget,
-                  const SizedBox(height: 36),
-                ],
-              );
-            } else {
-              return const SizedBox(height: 12);
-            }
-          },
-          orElse: () => const SizedBox(height: 12),
+    return messagesAsync.maybeWhen(
+      data: (messages) {
+        final countdownWidget = _buildCountDownTime(
+          context,
+          ref,
+          tradeState,
+          messages,
+          expiresAtTimestamp,
         );
+
+        if (countdownWidget != null) {
+          return Column(
+            children: [
+              countdownWidget,
+              const SizedBox(height: 36),
+            ],
+          );
+        } else {
+          return const SizedBox(height: 12);
+        }
       },
-      loading: () => const SizedBox(height: 12),
-      error: (error, stack) => const SizedBox(height: 12),
+      orElse: () => const SizedBox(height: 12),
     );
   }
 

--- a/lib/features/wallet/providers/nwc_provider.dart
+++ b/lib/features/wallet/providers/nwc_provider.dart
@@ -95,7 +95,6 @@ class NwcNotifier extends StateNotifier<NwcState> {
   Timer? _balanceRefreshTimer;
 
   /// Timer for connection health checks.
-  Timer? _healthCheckTimer;
 
   /// Number of consecutive reconnect attempts.
   int _reconnectAttempts = 0;
@@ -191,7 +190,6 @@ class NwcNotifier extends StateNotifier<NwcState> {
       _startBalanceRefresh();
 
       // Start connection health checks (every 30 seconds)
-      _startHealthChecks();
 
       logger.i('NWC: Connected to wallet "${info?.alias ?? "unknown"}"');
     } on NwcInvalidUriException catch (e) {
@@ -242,45 +240,36 @@ class NwcNotifier extends StateNotifier<NwcState> {
     );
   }
 
-  /// Starts periodic balance refresh.
+  /// Starts the periodic balance-and-health tick. A single get_balance per
+  /// minute both refreshes the balance and proves the connection is alive;
+  /// the previous separate 30 s health check tripled the relay round trips.
   void _startBalanceRefresh() {
     _balanceRefreshTimer?.cancel();
     _balanceRefreshTimer = Timer.periodic(
       const Duration(seconds: 60),
-      (_) => refreshBalance(),
+      (_) => _refreshBalanceAndHealth(),
     );
   }
 
-  /// Starts periodic connection health checks.
-  void _startHealthChecks() {
-    _healthCheckTimer?.cancel();
-    _healthCheckTimer = Timer.periodic(
-      const Duration(seconds: 30),
-      (_) => _checkHealth(),
-    );
-  }
-
-  /// Checks connection health by attempting a get_balance call.
-  Future<void> _checkHealth() async {
+  Future<void> _refreshBalanceAndHealth() async {
     if (_client == null || !_client!.isConnected) {
       _handleConnectionDrop();
       return;
     }
 
     try {
-      await _client!.getBalance();
-      if (!state.connectionHealthy) {
-        state = state.copyWith(
-          connectionHealthy: true,
-          lastSuccessfulContact: DateTime.now().millisecondsSinceEpoch,
-        );
-      }
+      final balance = await _client!.getBalance();
+      state = state.copyWith(
+        balanceMsats: balance.balance,
+        lastSuccessfulContact: DateTime.now().millisecondsSinceEpoch,
+        connectionHealthy: true,
+      );
     } on NwcTimeoutException {
       logger.w('NWC: Health check timed out');
       state = state.copyWith(connectionHealthy: false);
       _handleConnectionDrop();
     } catch (e) {
-      logger.w('NWC: Health check failed: $e');
+      logger.w('NWC: Balance/health refresh failed: $e');
       state = state.copyWith(connectionHealthy: false);
     }
   }
@@ -350,8 +339,6 @@ class NwcNotifier extends StateNotifier<NwcState> {
     _notificationSub = null;
     _balanceRefreshTimer?.cancel();
     _balanceRefreshTimer = null;
-    _healthCheckTimer?.cancel();
-    _healthCheckTimer = null;
     _client?.disconnect();
     _client = null;
   }

--- a/lib/features/wallet/providers/nwc_provider.dart
+++ b/lib/features/wallet/providers/nwc_provider.dart
@@ -94,8 +94,6 @@ class NwcNotifier extends StateNotifier<NwcState> {
   /// Timer for periodic balance refresh.
   Timer? _balanceRefreshTimer;
 
-  /// Timer for connection health checks.
-
   /// Number of consecutive reconnect attempts.
   int _reconnectAttempts = 0;
 
@@ -186,10 +184,8 @@ class NwcNotifier extends StateNotifier<NwcState> {
       // Subscribe to wallet notifications
       _subscribeToNotifications();
 
-      // Start periodic balance refresh (every 60 seconds)
+      // Start the periodic balance-and-health tick (every 60 seconds)
       _startBalanceRefresh();
-
-      // Start connection health checks (every 30 seconds)
 
       logger.i('NWC: Connected to wallet "${info?.alias ?? "unknown"}"');
     } on NwcInvalidUriException catch (e) {
@@ -251,6 +247,9 @@ class NwcNotifier extends StateNotifier<NwcState> {
     );
   }
 
+  /// Refreshes the balance and, from the same round trip, the connection
+  /// health. A timeout means the wallet relay stopped answering, which starts
+  /// the reconnect.
   Future<void> _refreshBalanceAndHealth() async {
     if (_client == null || !_client!.isConnected) {
       _handleConnectionDrop();
@@ -259,17 +258,20 @@ class NwcNotifier extends StateNotifier<NwcState> {
 
     try {
       final balance = await _client!.getBalance();
+      if (!mounted) return;
       state = state.copyWith(
         balanceMsats: balance.balance,
         lastSuccessfulContact: DateTime.now().millisecondsSinceEpoch,
         connectionHealthy: true,
       );
     } on NwcTimeoutException {
-      logger.w('NWC: Health check timed out');
+      logger.w('NWC: Balance/health refresh timed out');
+      if (!mounted) return;
       state = state.copyWith(connectionHealthy: false);
       _handleConnectionDrop();
     } catch (e) {
       logger.w('NWC: Balance/health refresh failed: $e');
+      if (!mounted) return;
       state = state.copyWith(connectionHealthy: false);
     }
   }
@@ -463,21 +465,13 @@ class NwcNotifier extends StateNotifier<NwcState> {
     }
   }
 
-  /// Refreshes the wallet balance.
-  Future<void> refreshBalance() async {
-    if (_client == null || !_client!.isConnected) return;
-
-    try {
-      final balance = await _client!.getBalance();
-      state = state.copyWith(
-        balanceMsats: balance.balance,
-        lastSuccessfulContact: DateTime.now().millisecondsSinceEpoch,
-        connectionHealthy: true,
-      );
-    } catch (e) {
-      logger.w('NWC: Failed to refresh balance: $e');
-    }
-  }
+  /// Refreshes the wallet balance on demand (wallet UI refresh button).
+  ///
+  /// Shares the periodic tick's implementation: the same get_balance already
+  /// carries the health signal, so a manual refresh that times out marks the
+  /// connection unhealthy and starts the reconnect instead of reporting a
+  /// healthy wallet with a stale balance.
+  Future<void> refreshBalance() => _refreshBalanceAndHealth();
 
   /// Refreshes wallet info (alias, supported methods, etc.).
   Future<void> refreshInfo() async {

--- a/lib/features/wallet/providers/nwc_provider.dart
+++ b/lib/features/wallet/providers/nwc_provider.dart
@@ -247,31 +247,48 @@ class NwcNotifier extends StateNotifier<NwcState> {
     );
   }
 
+  /// Whether [client] is still the notifier's live client.
+  ///
+  /// `NwcClient.disconnect()` cancels the request subscription but never
+  /// completes the pending `Completer`, so a `get_balance` issued by a client
+  /// that `_cleanup()` has already replaced stays in flight until its own
+  /// `requestTimeout` (30 s) fires. Without this check that stale timeout
+  /// would mark the *current* client unhealthy and kick off a reconnect it
+  /// does not need.
+  bool _isLiveClient(NwcClient client) => mounted && identical(client, _client);
+
   /// Refreshes the balance and, from the same round trip, the connection
   /// health. A timeout means the wallet relay stopped answering, which starts
   /// the reconnect.
   Future<void> _refreshBalanceAndHealth() async {
-    if (_client == null || !_client!.isConnected) {
+    final client = _client;
+    if (client == null || !client.isConnected) {
       _handleConnectionDrop();
       return;
     }
 
     try {
-      final balance = await _client!.getBalance();
-      if (!mounted) return;
+      final balance = await client.getBalance();
+      if (!_isLiveClient(client)) return;
       state = state.copyWith(
         balanceMsats: balance.balance,
         lastSuccessfulContact: DateTime.now().millisecondsSinceEpoch,
         connectionHealthy: true,
       );
     } on NwcTimeoutException {
+      if (!_isLiveClient(client)) {
+        logger.d('NWC: Ignoring timeout from a superseded wallet connection');
+        return;
+      }
       logger.w('NWC: Balance/health refresh timed out');
-      if (!mounted) return;
       state = state.copyWith(connectionHealthy: false);
       _handleConnectionDrop();
     } catch (e) {
+      if (!_isLiveClient(client)) {
+        logger.d('NWC: Ignoring failure from a superseded wallet connection');
+        return;
+      }
       logger.w('NWC: Balance/health refresh failed: $e');
-      if (!mounted) return;
       state = state.copyWith(connectionHealthy: false);
     }
   }

--- a/lib/shared/providers/time_provider.dart
+++ b/lib/shared/providers/time_provider.dart
@@ -11,7 +11,9 @@ final timeProvider = StreamProvider<DateTime>((ref) {
 
 /// Provides a more efficient countdown timer using Timer.periodic
 /// with automatic cleanup and debouncing
-final countdownTimeProvider = StreamProvider<DateTime>((ref) {
+// autoDispose: as keep-alive, the 1 s timer kept running for the app's whole
+// life after the first visit to a countdown screen.
+final countdownTimeProvider = StreamProvider.autoDispose<DateTime>((ref) {
   late StreamController<DateTime> controller;
   Timer? timer;
   DateTime? lastEmittedTime;

--- a/test/features/relays/relays_notifier_mostro_switch_test.dart
+++ b/test/features/relays/relays_notifier_mostro_switch_test.dart
@@ -57,9 +57,9 @@ void main() {
     await tester.pump(const Duration(seconds: 30));
   }
 
-  testWidgets('a Mostro pubkey change clears the previous instance relays',
-      (tester) async {
-    // Arrange: the current instance published a relay list.
+  /// Puts one relay published by the currently configured instance into the
+  /// notifier's state.
+  Future<void> seedCurrentInstanceRelay(WidgetTester tester) async {
     container.read(relaysProvider);
     await tester.pump();
     relayListController.add(RelayListEvent(
@@ -75,6 +75,12 @@ void main() {
       hasLength(1),
       reason: 'precondition: the old instance relay is in the list',
     );
+  }
+
+  testWidgets('a Mostro pubkey change clears the previous instance relays',
+      (tester) async {
+    // Arrange: the current instance published a relay list.
+    await seedCurrentInstanceRelay(tester);
 
     // Act: switch node, exactly as MostroNodesNotifier.selectNode does.
     await container
@@ -92,6 +98,35 @@ void main() {
           'leak the previous Mostro instance across the switch',
     );
     verify(nostrService.ensureBootstrapConnectivity()).called(1);
+
+    await tearDownContainer(tester);
+  });
+
+  testWidgets('clearing the Mostro pubkey also tears the old instance down',
+      (tester) async {
+    // Arrange
+    await seedCurrentInstanceRelay(tester);
+
+    // The constructor's deferred sync already unsubscribed once; only the
+    // calls caused by clearing the pubkey are of interest here.
+    clearInteractions(sharedManager);
+
+    // Act: drop the configured instance entirely.
+    await container.read(settingsProvider.notifier).updateMostroInstance('');
+    await tester.pump();
+
+    // Assert: syncWithMostroInstance() bails out on an empty pubkey before it
+    // reaches its own unsubscribe/prune, so this transition has to be torn
+    // down explicitly — otherwise the relays and the kind 10002 REQ of an
+    // instance the app is no longer configured for stay alive.
+    expect(
+      container.read(relaysProvider).where(
+            (r) => r.url == 'wss://relay.old-mostro.test',
+          ),
+      isEmpty,
+      reason: 'no instance is configured, so no instance relay may remain',
+    );
+    verify(sharedManager.unsubscribeFromMostroRelayList()).called(1);
 
     await tearDownContainer(tester);
   });

--- a/test/features/relays/relays_notifier_mostro_switch_test.dart
+++ b/test/features/relays/relays_notifier_mostro_switch_test.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/core/config.dart';
+import 'package:mostro_mobile/core/models/relay_list_event.dart';
+import 'package:mostro_mobile/features/relays/relays_provider.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../../mocks.mocks.dart';
+
+/// Switching Mostro instance must wipe the previous instance's relays.
+///
+/// That reset used to be driven by a `Timer.periodic(5 s)` polling
+/// `settings.state.mostroPublicKey`; it is now a `ref.listen` on the same
+/// value. The listener is registered inside a `try/catch` (fake refs in unit
+/// tests), so a wiring mistake would not throw — it would silently leave the
+/// app talking to the old instance's relays. This pins the behaviour.
+void main() {
+  late StreamController<RelayListEvent> relayListController;
+  late MockSubscriptionManagerSpy sharedManager;
+  late MockNostrService nostrService;
+  late ProviderContainer container;
+
+  const otherMostro =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    relayListController = StreamController<RelayListEvent>.broadcast();
+    sharedManager = MockSubscriptionManagerSpy();
+    when(sharedManager.relayList).thenAnswer((_) => relayListController.stream);
+    nostrService = MockNostrService();
+    when(nostrService.ensureBootstrapConnectivity())
+        .thenAnswer((_) async {});
+    container = ProviderContainer(overrides: [
+      sharedPreferencesProvider.overrideWithValue(SharedPreferencesAsync()),
+      subscriptionManagerProvider.overrideWithValue(sharedManager),
+      nostrServiceProvider.overrideWithValue(nostrService),
+    ]);
+  });
+
+  /// The notifier's deferred sync polls NostrService for up to 10 s and then
+  /// schedules a 10 s retry; let those timers elapse so the test binding's
+  /// "no pending timers" invariant holds.
+  Future<void> tearDownContainer(WidgetTester tester) async {
+    container.dispose();
+    await relayListController.close();
+    await tester.pump(const Duration(seconds: 30));
+  }
+
+  testWidgets('a Mostro pubkey change clears the previous instance relays',
+      (tester) async {
+    // Arrange: the current instance published a relay list.
+    container.read(relaysProvider);
+    await tester.pump();
+    relayListController.add(RelayListEvent(
+      relays: const ['wss://relay.old-mostro.test'],
+      publishedAt: DateTime.now(),
+      authorPubkey: Config.mostroPubKey,
+    ));
+    await tester.pump();
+    expect(
+      container.read(relaysProvider).where(
+            (r) => r.url == 'wss://relay.old-mostro.test',
+          ),
+      hasLength(1),
+      reason: 'precondition: the old instance relay is in the list',
+    );
+
+    // Act: switch node, exactly as MostroNodesNotifier.selectNode does.
+    await container
+        .read(settingsProvider.notifier)
+        .updateMostroInstance(otherMostro);
+    await tester.pump();
+
+    // Assert
+    expect(
+      container.read(relaysProvider).where(
+            (r) => r.url == 'wss://relay.old-mostro.test',
+          ),
+      isEmpty,
+      reason: 'the new instance never published this relay; keeping it would '
+          'leak the previous Mostro instance across the switch',
+    );
+    verify(nostrService.ensureBootstrapConnectivity()).called(1);
+
+    await tearDownContainer(tester);
+  });
+}

--- a/test/shared/providers/timer_hygiene_test.dart
+++ b/test/shared/providers/timer_hygiene_test.dart
@@ -17,6 +17,23 @@ void main() {
     );
   });
 
+  test('countdownTimeProvider is torn down when the last screen stops watching',
+      () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final sub = container.listen(countdownTimeProvider, (_, __) {});
+    expect(container.exists(countdownTimeProvider), isTrue,
+        reason: 'precondition: a watching screen keeps the ticker alive');
+
+    // Leaving the screen: the stream — and with it the 1 s Timer.periodic
+    // its onCancel/onDispose hooks clean up — must not outlive the listener.
+    sub.close();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.exists(countdownTimeProvider), isFalse);
+  });
+
   test('timeProvider (30 s ticker) stays keep-alive for the list screens',
       () {
     // Documented status quo: the coarse ticker is shared by Home/Trades rows

--- a/test/shared/providers/timer_hygiene_test.dart
+++ b/test/shared/providers/timer_hygiene_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/shared/providers/time_provider.dart';
+
+/// `countdownTimeProvider` drives the per-second countdown on the trade
+/// detail and take-order screens. As a keep-alive provider, its 1 s
+/// `Timer.periodic` ran for the rest of the app's life after the first visit
+/// to either screen; autoDispose tears the stream (and its `onCancel` timer
+/// cleanup) down when the last screen stops watching.
+void main() {
+  test('countdownTimeProvider is autoDispose', () {
+    expect(
+      countdownTimeProvider,
+      isA<AutoDisposeStreamProvider<DateTime>>(),
+      reason: 'a keep-alive countdown keeps its 1 s timer running forever '
+          'after the first trade-detail visit',
+    );
+  });
+
+  test('timeProvider (30 s ticker) stays keep-alive for the list screens',
+      () {
+    // Documented status quo: the coarse ticker is shared by Home/Trades rows
+    // and is cheap; scoping it further is plan item 2.7.
+    expect(timeProvider, isNot(isA<AutoDisposeStreamProvider<DateTime>>()));
+  });
+}


### PR DESCRIPTION
## Summary

Item **1.8** (last of Phase 1) of the performance plan: three timers doing avoidable periodic work.

1. **5 s settings poll, forever** — `RelaysNotifier._initSettingsListener` ran a `Timer.periodic(5 s)` for the app's whole life just to detect a Mostro pubkey change. Replaced with `ref.listen(settingsProvider.select((s) => s.mostroPublicKey))`, preserving the initial-load vs real-change semantics (`syncWithMostroInstance` vs `_cleanAllRelaysAndResync`). Wrapped in try/catch so unit tests with fake refs keep working (same pattern as `_initMostroRelaySync`).
2. **1 s countdown timer, forever** — `countdownTimeProvider` was keep-alive, so after the first visit to a trade-detail/take-order screen its `Timer.periodic(1 s)` ran until process exit. Now `autoDispose`; its existing `onListen`/`onCancel` lifecycle already handles per-listener start/stop.
3. **3 NWC round trips per minute** — a 60 s balance refresh plus a 30 s health check, both issuing `get_balance` over the wallet relay. A single 60 s tick now refreshes the balance and derives `connectionHealthy` from the same call, keeping the `NwcTimeoutException` → `_handleConnectionDrop()` reconnect path.

**Deliberately out of scope:** pausing the NWC/time tickers while the app is backgrounded — it interacts with the lifecycle switch (PR #688) and wallet UX, and belongs with plan item 4.2.

## Test plan

- [x] New `test/shared/providers/timer_hygiene_test.dart` (RED on `main`): pins `countdownTimeProvider` as autoDispose and documents `timeProvider` status quo
- [x] Targeted suites (shared/providers, relays, nwc, trades) — 133/133
- [x] Full `flutter test` — 1161/1161
- [x] `flutter analyze` — no new issues
- [ ] Manual: switch Mostro node (relay list must reset and resync); leave a trade-detail screen and check no 1 s timer remains (DevTools timeline); NWC wallet stays healthy with 1 request/min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relay connections now update immediately when switching Mostro instances, removing outdated relays and reconnecting to the selected instance.
  * Wallet health and balance updates are synchronized, with timeouts correctly triggering reconnection.
  * Manual wallet refreshes now detect connection failures and stale balances.

* **Performance**
  * Countdown timers are automatically stopped when no longer in use, reducing unnecessary background activity.

* **Tests**
  * Added coverage for Mostro instance switching, relay cleanup, reconnection, and countdown timer lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->