### PR TITLE
perf: dedupe and coalesce order book emissions

### DIFF
--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -33,6 +33,11 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
   /// init() completes, so the order subscription can be opened once Nostr is up.
   Timer? _initRetryTimer;
 
+  /// Coalesces stream emissions: during a 48 h replay burst every relay copy
+  /// used to trigger a full-list emission (and downstream sort/filter).
+  static const Duration emitDebounce = Duration(milliseconds: 50);
+  Timer? _emitTimer;
+
   static const _initRetryInterval = Duration(milliseconds: 200);
   static const _maxInitRetries = 150; // ~30s before giving up
 
@@ -78,8 +83,18 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
 
     _subscription = _nostrService.subscribeToEvents(request).listen((event) {
       if (event.type == 'order') {
-        _events[event.orderId!] = event;
-        _eventStreamController.add(_events.values.toList());
+        final orderId = event.orderId!;
+        // Drop duplicate/stale relay copies: kind 38383 is replaceable, only
+        // the newest created_at per order id matters.
+        final known = _events[orderId];
+        if (known != null &&
+            known.createdAt != null &&
+            event.createdAt != null &&
+            !event.createdAt!.isAfter(known.createdAt!)) {
+          return;
+        }
+        _events[orderId] = event;
+        _scheduleEmit();
       } else if (event.kind == infoEventKind &&
           event.pubkey == _settings.mostroPublicKey) {
         logger.i('Mostro instance info loaded: $event');
@@ -119,15 +134,23 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
   }
 
   void _emitEvents() {
+    _emitTimer?.cancel();
+    _emitTimer = null;
     if (!_eventStreamController.isClosed) {
       _eventStreamController.add(_events.values.toList());
     }
+  }
+
+  /// Emits once per [emitDebounce] window instead of once per event.
+  void _scheduleEmit() {
+    _emitTimer ??= Timer(emitDebounce, _emitEvents);
   }
 
   @override
   void dispose() {
     _subscription?.cancel();
     _initRetryTimer?.cancel();
+    _emitTimer?.cancel();
     _eventStreamController.close();
     _mostroInstanceController.close();
     _events.clear();

--- a/lib/data/repositories/open_orders_repository.dart
+++ b/lib/data/repositories/open_orders_repository.dart
@@ -84,19 +84,22 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
     _subscription = _nostrService.subscribeToEvents(request).listen((event) {
       if (event.type == 'order') {
         final orderId = event.orderId!;
-        // Drop duplicate/stale relay copies: kind 38383 is replaceable, only
-        // the newest created_at per order id matters.
+        // Drop duplicate/stale relay copies: kind 38383 is addressable, only
+        // the surviving replacement per order id matters.
         final known = _events[orderId];
-        if (known != null &&
-            known.createdAt != null &&
-            event.createdAt != null &&
-            !event.createdAt!.isAfter(known.createdAt!)) {
+        if (known != null && !_supersedes(event, known)) {
           return;
         }
         _events[orderId] = event;
         _scheduleEmit();
       } else if (event.kind == infoEventKind &&
           event.pubkey == _settings.mostroPublicKey) {
+        // Kind 38385 is addressable too, and it carries pow, protocolVersion
+        // and the order limits: a stale relay copy must not roll those back.
+        final knownInstance = _mostroInstance;
+        if (knownInstance != null && !_supersedes(event, knownInstance)) {
+          return;
+        }
         logger.i('Mostro instance info loaded: $event');
         _mostroInstance = event;
         if (!_mostroInstanceController.isClosed) {
@@ -131,6 +134,26 @@ class OpenOrdersRepository implements OrderRepository<NostrEvent> {
         );
       }
     });
+  }
+
+  /// NIP-01 retention rule for addressable events: the newest `created_at`
+  /// wins and, when two copies share the same second, the lexicographically
+  /// lower event id does. Relays apply the same rule, so the copy kept here is
+  /// the one that actually survives on the relay set rather than whichever
+  /// relay happened to answer first.
+  static bool _supersedes(NostrEvent candidate, NostrEvent known) {
+    final knownAt = known.createdAt;
+    if (knownAt == null) return true;
+    final candidateAt = candidate.createdAt;
+    if (candidateAt == null) return false;
+    // compareTo compares the instant only, so a UTC and a local copy of the
+    // same second still tie instead of ordering arbitrarily.
+    final byTime = candidateAt.compareTo(knownAt);
+    if (byTime != 0) return byTime > 0;
+    final candidateId = candidate.id;
+    final knownId = known.id;
+    if (candidateId == null || knownId == null) return false;
+    return candidateId.compareTo(knownId) < 0;
   }
 
   void _emitEvents() {

--- a/test/data/repositories/open_orders_repository_test.dart
+++ b/test/data/repositories/open_orders_repository_test.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:dart_nostr/nostr/model/event/event.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/data/repositories/open_orders_repository.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+
+import '../../mocks.mocks.dart';
+
+/// The order book repository used to emit a fresh copy of the whole book for
+/// every kind-38383 event from every relay, with no deduplication: a 48 h
+/// replay from R relays produced R×M list emissions, each re-sorting and
+/// re-filtering downstream. Emissions are now coalesced per debounce window
+/// and stale/duplicate relay copies are dropped by (orderId, created_at).
+void main() {
+  const mostroPubkey = 'mostro-pubkey';
+
+  late MockNostrService nostr;
+  late StreamController<NostrEvent> relay;
+  late OpenOrdersRepository repo;
+
+  NostrEvent order(String id,
+      {required int createdAt, String status = 'pending'}) {
+    return NostrEvent(
+      id: 'event-$id-$createdAt',
+      kind: 38383,
+      content: '',
+      sig: '',
+      pubkey: mostroPubkey,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+      tags: [
+        ['d', id],
+        ['z', 'order'],
+        ['s', status],
+      ],
+    );
+  }
+
+  setUp(() {
+    relay = StreamController<NostrEvent>.broadcast();
+    nostr = MockNostrService();
+    when(nostr.isInitialized).thenReturn(true);
+    when(nostr.subscribeToEvents(any)).thenAnswer((_) => relay.stream);
+    repo = OpenOrdersRepository(
+      nostr,
+      Settings(
+        relays: const ['wss://relay.a'],
+        fullPrivacyMode: false,
+        mostroPublicKey: mostroPubkey,
+      ),
+    );
+  });
+
+  tearDown(() async {
+    repo.dispose();
+    await relay.close();
+  });
+
+  test('coalesces a burst of events into a single emission', () async {
+    // Arrange
+    final emissions = <List<NostrEvent>>[];
+    final sub = repo.eventsStream.skip(1).listen(emissions.add);
+    addTearDown(sub.cancel);
+
+    // Act: a replay burst of three different orders
+    relay
+      ..add(order('a', createdAt: 100))
+      ..add(order('b', createdAt: 101))
+      ..add(order('c', createdAt: 102));
+    await Future<void>.delayed(
+      OpenOrdersRepository.emitDebounce + const Duration(milliseconds: 20),
+    );
+
+    // Assert: one coalesced emission carrying the three orders
+    expect(emissions, hasLength(1));
+    expect(emissions.single, hasLength(3));
+  });
+
+  test('drops stale relay copies of an order', () async {
+    // Act: newest first, then an older copy from another relay
+    relay
+      ..add(order('a', createdAt: 200, status: 'canceled'))
+      ..add(order('a', createdAt: 100, status: 'pending'));
+    await Future<void>.delayed(
+      OpenOrdersRepository.emitDebounce + const Duration(milliseconds: 20),
+    );
+
+    // Assert: the older event must not overwrite the newer state
+    final kept = await repo.getOrderById('a');
+    expect(kept!.status.toString(), contains('canceled'));
+  });
+
+  test('keeps the newer copy when it arrives second', () async {
+    relay
+      ..add(order('a', createdAt: 100, status: 'pending'))
+      ..add(order('a', createdAt: 200, status: 'canceled'));
+    await Future<void>.delayed(
+      OpenOrdersRepository.emitDebounce + const Duration(milliseconds: 20),
+    );
+
+    final kept = await repo.getOrderById('a');
+    expect(kept!.status.toString(), contains('canceled'));
+  });
+}

--- a/test/data/repositories/open_orders_repository_test.dart
+++ b/test/data/repositories/open_orders_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/data/repositories/open_orders_repository.dart';
+import 'package:mostro_mobile/features/mostro/mostro_instance.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
 
 import '../../mocks.mocks.dart';
@@ -22,9 +23,9 @@ void main() {
   late OpenOrdersRepository repo;
 
   NostrEvent order(String id,
-      {required int createdAt, String status = 'pending'}) {
+      {required int createdAt, String status = 'pending', String? eventId}) {
     return NostrEvent(
-      id: 'event-$id-$createdAt',
+      id: eventId ?? 'event-$id-$createdAt',
       kind: 38383,
       content: '',
       sig: '',
@@ -34,6 +35,22 @@ void main() {
         ['d', id],
         ['z', 'order'],
         ['s', status],
+      ],
+    );
+  }
+
+  NostrEvent info({required int createdAt, required int pow}) {
+    return NostrEvent(
+      id: 'info-$createdAt-$pow',
+      kind: 38385,
+      content: '',
+      sig: '',
+      pubkey: mostroPubkey,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+      tags: [
+        ['d', 'mostro'],
+        ['z', 'info'],
+        ['pow', '$pow'],
       ],
     );
   }
@@ -102,5 +119,62 @@ void main() {
 
     final kept = await repo.getOrderById('a');
     expect(kept!.status.toString(), contains('canceled'));
+  });
+
+  test('breaks created_at ties by the lower event id, whichever arrives first',
+      () async {
+    // Two replacements published in the same second: NIP-01 keeps the
+    // lexicographically lower id, so both relay orderings must converge.
+    relay
+      ..add(order('a', createdAt: 100, status: 'pending', eventId: 'bbb'))
+      ..add(order('a', createdAt: 100, status: 'canceled', eventId: 'aaa'));
+    await Future<void>.delayed(
+      OpenOrdersRepository.emitDebounce + const Duration(milliseconds: 20),
+    );
+
+    final kept = await repo.getOrderById('a');
+    expect(kept!.id, 'aaa');
+    expect(kept.status.toString(), contains('canceled'));
+  });
+
+  test('keeps the lower event id when the higher one arrives second', () async {
+    relay
+      ..add(order('a', createdAt: 100, status: 'canceled', eventId: 'aaa'))
+      ..add(order('a', createdAt: 100, status: 'pending', eventId: 'bbb'));
+    await Future<void>.delayed(
+      OpenOrdersRepository.emitDebounce + const Duration(milliseconds: 20),
+    );
+
+    final kept = await repo.getOrderById('a');
+    expect(kept!.id, 'aaa');
+    expect(kept.status.toString(), contains('canceled'));
+  });
+
+  test('a stale relay copy cannot roll back the mostro instance info',
+      () async {
+    // Kind 38385 carries pow/protocol_version/order limits, so an older copy
+    // replayed by a lagging relay must not overwrite the newer one.
+    relay
+      ..add(info(createdAt: 200, pow: 8))
+      ..add(info(createdAt: 100, pow: 0));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(repo.mostroInstance!.pow, 8);
+  });
+
+  test('emits the mostro instance only once per distinct info event', () async {
+    final seen = <NostrEvent>[];
+    final sub = repo.mostroInstanceStream.listen(seen.add);
+    addTearDown(sub.cancel);
+
+    final duplicate = info(createdAt: 200, pow: 8);
+    relay
+      ..add(duplicate)
+      ..add(duplicate)
+      ..add(info(createdAt: 300, pow: 4));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(seen, hasLength(2));
+    expect(seen.last.pow, 4);
   });
 }


### PR DESCRIPTION
## Summary

Item **2.1** of the performance plan. `OpenOrdersRepository` did `_events[orderId] = event; add(_events.values.toList())` for **every** kind-38383 event from **every** relay:

- no dedup: with R relays, each order arrived R times and each copy overwrote the map (even with an older `created_at`) and emitted the full list;
- during the 48 h replay at cold start / resume, R×M list emissions hit `filteredOrdersProvider` (full sort with tag-scanning comparators), `filteredTradesWithOrderStateProvider`, and a listener in every `OrderNotifier` — the burst behind the multi-second freeze while the book loads.

## Changes

- **Dedup by `(orderId, created_at)`**: kind 38383 is a replaceable event; a copy that is not strictly newer than the cached one is dropped, so a stale relay can no longer roll back an order's visible state either.
- **Coalescing**: subscription-driven emissions collapse to one per 50 ms window (`OpenOrdersRepository.emitDebounce`). Explicit mutations (`addOrder`, `deleteOrder`, `reloadData`, initial snapshot) still emit immediately and cancel any pending scheduled emission.

## Test plan

- [x] New `test/data/repositories/open_orders_repository_test.dart` (RED on `main`): a 3-event burst produces exactly one emission; a stale relay copy cannot overwrite a newer one; a newer copy still replaces an older one
- [x] Full `flutter test` — 1182/1182
- [x] `flutter analyze` — no new issues
- [ ] Manual: cold start with a populated book — the list fills in one paint instead of reflowing per event; pull-to-refresh unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur