### PR TITLE
perf: O(1) order event lookups and per-order public event listeners

### DIFF
--- a/lib/features/order/notifiers/order_notifier.dart
+++ b/lib/features/order/notifiers/order_notifier.dart
@@ -13,7 +13,7 @@ import 'package:mostro_mobile/shared/utils/order_sync_helpers.dart';
 
 class OrderNotifier extends AbstractMostroNotifier {
   late final MostroService mostroService;
-  ProviderSubscription<AsyncValue<List<NostrEvent>>>? _publicEventsSubscription;
+  ProviderSubscription<NostrEvent?>? _publicEventsSubscription;
   bool _isSyncing = false; // Only for sync() method
   bool _hydrated = false; // A sync() has read the history successfully
   bool _resyncRequested = false; // A sync() was asked for while one was running
@@ -296,12 +296,13 @@ class OrderNotifier extends AbstractMostroNotifier {
 
   /// Subscribe to public events (38383) to detect automatic order cancellation
   void _subscribeToPublicEvents() {
+    // Listen to this order's own public event: listening to the whole book
+    // made every notifier run this callback for every incoming public event.
     _publicEventsSubscription = ref.listen(
-      orderEventsProvider,
-      (_, next) async {
+      eventProvider(orderId),
+      (_, publicEvent) async {
         try {
           // Only detect automatic cancellation for pending orders
-          final publicEvent = ref.read(eventProvider(orderId));
           final currentSession = ref.read(sessionProvider(orderId));
           
           if (publicEvent?.status == Status.canceled && 

--- a/lib/shared/providers/order_repository_provider.dart
+++ b/lib/shared/providers/order_repository_provider.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/data/repositories/open_orders_repository.dart';
@@ -24,13 +23,21 @@ final orderEventsProvider = StreamProvider<List<NostrEvent>>((ref) {
   return orderRepository.eventsStream;
 });
 
+/// The book indexed by order id, rebuilt once per emission. Family lookups
+/// go through this map instead of each scanning the whole list.
+final orderMapProvider = Provider<Map<String, NostrEvent>>((ref) {
+  final allEvents = ref.watch(orderEventsProvider).maybeWhen(
+        data: (data) => data,
+        orElse: () => const <NostrEvent>[],
+      );
+  return {
+    for (final event in allEvents)
+      if (event.orderId != null) event.orderId!: event,
+  };
+});
+
 final eventProvider = Provider.family<NostrEvent?, String>((ref, orderId) {
-  final allEventsAsync = ref.watch(orderEventsProvider);
-  final allEvents = allEventsAsync.maybeWhen(
-    data: (data) => data,
-    orElse: () => [],
-  );
-  // lastWhereOrNull returns null if no match is found
-  return allEvents
-      .lastWhereOrNull((evt) => (evt as NostrEvent).orderId == orderId);
+  // O(1) per lookup; previously a lastWhereOrNull scan of the whole book per
+  // family instance per emission (O(sessions x orders) per public event).
+  return ref.watch(orderMapProvider.select((map) => map[orderId]));
 });

--- a/test/shared/providers/event_provider_test.dart
+++ b/test/shared/providers/event_provider_test.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:dart_nostr/nostr/model/event/event.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/repositories/open_orders_repository.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
+
+import '../../mocks.mocks.dart';
+
+/// `eventProvider(orderId)` used to scan the whole book with
+/// `lastWhereOrNull` — O(orders) per family instance per emission, and every
+/// `OrderNotifier` consulted it on every emission: O(sessions × orders) per
+/// incoming public event. It is now an O(1) lookup on `orderMapProvider`.
+void main() {
+  const mostroPubkey = 'mostro-pubkey';
+
+  late StreamController<NostrEvent> relay;
+  late OpenOrdersRepository repo;
+  late ProviderContainer container;
+
+  NostrEvent order(String id, {required int createdAt}) => NostrEvent(
+        id: 'event-$id-$createdAt',
+        kind: 38383,
+        content: '',
+        sig: '',
+        pubkey: mostroPubkey,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+        tags: [
+          ['d', id],
+          ['z', 'order'],
+          ['s', 'pending'],
+        ],
+      );
+
+  setUp(() {
+    relay = StreamController<NostrEvent>.broadcast();
+    final nostr = MockNostrService();
+    when(nostr.isInitialized).thenReturn(true);
+    when(nostr.subscribeToEvents(any)).thenAnswer((_) => relay.stream);
+    repo = OpenOrdersRepository(
+      nostr,
+      Settings(
+        relays: const ['wss://relay.a'],
+        fullPrivacyMode: false,
+        mostroPublicKey: mostroPubkey,
+      ),
+    );
+    container = ProviderContainer(overrides: [
+      orderRepositoryProvider.overrideWithValue(repo),
+    ]);
+    // Keep the stream chain alive from the start: without a listener the
+    // StreamProvider stays in loading and the derived map reads empty.
+    container.listen(orderMapProvider, (_, __) {});
+  });
+
+  tearDown(() async {
+    container.dispose();
+    repo.dispose();
+    await relay.close();
+  });
+
+  // Generous settle window: covers both immediate emissions and the
+  // coalesced emissions introduced by the order-book debounce PR.
+  Future<void> flush() =>
+      Future<void>.delayed(const Duration(milliseconds: 200));
+
+  test('orderMapProvider indexes the book by order id', () async {
+    relay
+      ..add(order('a', createdAt: 100))
+      ..add(order('b', createdAt: 101));
+    await flush();
+
+    final map = container.read(orderMapProvider);
+    expect(map.keys, containsAll(['a', 'b']));
+    expect(map['a']!.id, 'event-a-100');
+  });
+
+  test('eventProvider resolves through the map', () async {
+    relay.add(order('a', createdAt: 100));
+    await flush();
+
+    expect(container.read(eventProvider('a'))!.id, 'event-a-100');
+    expect(container.read(eventProvider('missing')), isNull);
+  });
+
+  test('an unrelated order does not notify an eventProvider listener',
+      () async {
+    relay.add(order('a', createdAt: 100));
+    await flush();
+    expect(container.read(eventProvider('a')), isNotNull,
+        reason: 'precondition: the map already carries order a');
+    var notifications = 0;
+    container.listen(eventProvider('a'), (_, __) => notifications++);
+
+    relay.add(order('b', createdAt: 200));
+    await flush();
+
+    expect(notifications, 0);
+    expect(container.read(eventProvider('b')), isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary

Item **2.2** of the performance plan. Two multiplicative costs on every incoming kind-38383 event:

1. `eventProvider(orderId)` recomputed with a `lastWhereOrNull` scan of the whole book (tag-scanning `orderId` getter per element) for **every family instance** on every emission.
2. Every `OrderNotifier` (one per session) listened to `orderEventsProvider` (the whole book) to detect auto-cancellation, and read `eventProvider(orderId)` inside each callback → O(sessions × orders) per public event, worst during the initial replay burst.

## Changes

- **`orderMapProvider`**: the book indexed by order id, rebuilt once per emission (O(M) total instead of O(M) per family instance).
- **`eventProvider`** = `ref.watch(orderMapProvider.select((m) => m[orderId]))` — O(1), and listeners are only notified when *their* order's event instance changes.
- **`OrderNotifier._subscribeToPublicEvents`** listens to `eventProvider(orderId)`; the auto-expiration logic is unchanged and now runs only when that order's event actually changes.

Complements #691 (2.1: dedup + coalescing at the repository); the two PRs are independent and touch different files.

## Test plan

- [x] New `test/shared/providers/event_provider_test.dart` (compile-RED on `main`): map indexes the book; `eventProvider` resolves through it; an event for another order does **not** notify an `eventProvider(a)` listener
- [x] Full `flutter test` — 1187/1187
- [x] `flutter analyze` — no new issues
- [ ] Manual: a pending order taken elsewhere still disappears from My Trades when its public event flips to canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur