### PR TITLE
perf: recompute the trades list only when its real inputs change

### DIFF
--- a/lib/features/trades/providers/trades_provider.dart
+++ b/lib/features/trades/providers/trades_provider.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
-import 'package:mostro_mobile/features/order/models/order_state.dart';
 import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
@@ -25,64 +24,65 @@ bool matchesStatusFilter(Status status, Status filter) {
 }
 
 // New provider that properly handles synthetic status filtering by checking OrderState
+/// The session list re-emits on every save (several per protocol step);
+/// only the set of order ids matters here. A sorted joined key gives the
+/// select() a value with string equality, so unchanged ids don't recompute.
+final _sessionOrderIdsKeyProvider = Provider<String>((ref) {
+  return ref.watch(sessionNotifierProvider.select((sessions) {
+    final ids = sessions
+        .map((s) => s.orderId)
+        .whereType<String>()
+        .toList()
+      ..sort();
+    return ids.join('\n');
+  }));
+});
+
 final filteredTradesWithOrderStateProvider =
     Provider<AsyncValue<List<NostrEvent>>>((ref) {
   final allOrdersAsync = ref.watch(orderEventsProvider);
-  final sessions = ref.watch(sessionNotifierProvider);
+  final idsKey = ref.watch(_sessionOrderIdsKeyProvider);
   final selectedStatusFilter = ref.watch(statusFilterProvider);
 
   return allOrdersAsync.when(
     data: (allOrders) {
-      final orderIds = sessions.map((s) => s.orderId).toSet();
-      logger
-          .d('Got ${allOrders.length} orders and ${orderIds.length} sessions');
+      final orderIds =
+          idsKey.isEmpty ? const <String>{} : idsKey.split('\n').toSet();
 
-      // Make a copy to avoid modifying the original list
-      final sortedOrders = List<NostrEvent>.from(allOrders);
-      sortedOrders
-          .sort((o1, o2) => o1.expirationDate.compareTo(o2.expirationDate));
+      // Pick only the user's orders (O(book)) and sort just those (O(n log n)
+      // over the sessions instead of the whole book, with the expiration tag
+      // parsed once per order instead of per comparison).
+      final mine = <(DateTime, NostrEvent)>[
+        for (final order in allOrders)
+          if (orderIds.contains(order.orderId))
+            (order.expirationDate, order),
+      ]..sort((a, b) => b.$1.compareTo(a.$1));
 
-      var filtered =
-          sortedOrders.reversed.where((o) => orderIds.contains(o.orderId));
+      var filtered = mine.map((entry) => entry.$2);
 
-      // Watch all OrderNotifier providers for reactive updates
-      final Map<String, OrderState> orderStates = {};
-      for (final order in filtered) {
-        if (order.orderId != null) {
-          try {
-            // Watch (not read) each OrderNotifier to make it reactive
-            final orderState = ref.watch(orderNotifierProvider(order.orderId!));
-            orderStates[order.orderId!] = orderState;
-          } catch (e) {
-            logger.w('Could not watch OrderState for ${order.orderId}: $e');
-            // Skip this order if we can't get its state
-          }
-        }
-      }
-
-      // Apply status filter if one is selected - use the watched OrderStates
+      // Order states are only needed when a status filter is active; watching
+      // them unconditionally instantiated a notifier per session and re-ran
+      // this provider on every state assignment.
       if (selectedStatusFilter != null) {
         filtered = filtered.where((order) {
-          if (order.orderId == null) return false;
-
-          final orderState = orderStates[order.orderId!];
-          if (orderState != null) {
-            return matchesStatusFilter(orderState.status, selectedStatusFilter);
-          } else {
-            // Fallback to raw status comparison if OrderState not available
-            return matchesStatusFilter(order.status, selectedStatusFilter);
+          final orderId = order.orderId;
+          if (orderId == null) return false;
+          Status status;
+          try {
+            status = ref.watch(
+              orderNotifierProvider(orderId).select((s) => s.status),
+            );
+          } catch (e) {
+            logger.w('Could not watch OrderState for $orderId: $e');
+            status = order.status;
           }
+          return matchesStatusFilter(status, selectedStatusFilter);
         });
       }
 
-      final result = filtered.toList();
-      logger.d('Filtered to ${result.length} trades');
-      return AsyncValue.data(result);
+      return AsyncValue.data(filtered.toList());
     },
-    loading: () {
-      logger.d('Orders loading');
-      return const AsyncValue.loading();
-    },
+    loading: () => const AsyncValue.loading(),
     error: (error, stackTrace) {
       logger.e('Error filtering trades: $error');
       return AsyncValue.error(error, stackTrace);

--- a/lib/services/lifecycle_manager.dart
+++ b/lib/services/lifecycle_manager.dart
@@ -10,7 +10,6 @@ import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
 import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
-import 'package:mostro_mobile/features/trades/providers/trades_provider.dart';
 import 'package:mostro_mobile/shared/providers/background_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
@@ -123,10 +122,6 @@ class LifecycleManager extends WidgetsBindingObserver {
       // never re-reads storage nor re-opens its relay subscription on its own
       logger.i("Reloading dispute chats");
       ref.invalidate(disputeChatNotifierProvider);
-
-      // Force UI update for trades
-      logger.i("Invalidating providers to refresh UI");
-      ref.invalidate(filteredTradesWithOrderStateProvider);
 
       logger.i("Foreground transition complete");
     } catch (e) {

--- a/test/features/trades/trades_provider_test.dart
+++ b/test/features/trades/trades_provider_test.dart
@@ -1,0 +1,124 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/features/trades/providers/trades_provider.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+
+import '../../mocks.mocks.dart';
+
+/// `filteredTradesWithOrderStateProvider` watched the whole session list and
+/// sorted the whole order book on every recompute. Any session save (several
+/// per protocol step) re-ran it even when the set of the user's order ids was
+/// unchanged, returning a fresh list and rebuilding the whole Trades screen.
+void main() {
+  NostrEvent order(String id, {required int expiration}) => NostrEvent(
+        id: 'event-$id',
+        kind: 38383,
+        content: '',
+        sig: '',
+        pubkey: 'mostro-pubkey',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1000000),
+        tags: [
+          ['d', id],
+          ['z', 'order'],
+          ['s', 'pending'],
+          ['expiration', '$expiration'],
+        ],
+      );
+
+  Session session(String orderId) {
+    final s = Session(
+      masterKey: NostrKeyPairs(
+          private:
+              '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'),
+      tradeKey: NostrKeyPairs(
+          private:
+              'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'),
+      keyIndex: 0,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+    );
+    s.orderId = orderId;
+    return s;
+  }
+
+  late _FakeSessionNotifier sessions;
+  late ProviderContainer container;
+
+  setUp(() {
+    final book = [
+      order('a', expiration: 100),
+      order('b', expiration: 300),
+      order('c', expiration: 200),
+    ];
+    container = ProviderContainer(overrides: [
+      orderEventsProvider.overrideWith((ref) => Stream.value(book)),
+      sessionNotifierProvider.overrideWith((ref) {
+        sessions = _FakeSessionNotifier(ref);
+        return sessions;
+      }),
+    ]);
+    container.listen(filteredTradesWithOrderStateProvider, (_, __) {});
+  });
+
+  tearDown(() => container.dispose());
+
+  Future<void> flush() => Future<void>.delayed(Duration.zero);
+
+  test('returns only the sessions\' orders, newest expiration first',
+      () async {
+    sessions.emit([session('a'), session('b')]);
+    await flush();
+
+    final trades =
+        container.read(filteredTradesWithOrderStateProvider).value!;
+    expect(trades.map((e) => e.orderId), ['b', 'a']);
+  });
+
+  test('a session emission with the same order ids does not notify listeners',
+      () async {
+    sessions.emit([session('a'), session('b')]);
+    await flush();
+    var notifications = 0;
+    container.listen(
+        filteredTradesWithOrderStateProvider, (_, __) => notifications++);
+
+    // New list, new Session instances, same order ids — several of these
+    // happen per protocol step (saveSession/updateSession).
+    sessions.emit([session('a'), session('b')]);
+    await flush();
+
+    expect(notifications, 0,
+        reason: 'an unchanged order-id set must not rebuild the screen');
+  });
+
+  test('a genuinely new session id does notify listeners', () async {
+    sessions.emit([session('a')]);
+    await flush();
+    var notifications = 0;
+    container.listen(
+        filteredTradesWithOrderStateProvider, (_, __) => notifications++);
+
+    sessions.emit([session('a'), session('c')]);
+    await flush();
+
+    expect(notifications, greaterThan(0));
+    final trades =
+        container.read(filteredTradesWithOrderStateProvider).value!;
+    expect(trades.map((e) => e.orderId), ['c', 'a']);
+  });
+}
+
+/// Session list the provider can read without touching storage.
+class _FakeSessionNotifier extends SessionNotifier {
+  _FakeSessionNotifier(Ref ref)
+      : super(ref, MockSessionStorage(), MockSettings()) {
+    state = const [];
+  }
+
+  void emit(List<Session> sessions) => state = sessions;
+}


### PR DESCRIPTION
## Summary

Item **2.4** of the performance plan. `filteredTradesWithOrderStateProvider` was the god provider behind most My Trades rebuilds:

- watched the **whole session list**, which re-emits a fresh list on every save — and `handleEvent` saves the session on `payInvoice`, `addInvoice`, `buyerTookOrder`, `holdInvoicePaymentAccepted`, disputes…;
- copied and sorted the **entire order book** per recompute, with `expirationDate` (linear tag scan + parse) evaluated per comparison;
- `ref.watch(orderNotifierProvider(id))` for every session **even with no status filter**, instantiating a notifier (DB sync + subscriptions) per session and re-running on every state assignment;
- was blanket-`ref.invalidate`d on every foreground transition.

## Changes

- Session dependency narrowed to a **sorted order-id key** through `select()` — emissions that keep the id set unchanged no longer recompute (pinned by test).
- Only the user's orders are picked from the book (single O(book) pass) and only those are sorted, with the expiration tag parsed once per order.
- Order statuses watched via `orderNotifierProvider(id).select((s) => s.status)` and **only while a status filter is active** (same admin-canceled semantics via `matchesStatusFilter`).
- Removed the foreground `ref.invalidate(filteredTradesWithOrderStateProvider)` — the provider recomputes from its own inputs (the order-book reload still flows through `orderEventsProvider`). The pull-to-refresh invalidate in `TradesScreen` is left as an explicit user action.

## Test plan

- [x] New `test/features/trades/trades_provider_test.dart` (RED on `main`): filtering + newest-expiration ordering; a session emission with the same ids does **not** notify; a new id does
- [x] `lifecycle_manager_test.dart` still green
- [x] Full `flutter test` — all green
- [x] `flutter analyze` — no new issues
- [ ] Manual: My Trades with a status filter reacts to an order state change; without filter, background protocol chatter causes no visible reflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur