### PR TITLE
perf: skip resubscribing when the session filter identity is unchanged

### DIFF
--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -64,6 +64,13 @@ class SubscriptionManager {
   /// (a relay sync retry, say) must not re-open a REQ behind its back.
   bool _isSuspended = false;
 
+  /// Identity of the filter each session subscription was built from
+  /// (sorted keys + transport + node). When a session-list emission produces
+  /// the same identity, the CLOSE + REQ (and its full history replay) is
+  /// skipped. Cleared in [unsubscribeByType] so an explicit teardown always
+  /// forces the next update through.
+  final Map<SubscriptionType, String> _appliedFilterKeys = {};
+
   SubscriptionManager(this.ref) {
     _initSessionListener();
     // Ensure resources are released with provider/container lifecycle
@@ -176,6 +183,13 @@ class SubscriptionManager {
     }
 
     try {
+      final filterKey = _filterIdentity(type, sessions);
+      if (filterKey != null &&
+          _appliedFilterKeys[type] == filterKey &&
+          _subscriptions.containsKey(type)) {
+        return;
+      }
+
       // Pre-warm persisted cursors so the chat filters — built
       // synchronously and later persisted for the background service —
       // see durable state even on a cold start
@@ -204,12 +218,45 @@ class SubscriptionManager {
         type: type,
         filter: filter,
       );
+      if (filterKey != null) {
+        _appliedFilterKeys[type] = filterKey;
+      }
 
       logger
           .i('Subscription created for $type with ${sessions.length} sessions');
     } catch (e, stackTrace) {
       logger.e('Failed to create $type subscription',
           error: e, stackTrace: stackTrace);
+    }
+  }
+
+  /// Stable identity of the inputs a session filter is derived from. Uses
+  /// the shared-key publics directly (not the derived K_sign) so no EC math
+  /// runs on the skip path. Cursor `since` values are deliberately excluded:
+  /// while a subscription stays open its cursor only moves forward.
+  String? _filterIdentity(SubscriptionType type, List<Session> sessions) {
+    switch (type) {
+      case SubscriptionType.orders:
+        final keys = sessions.map((s) => s.tradeKey.public).toList()..sort();
+        final transport = _resolveOrdersTransport();
+        final node = ref.read(settingsProvider).mostroPublicKey;
+        return 'orders|$transport|$node|${keys.join(',')}';
+      case SubscriptionType.chat:
+        final keys = sessions
+            .where((s) => s.sharedKey != null)
+            .map((s) => s.sharedKey!.public)
+            .toList()
+          ..sort();
+        return keys.isEmpty ? null : 'chat|${keys.join(',')}';
+      case SubscriptionType.disputeChat:
+        final keys = sessions
+            .where((s) => s.adminSharedKey != null)
+            .map((s) => s.adminSharedKey!.public)
+            .toList()
+          ..sort();
+        return keys.isEmpty ? null : 'dispute|${keys.join(',')}';
+      case SubscriptionType.relayList:
+        return null;
     }
   }
 
@@ -368,6 +415,7 @@ class SubscriptionManager {
   }
 
   void unsubscribeByType(SubscriptionType type) {
+    _appliedFilterKeys.remove(type);
     final subscription = _subscriptions[type];
     if (subscription != null) {
       subscription.cancel();

--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -71,6 +71,13 @@ class SubscriptionManager {
   /// forces the next update through.
   final Map<SubscriptionType, String> _appliedFilterKeys = {};
 
+  /// Per-type chain serializing subscription updates. The chat paths await a
+  /// cursor warm-up before recording their filter key, so without this two
+  /// identical bursty emissions both pass the identity check while the first
+  /// is still warming up, and each replays the CLOSE + REQ. Same pattern as
+  /// [ChatCursorStore.advance].
+  final Map<SubscriptionType, Future<void>> _updateQueue = {};
+
   SubscriptionManager(this.ref) {
     _initSessionListener();
     // Ensure resources are released with provider/container lifecycle
@@ -175,7 +182,22 @@ class SubscriptionManager {
   }
 
   Future<void> _updateSubscription(
+      SubscriptionType type, List<Session> sessions) {
+    final previous = _updateQueue[type] ?? Future.value();
+    final next = previous
+        .catchError((_) {})
+        .then((_) => _applySubscriptionUpdate(type, sessions));
+    _updateQueue[type] = next;
+    return next;
+  }
+
+  Future<void> _applySubscriptionUpdate(
       SubscriptionType type, List<Session> sessions) async {
+    // A queued update can run after [suspend]; the background service owns
+    // the filters then, and [resume] rebuilds everything from sessions.
+    if (_isSuspended) {
+      return;
+    }
     if (sessions.isEmpty) {
       logger.i('No sessions for $type subscription');
       unsubscribeByType(type);

--- a/test/features/subscriptions/subscription_filter_diff_test.dart
+++ b/test/features/subscriptions/subscription_filter_diff_test.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+
+import '../../mocks.mocks.dart';
+
+/// Every session-list emission tore down and re-issued the orders/chat/
+/// dispute REQs on every relay — and `handleEvent` saves the session several
+/// times per protocol step. Since the orders filter carries no `since`, each
+/// re-issue replayed the full gift-wrap history. The manager now skips the
+/// resubscribe when the filter identity (keys, transport, node) is unchanged.
+void main() {
+  late MockNostrService nostrService;
+  late MockOpenOrdersRepository orderRepository;
+  late ProviderContainer container;
+  late _FakeSessionNotifier sessions;
+  late SubscriptionManager manager;
+  var nextSubscriptionId = 0;
+
+  Session session(String orderId, String tradeKeyPrivate) {
+    final s = Session(
+      masterKey: NostrKeyPairs(
+          private:
+              '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'),
+      tradeKey: NostrKeyPairs(private: tradeKeyPrivate),
+      keyIndex: 0,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+    );
+    s.orderId = orderId;
+    return s;
+  }
+
+  const keyA =
+      'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+  const keyB =
+      'bbcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+  setUp(() {
+    nostrService = MockNostrService();
+    orderRepository = MockOpenOrdersRepository();
+    nextSubscriptionId = 0;
+    when(nostrService.subscribeToEvents(any)).thenAnswer((invocation) {
+      final request = invocation.positionalArguments.first as NostrRequest;
+      request.subscriptionId ??= 'sub-${nextSubscriptionId++}';
+      return const Stream<NostrEvent>.empty();
+    });
+    when(nostrService.unsubscribe(any)).thenAnswer((_) async {});
+    when(orderRepository.mostroInstanceStream)
+        .thenAnswer((_) => const Stream<NostrEvent>.empty());
+    when(orderRepository.mostroInstance).thenReturn(null);
+
+    container = ProviderContainer(overrides: [
+      nostrServiceProvider.overrideWithValue(nostrService),
+      orderRepositoryProvider.overrideWithValue(orderRepository),
+      settingsProvider.overrideWith((ref) => _FixedSettingsNotifier()),
+      sessionNotifierProvider.overrideWith((ref) {
+        sessions = _FakeSessionNotifier(ref);
+        return sessions;
+      }),
+    ]);
+  });
+
+  tearDown(() {
+    manager.unsubscribeAll();
+    container.dispose();
+  });
+
+  Future<void> flush() => Future<void>.delayed(Duration.zero);
+
+  Future<void> buildWithSession() async {
+    container.read(sessionNotifierProvider);
+    manager = container.read(subscriptionManagerProvider);
+    sessions.emit([session('order-a', keyA)]);
+    await flush();
+    clearInteractions(nostrService);
+  }
+
+  test('an unchanged session set does not re-issue the REQs', () async {
+    await buildWithSession();
+
+    // Same order id and trade key, fresh Session instances — what every
+    // saveSession/updateSession emission looks like.
+    sessions.emit([session('order-a', keyA)]);
+    await flush();
+
+    verifyNever(nostrService.subscribeToEvents(any));
+    verifyNever(nostrService.unsubscribe(any));
+  });
+
+  test('a new trade key re-issues the orders REQ', () async {
+    await buildWithSession();
+
+    sessions.emit([session('order-a', keyA), session('order-b', keyB)]);
+    await flush();
+
+    verify(nostrService.subscribeToEvents(any)).called(1);
+  });
+
+  test('subscribeAll still forces a resubscribe with unchanged sessions',
+      () async {
+    await buildWithSession();
+
+    manager.subscribeAll();
+    await flush();
+
+    verify(nostrService.subscribeToEvents(any)).called(greaterThan(0));
+  });
+}
+
+class _FixedSettingsNotifier extends SettingsNotifier {
+  _FixedSettingsNotifier() : super(MockSharedPreferencesAsync()) {
+    state = Settings(
+      relays: const [],
+      fullPrivacyMode: false,
+      mostroPublicKey: 'mostro-pubkey',
+    );
+  }
+}
+
+/// Session list the manager can read without touching storage.
+class _FakeSessionNotifier extends SessionNotifier {
+  _FakeSessionNotifier(Ref ref)
+      : super(ref, MockSessionStorage(), MockSettings()) {
+    state = const [];
+  }
+
+  void emit(List<Session> sessions) => state = sessions;
+}

--- a/test/features/subscriptions/subscription_filter_diff_test.dart
+++ b/test/features/subscriptions/subscription_filter_diff_test.dart
@@ -4,11 +4,13 @@ import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/peer.dart';
 import 'package:mostro_mobile/data/models/session.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/features/settings/settings_notifier.dart';
 import 'package:mostro_mobile/features/settings/settings_provider.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager.dart';
+import 'package:mostro_mobile/services/chat_cursor_store.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
 import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
 import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
@@ -119,6 +121,59 @@ void main() {
 
     verify(nostrService.subscribeToEvents(any)).called(greaterThan(0));
   });
+
+  test(
+      'identical chat emissions during a slow cursor warm-up issue a single '
+      'chat REQ', () async {
+    // The chat path awaits ChatCursorStore.warmUp before recording its
+    // filter key. Two identical bursty emissions used to both pass the
+    // identity check while the first was still warming up, each replaying
+    // the CLOSE + REQ.
+    container.dispose();
+    container = ProviderContainer(overrides: [
+      nostrServiceProvider.overrideWithValue(nostrService),
+      orderRepositoryProvider.overrideWithValue(orderRepository),
+      settingsProvider.overrideWith((ref) => _FixedSettingsNotifier()),
+      chatCursorStoreProvider.overrideWithValue(_SlowWarmUpCursorStore()),
+      sessionNotifierProvider.overrideWith((ref) {
+        sessions = _FakeSessionNotifier(ref);
+        return sessions;
+      }),
+    ]);
+    container.read(sessionNotifierProvider);
+    manager = container.read(subscriptionManagerProvider);
+
+    final peerPubkey = NostrKeyPairs(private: keyB).public;
+    Session chatSession() =>
+        session('order-a', keyA)..peer = Peer(publicKey: peerPubkey);
+
+    // Back-to-back emissions of the same session set, no flush in between —
+    // the second arrives while the first is still awaiting warmUp.
+    sessions.emit([chatSession()]);
+    sessions.emit([chatSession()]);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    final requests = verify(nostrService.subscribeToEvents(captureAny))
+        .captured
+        .cast<NostrRequest>();
+    final chatRequests = requests
+        .where((r) => r.filters.any((f) => (f.kinds ?? []).contains(14)))
+        .toList();
+    expect(chatRequests, hasLength(1));
+    verifyNever(nostrService.unsubscribe(any));
+  });
+}
+
+/// Chat cursor store whose warm-up stays pending across event-loop turns,
+/// widening the race window between the identity check and the REQ.
+class _SlowWarmUpCursorStore extends ChatCursorStore {
+  _SlowWarmUpCursorStore()
+      : super(MockSharedPreferencesAsync(),
+            keyPrefix: ChatCursorStore.peerKeyPrefix);
+
+  @override
+  Future<void> warmUp(Iterable<String> conversationIds) =>
+      Future<void>.delayed(const Duration(milliseconds: 5));
 }
 
 class _FixedSettingsNotifier extends SettingsNotifier {


### PR DESCRIPTION
## Summary

Item **2.5** of the performance plan. `SubscriptionManager` re-issued the orders/chat/disputeChat REQs on **every** `sessionNotifierProvider` emission — and `AbstractMostroNotifier.handleEvent` saves the session several times per protocol step (`payInvoice`, `addInvoice`, `buyerTookOrder`, `holdInvoicePaymentAccepted`, disputes). Each re-issue is a CLOSE + new REQ with a fresh sub-id on every relay; since the orders filter has no `since`, every relay replayed the full gift-wrap history, each replayed event costing a Sembast dedup read on the UI isolate.

## Changes

- `_filterIdentity(type, sessions)`: a stable key per subscription type — sorted trade keys + resolved transport + node pubkey for orders; sorted **shared-key publics** for chat/dispute (deliberately not the derived K_sign, so no EC math runs on the skip path). Cursor `since` values are excluded: while a REQ stays open its cursor only moves forward.
- `_updateSubscription` returns early (before the cursor warm-ups) when the identity matches the applied one and the subscription is still open.
- `unsubscribeByType` clears the applied identity, so `subscribeAll()`, `suspend()`/`resume()` and node switches keep forcing a fresh REQ (pinned by test).

## Test plan

- [x] New `test/features/subscriptions/subscription_filter_diff_test.dart` (RED on `main`): an unchanged session set issues no REQ/CLOSE; a new trade key re-issues; `subscribeAll` still forces
- [x] `subscription_manager_relay_list_lifecycle_test.dart` — still green (14/14 in the folder)
- [x] Full `flutter test` — 1196/1196
- [x] `flutter analyze` — no new issues
- [ ] Manual: walk an order through payInvoice → active with relay logging on — REQs must be issued once per real key-set change, not per protocol step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Reduced unnecessary subscription reconnects when session filters remain unchanged.
  - Serialized rapid subscription updates to prevent duplicate requests.
  - Helps preserve active subscriptions and avoid replaying full history unnecessarily.

- **Bug Fixes**
  - Subscription updates now correctly occur when relevant trading keys or connection details change.
  - Suspended subscriptions no longer reopen unexpectedly during queued updates.
  - Explicit unsubscribe and resubscribe actions continue to force a fresh subscription.

- **Tests**
  - Added coverage for unchanged filters, changed trading keys, and forced resubscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->