### PR TITLE
perf: cut per-build chat render costs

### DIFF
--- a/lib/features/chat/notifiers/chat_room_notifier.dart
+++ b/lib/features/chat/notifiers/chat_room_notifier.dart
@@ -190,7 +190,6 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       if (!messageExists) {
         // Add new message and sort
         final updatedMessages = [...state.messages, chat];
-        updatedMessages.sort((a, b) => b.createdAt!.compareTo(a.createdAt!));
         state = state.copy(messages: updatedMessages);
         logger.d('New message added from relay, total messages: ${updatedMessages.length}');
 
@@ -276,7 +275,6 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       final messageExists = state.messages.any((m) => m.id == innerEvent.id);
       if (!messageExists) {
         final updatedMessages = [...state.messages, innerEvent];
-        updatedMessages.sort((a, b) => b.createdAt!.compareTo(a.createdAt!));
         state = state.copy(messages: updatedMessages);
         logger.d('Message added to state optimistically, total messages: ${updatedMessages.length}');
       } else {
@@ -420,7 +418,6 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
           seen.add(m.id!);
           return true;
         }).toList();
-        deduped.sort((a, b) => b.createdAt!.compareTo(a.createdAt!));
         state = state.copy(messages: deduped);
         logger.i(
             'Successfully loaded and merged ${historicalMessages.length} historical messages, total: ${deduped.length} for chat $orderId');

--- a/lib/features/chat/notifiers/chat_rooms_notifier.dart
+++ b/lib/features/chat/notifiers/chat_rooms_notifier.dart
@@ -83,9 +83,6 @@ class ChatRoomsNotifier extends StateNotifier<List<ChatRoom>> {
     final now = DateTime.now();
 
     try {
-      // Add a small delay to ensure state has been updated
-      await Future.delayed(const Duration(milliseconds: 100));
-
       final chats = sessions
           .where(
         (s) =>
@@ -101,8 +98,24 @@ class ChatRoomsNotifier extends StateNotifier<List<ChatRoom>> {
           .where((chat) => chat.messages.isNotEmpty)
           .toList();
 
-      // Force update the state to trigger UI refresh
-      state = [...chats];
+      // Skip the emission when nothing visible changed: this runs after
+      // every incoming chat event and a fresh list rebuilds the whole
+      // chat-rooms screen.
+      final unchanged = state.length == chats.length &&
+          () {
+            for (var i = 0; i < chats.length; i++) {
+              if (state[i].orderId != chats[i].orderId ||
+                  state[i].messages.length != chats[i].messages.length ||
+                  (state[i].messages.isNotEmpty &&
+                      state[i].messages.last.id != chats[i].messages.last.id)) {
+                return false;
+              }
+            }
+            return true;
+          }();
+      if (!unchanged) {
+        state = [...chats];
+      }
       logger.d("Refreshed ${chats.length} chats with messages");
     } catch (e) {
       logger.e("Error refreshing chats: $e");

--- a/lib/features/chat/screens/chat_room_screen.dart
+++ b/lib/features/chat/screens/chat_room_screen.dart
@@ -56,7 +56,7 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom > 0;
+    final isKeyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
 
     if (isKeyboardVisible && !_wasKeyboardVisible) {
       Future.delayed(const Duration(milliseconds: 100), () {
@@ -111,7 +111,7 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
     final order = orderState.order;
 
     // Check if keyboard is visible
-    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom > 0;
+    final isKeyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
 
     return Scaffold(
       backgroundColor: AppTheme.backgroundDark,

--- a/lib/features/chat/utils/message_type_helpers.dart
+++ b/lib/features/chat/utils/message_type_helpers.dart
@@ -1,39 +1,65 @@
 import 'dart:convert';
 import 'package:dart_nostr/dart_nostr.dart';
 
-/// Utilities for determining message types from NostrEvent content
+/// Utilities for determining message types from NostrEvent content.
+///
+/// Message content is immutable per event id, so the classification is
+/// decoded once and memoized: the bubble used to run up to two jsonDecode
+/// calls per build per message.
 class MessageTypeUtils {
-  /// Helper function to check if a message is an encrypted image
-  static bool isEncryptedImageMessage(NostrEvent message) {
-    try {
-      final content = message.content;
-      if (content == null || !content.startsWith('{')) return false;
+  static const int _cacheLimit = 2000;
+  static final Map<String, (String?, MessageContentType)> _cache = {};
 
-      final jsonContent = jsonDecode(content) as Map<String, dynamic>;
-      return jsonContent['type'] == 'image_encrypted';
-    } catch (e) {
-      return false;
-    }
-  }
+  /// Test hook: the memoized classification for an event id, if any.
+  static MessageContentType? cachedTypeFor(String eventId) =>
+      _cache[eventId]?.$2;
 
-  /// Helper function to check if a message is an encrypted file
-  static bool isEncryptedFileMessage(NostrEvent message) {
-    try {
-      final content = message.content;
-      if (content == null || !content.startsWith('{')) return false;
+  static bool isEncryptedImageMessage(NostrEvent message) =>
+      getMessageType(message) == MessageContentType.encryptedImage;
 
-      final jsonContent = jsonDecode(content) as Map<String, dynamic>;
-      return jsonContent['type'] == 'file_encrypted';
-    } catch (e) {
-      return false;
-    }
-  }
-  
+  static bool isEncryptedFileMessage(NostrEvent message) =>
+      getMessageType(message) == MessageContentType.encryptedFile;
+
   /// Get the message type enum for more structured handling
   static MessageContentType getMessageType(NostrEvent message) {
-    if (isEncryptedImageMessage(message)) return MessageContentType.encryptedImage;
-    if (isEncryptedFileMessage(message)) return MessageContentType.encryptedFile;
-    return MessageContentType.text;
+    final id = message.id;
+    if (id != null) {
+      final cached = _cache[id];
+      // Validated by content identity: a rebuild passes the same event
+      // instance and hits; a different content under a reused id (tests,
+      // hypothetical replacements) re-classifies.
+      if (cached != null && identical(cached.$1, message.content)) {
+        return cached.$2;
+      }
+    }
+    final type = _classify(message);
+    if (id != null) {
+      if (_cache.length >= _cacheLimit) {
+        _cache.clear();
+      }
+      _cache[id] = (message.content, type);
+    }
+    return type;
+  }
+
+  static MessageContentType _classify(NostrEvent message) {
+    try {
+      final content = message.content;
+      if (content == null || !content.startsWith('{')) {
+        return MessageContentType.text;
+      }
+      final jsonContent = jsonDecode(content) as Map<String, dynamic>;
+      switch (jsonContent['type']) {
+        case 'image_encrypted':
+          return MessageContentType.encryptedImage;
+        case 'file_encrypted':
+          return MessageContentType.encryptedFile;
+        default:
+          return MessageContentType.text;
+      }
+    } catch (e) {
+      return MessageContentType.text;
+    }
   }
 }
 

--- a/lib/features/chat/utils/message_type_helpers.dart
+++ b/lib/features/chat/utils/message_type_helpers.dart
@@ -45,7 +45,7 @@ class MessageTypeUtils {
   static MessageContentType _classify(NostrEvent message) {
     try {
       final content = message.content;
-      if (content == null || !content.startsWith('{')) {
+      if (content == null || !content.trimLeft().startsWith('{')) {
         return MessageContentType.text;
       }
       final jsonContent = jsonDecode(content) as Map<String, dynamic>;

--- a/lib/features/chat/widgets/chat_messages_list.dart
+++ b/lib/features/chat/widgets/chat_messages_list.dart
@@ -1,4 +1,3 @@
-import 'package:dart_nostr/nostr/model/event/event.dart';
 import 'package:flutter/material.dart';
 import 'package:mostro_mobile/core/app_theme.dart';
 import 'package:mostro_mobile/data/models/chat_room.dart';
@@ -99,13 +98,9 @@ class _ChatMessagesListState extends State<ChatMessagesList> {
 
   @override
   Widget build(BuildContext context) {
-    // Sort messages chronologically (oldest first) for proper chat display
-    final sortedMessages = List<NostrEvent>.from(widget.chatRoom.messages);
-    sortedMessages.sort((a, b) {
-      final aTime = a.createdAt is int ? a.createdAt as int : 0;
-      final bTime = b.createdAt is int ? b.createdAt as int : 0;
-      return aTime.compareTo(bTime); // Oldest first
-    });
+    // ChatRoom's constructor keeps messages sorted oldest-first; re-sorting
+    // a copy here ran on every build (including each keyboard frame).
+    final sortedMessages = widget.chatRoom.messages;
 
     return Container(
       color: AppTheme.backgroundDark,

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -47,7 +47,7 @@ class MessageBubble extends ConsumerWidget {
             Flexible(
               child: ConstrainedBox(
                 constraints: BoxConstraints(
-                  maxWidth: MediaQuery.of(context).size.width * 0.75,
+                  maxWidth: MediaQuery.sizeOf(context).width * 0.75,
                   minWidth: 0,
                 ),
                 child: Container(
@@ -95,7 +95,7 @@ class MessageBubble extends ConsumerWidget {
             Flexible(
               child: ConstrainedBox(
                 constraints: BoxConstraints(
-                  maxWidth: MediaQuery.of(context).size.width * 0.75,
+                  maxWidth: MediaQuery.sizeOf(context).width * 0.75,
                   minWidth: 0,
                 ),
                 child: Container(
@@ -141,7 +141,7 @@ class MessageBubble extends ConsumerWidget {
           Flexible(
             child: ConstrainedBox(
               constraints: BoxConstraints(
-                maxWidth: MediaQuery.of(context).size.width * 0.75, // Max 75% of screen width
+                maxWidth: MediaQuery.sizeOf(context).width * 0.75, // Max 75% of screen width
                 minWidth: 0,
               ),
               child: GestureDetector(
@@ -182,10 +182,15 @@ class MessageBubble extends ConsumerWidget {
     );
   }
 
+  // Hoisted: DateFormat parses its pattern on construction, and one was
+  // built per bubble per build.
+  static final DateFormat _format24h = DateFormat('HH:mm');
+  static final DateFormat _format12h = DateFormat('h:mm a');
+
   String _formatTime(BuildContext context) {
     if (message.createdAt == null) return '';
     final use24h = MediaQuery.alwaysUse24HourFormatOf(context);
-    return DateFormat(use24h ? 'HH:mm' : 'h:mm a')
+    return (use24h ? _format24h : _format12h)
         .format(message.createdAt!.toLocal());
   }
 

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -182,16 +182,23 @@ class MessageBubble extends ConsumerWidget {
     );
   }
 
-  // Hoisted: DateFormat parses its pattern on construction, and one was
-  // built per bubble per build.
-  static final DateFormat _format24h = DateFormat('HH:mm');
-  static final DateFormat _format12h = DateFormat('h:mm a');
+  // DateFormat parses its pattern on construction. Cache one per locale so
+  // rebuilding after an in-app language change does not reuse the formatter
+  // created for the previous locale.
+  static final Map<Locale, DateFormat> _format24hByLocale = {};
+  static final Map<Locale, DateFormat> _format12hByLocale = {};
 
   String _formatTime(BuildContext context) {
     if (message.createdAt == null) return '';
     final use24h = MediaQuery.alwaysUse24HourFormatOf(context);
-    return (use24h ? _format24h : _format12h)
-        .format(message.createdAt!.toLocal());
+    final locale = Localizations.localeOf(context);
+    final formatters = use24h ? _format24hByLocale : _format12hByLocale;
+    final pattern = use24h ? 'HH:mm' : 'h:mm a';
+    final formatter = formatters.putIfAbsent(
+      locale,
+      () => DateFormat(pattern, locale.toString()),
+    );
+    return formatter.format(message.createdAt!.toLocal());
   }
 
   Widget _buildTimestamp(BuildContext context) {

--- a/test/features/chat/message_type_and_order_test.dart
+++ b/test/features/chat/message_type_and_order_test.dart
@@ -1,0 +1,89 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/chat_room.dart';
+import 'package:mostro_mobile/features/chat/utils/message_type_helpers.dart';
+
+/// Chat render costs: the bubble ran up to two `jsonDecode`s of the message
+/// content per build to classify it, and the message list re-sorted the room
+/// on every build even though `ChatRoom`'s constructor already sorts. The
+/// classification is now decoded once and memoized by event id, and the
+/// ascending constructor order is the single canonical order.
+void main() {
+  NostrEvent event(String id, {String? content, required int createdAt}) =>
+      NostrEvent(
+        id: id,
+        kind: 14,
+        content: content ?? 'hola',
+        sig: '',
+        pubkey: 'peer',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+        tags: const [],
+      );
+
+  group('MessageTypeUtils', () {
+    test('classifies text, encrypted image and encrypted file', () {
+      expect(MessageTypeUtils.getMessageType(event('t', createdAt: 1)),
+          MessageContentType.text);
+      expect(
+        MessageTypeUtils.getMessageType(event('i',
+            content: '{"type":"image_encrypted","url":"x"}', createdAt: 1)),
+        MessageContentType.encryptedImage,
+      );
+      expect(
+        MessageTypeUtils.getMessageType(event('f',
+            content: '{"type":"file_encrypted","url":"x"}', createdAt: 1)),
+        MessageContentType.encryptedFile,
+      );
+      expect(
+        MessageTypeUtils.getMessageType(
+            event('j', content: '{"type":"other"}', createdAt: 1)),
+        MessageContentType.text,
+      );
+      expect(
+        MessageTypeUtils.getMessageType(
+            event('b', content: '{broken json', createdAt: 1)),
+        MessageContentType.text,
+      );
+    });
+
+    test('boolean helpers agree with the classification', () {
+      final img = event('i2',
+          content: '{"type":"image_encrypted","url":"x"}', createdAt: 1);
+      expect(MessageTypeUtils.isEncryptedImageMessage(img), isTrue);
+      expect(MessageTypeUtils.isEncryptedFileMessage(img), isFalse);
+    });
+
+    test('the classification is memoized per event id', () {
+      final e = event('memo',
+          content: '{"type":"image_encrypted","url":"x"}', createdAt: 1);
+      MessageTypeUtils.getMessageType(e);
+
+      expect(MessageTypeUtils.cachedTypeFor('memo'),
+          MessageContentType.encryptedImage,
+          reason: 'a bubble rebuild must not re-decode the JSON content');
+    });
+  });
+
+  group('ChatRoom canonical order', () {
+    test('constructor sorts ascending regardless of input order', () {
+      final room = ChatRoom(orderId: 'o1', messages: [
+        event('late', createdAt: 300),
+        event('early', createdAt: 100),
+        event('mid', createdAt: 200),
+      ]);
+
+      expect(room.messages.map((m) => m.id), ['early', 'mid', 'late']);
+    });
+
+    test('copy() keeps the ascending order after appending', () {
+      final room = ChatRoom(orderId: 'o1', messages: [
+        event('early', createdAt: 100),
+      ]);
+
+      final updated =
+          room.copy(messages: [...room.messages, event('late', createdAt: 50)]);
+
+      expect(updated.messages.map((m) => m.id), ['late', 'early']);
+    });
+  });
+}

--- a/test/features/chat/message_type_and_order_test.dart
+++ b/test/features/chat/message_type_and_order_test.dart
@@ -35,6 +35,17 @@ void main() {
         MessageContentType.encryptedFile,
       );
       expect(
+        MessageTypeUtils.getMessageType(event('wi',
+            content: '  \n{"type":"image_encrypted","url":"x"}',
+            createdAt: 1)),
+        MessageContentType.encryptedImage,
+      );
+      expect(
+        MessageTypeUtils.getMessageType(event('wf',
+            content: '\t{"type":"file_encrypted","url":"x"}', createdAt: 1)),
+        MessageContentType.encryptedFile,
+      );
+      expect(
         MessageTypeUtils.getMessageType(
             event('j', content: '{"type":"other"}', createdAt: 1)),
         MessageContentType.text,

--- a/test/features/chat/widgets/chat_widgets_test.dart
+++ b/test/features/chat/widgets/chat_widgets_test.dart
@@ -2,17 +2,22 @@ import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:mostro_mobile/data/models/chat_room.dart';
 import 'package:mostro_mobile/data/models/enums/order_type.dart';
 import 'package:mostro_mobile/data/models/enums/role.dart';
 import 'package:mostro_mobile/data/models/enums/status.dart';
 import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
 import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/features/chat/chat_room_provider.dart';
+import 'package:mostro_mobile/features/chat/notifiers/chat_room_notifier.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_tab_provider.dart';
 import 'package:mostro_mobile/features/chat/widgets/chat_error_screen.dart';
 import 'package:mostro_mobile/features/chat/widgets/chat_tabs.dart';
 import 'package:mostro_mobile/features/chat/widgets/empty_state_view.dart';
 import 'package:mostro_mobile/features/chat/widgets/info_buttons.dart';
+import 'package:mostro_mobile/features/chat/widgets/message_bubble.dart';
 import 'package:mostro_mobile/features/chat/widgets/peer_header.dart';
 import 'package:mostro_mobile/features/chat/widgets/trade_information_tab.dart';
 import 'package:mostro_mobile/features/chat/widgets/user_information_tab.dart';
@@ -45,6 +50,16 @@ Order order({Status status = Status.active}) => Order(
       paymentMethod: 'Wire transfer',
       premium: 3,
       createdAt: 1700000000,
+    );
+
+NostrEvent message(DateTime createdAt) => NostrEvent(
+      id: 'message-1',
+      kind: 14,
+      content: 'hola',
+      sig: '',
+      pubkey: _peerPubkey,
+      createdAt: createdAt,
+      tags: const [],
     );
 
 Future<void> pump(
@@ -258,6 +273,49 @@ void main() {
 
       expect(find.byType(TradeInformationTab), findsOneWidget);
       expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('MessageBubble', () {
+    testWidgets('updates its time formatter when the locale changes',
+        (tester) async {
+      final createdAt = DateTime(2026, 1, 1, 13, 5);
+      final bubble = MessageBubble(
+        message: message(createdAt),
+        peerPubkey: _peerPubkey,
+        orderId: 'order-1',
+      );
+
+      Future<void> pumpWithLocale(Locale locale) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              chatRoomsProvider.overrideWith(
+                (ref, orderId) => ChatRoomNotifier(
+                  ChatRoom(orderId: orderId, messages: []),
+                  orderId,
+                  ref,
+                ),
+              ),
+            ],
+            child: MaterialApp(
+              locale: locale,
+              localizationsDelegates: S.localizationsDelegates,
+              supportedLocales: S.supportedLocales,
+              home: Scaffold(body: bubble),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      await pumpWithLocale(const Locale('en'));
+      expect(find.text(DateFormat('h:mm a', 'en').format(createdAt)),
+          findsOneWidget);
+
+      await pumpWithLocale(const Locale('es'));
+      expect(find.text(DateFormat('h:mm a', 'es').format(createdAt)),
+          findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

Item **2.6** of the performance plan: chat paid several per-build costs multiplied by message count and keyboard animation frames (~15 frames per open/close, each rebuilding the screen because of a full `MediaQuery.of` dependency).

## Changes

- **Message classification memoized** — `MessageTypeUtils` ran up to two `jsonDecode`s of the content per bubble per build. One decode now classifies (image/file/text) and the result is memoized per event id, validated by content identity (same instance → hit; reused id with different content — tests, hypothetical replacement — re-classifies). Bounded cache (2000).
- **Scoped MediaQuery** — `MediaQuery.viewInsetsOf` in `chat_room_screen` (2×) and `MediaQuery.sizeOf` in `message_bubble` (3×): bubbles no longer depend on every media-query aspect.
- **Single canonical sort** — messages were sorted three times: notifier sorted descending, `ChatRoom`'s constructor immediately re-sorted ascending (making the descending sorts dead work), and `chat_messages_list` re-sorted a copy on every build. The constructor's ascending order is now the only sort (pinned by test, including through `copy()`).
- **`DateFormat` hoisted** — was constructed (pattern parse) per bubble per build.
- **`refreshChatList`** — dropped the artificial 100 ms delay; skips the state emission when no room's `(orderId, message count, last message id)` changed, so background chatter no longer rebuilds the chat-rooms screen.

## Test plan

- [x] New `test/features/chat/message_type_and_order_test.dart` (RED on `main`): classification of all shapes, boolean helpers agree, memoization pinned, ascending order pinned incl. `copy()`
- [x] Existing `shared_utils_test.dart` MessageTypeUtils suite — green (drove the content-identity validation)
- [x] Full `flutter test` — all green
- [x] `flutter analyze` — no new issues
- [ ] Manual: open a long chat, toggle the keyboard — no visible jank; message order and image/file bubbles unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat list refresh behavior to avoid unnecessary updates and delays.
  * Preserved consistent chronological ordering for chat messages.
  * Corrected message-time formatting after language changes.
  * Improved keyboard and message bubble layout handling across screen sizes.
  * Enhanced recognition of encrypted image and file messages, with safe fallback for invalid content.

* **Tests**
  * Added coverage for message classification, ordering, localization, and chat widget behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->