### PR TITLE
perf: cheaper order cards and scoped list tickers

### DIFF
--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -196,7 +196,10 @@ class HomeScreen extends ConsumerWidget {
   }
 
   Widget _buildFilterButton(BuildContext context, WidgetRef ref) {
-    final filteredOrders = ref.watch(filteredOrdersProvider);
+    // Only the count is rendered; watching the list rebuilt the pill (and
+    // its shadowed containers) on every book emission.
+    final offersCount =
+        ref.watch(filteredOrdersProvider.select((orders) => orders.length));
     final activeFilterCount = ref.watch(activeFilterCountProvider);
     final hasFilters = activeFilterCount > 0;
 
@@ -294,7 +297,7 @@ class HomeScreen extends ConsumerWidget {
                         Text(
                           S
                               .of(context)!
-                              .offersCount(filteredOrders.length.toString()),
+                              .offersCount(offersCount.toString()),
                           style: const TextStyle(
                             color: Colors.grey,
                             fontSize: 12,

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -19,8 +19,6 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final filteredOrders = ref.watch(filteredOrdersProvider);
-
     return Scaffold(
       backgroundColor: AppTheme.backgroundDark,
       appBar: const MostroAppBar(),
@@ -52,50 +50,7 @@ class HomeScreen extends ConsumerWidget {
                         children: [
                           _buildTabs(context, ref),
                           _buildFilterButton(context, ref),
-                          Expanded(
-                            child: Container(
-                              color: AppTheme.dark1,
-                              child: filteredOrders.isEmpty
-                                  ? Center(
-                                      child: Column(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.center,
-                                        children: [
-                                          const Icon(
-                                            Icons.search_off,
-                                            color: Colors.white30,
-                                            size: 48,
-                                          ),
-                                          const SizedBox(height: 16),
-                                          Text(
-                                            S.of(context)!.noOrdersAvailable,
-                                            style: const TextStyle(
-                                              color: Colors.white60,
-                                              fontSize: 16,
-                                            ),
-                                          ),
-                                          Text(
-                                            S.of(context)!.tryChangingFilters,
-                                            style: const TextStyle(
-                                              color: Colors.white38,
-                                              fontSize: 14,
-                                            ),
-                                            textAlign: TextAlign.center,
-                                          ),
-                                        ],
-                                      ),
-                                    )
-                                  : ListView.builder(
-                                      itemCount: filteredOrders.length,
-                                      padding: const EdgeInsets.only(
-                                          bottom: 100, top: 6),
-                                      itemBuilder: (context, index) {
-                                        final order = filteredOrders[index];
-                                        return OrderListItem(order: order);
-                                      },
-                                    ),
-                            ),
-                          ),
+                          const Expanded(child: _OrderBookList()),
                         ],
                       ),
                     ),
@@ -363,6 +318,60 @@ class HomeScreen extends ConsumerWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// The only widget that watches the full filtered list. Scoping the watch
+/// here means a book emission rebuilds just the list — the tabs and the
+/// filter pill above it watch narrower slices (order type, filter state,
+/// order count) and stay put.
+class _OrderBookList extends ConsumerWidget {
+  const _OrderBookList();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filteredOrders = ref.watch(filteredOrdersProvider);
+
+    return Container(
+      color: AppTheme.dark1,
+      child: filteredOrders.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.search_off,
+                    color: Colors.white30,
+                    size: 48,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    S.of(context)!.noOrdersAvailable,
+                    style: const TextStyle(
+                      color: Colors.white60,
+                      fontSize: 16,
+                    ),
+                  ),
+                  Text(
+                    S.of(context)!.tryChangingFilters,
+                    style: const TextStyle(
+                      color: Colors.white38,
+                      fontSize: 14,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            )
+          : ListView.builder(
+              itemCount: filteredOrders.length,
+              padding: const EdgeInsets.only(bottom: 100, top: 6),
+              itemBuilder: (context, index) {
+                final order = filteredOrders[index];
+                return OrderListItem(order: order);
+              },
+            ),
     );
   }
 }

--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -10,6 +10,7 @@ import 'package:mostro_mobile/data/enums.dart';
 import 'package:mostro_mobile/data/models/nostr_event.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
 import 'package:mostro_mobile/shared/providers/time_provider.dart';
+import 'package:mostro_mobile/shared/widgets/star_rating_row.dart';
 import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
 import 'package:mostro_mobile/generated/l10n.dart';
@@ -21,7 +22,6 @@ class OrderListItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(timeProvider);
     final currencyData = ref.watch(currencyCodesProvider).asData?.value;
 
     // Determine if this is a fixed order (has specific sats amount and is not zero)
@@ -97,20 +97,7 @@ class OrderListItem extends ConsumerWidget {
                       decoration: BoxDecoration(
                         color: AppTheme.backgroundCard,
                         borderRadius: BorderRadius.circular(14),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.6),
-                            blurRadius: 4,
-                            offset: const Offset(0, 2),
-                            spreadRadius: -1,
-                          ),
-                          BoxShadow(
-                            color: Colors.white.withValues(alpha: 0.08),
-                            blurRadius: 1,
-                            offset: const Offset(0, -1),
-                            spreadRadius: 0,
-                          ),
-                        ],
+                        boxShadow: _labelShadow,
                       ),
                       child: Text(
                         orderLabel,
@@ -122,16 +109,9 @@ class OrderListItem extends ConsumerWidget {
                       ),
                     ),
 
-                    // Timestamp
-                    Text(
-                      order.timeAgoWithLocale(
-                              Localizations.localeOf(context).languageCode) ??
-                          S.of(context)!.hoursAgo('9'),
-                      style: const TextStyle(
-                        color: Colors.white60,
-                        fontSize: 14,
-                      ),
-                    ),
+                    // Timestamp (watches the 30 s ticker on its own, so the
+                    // tick refreshes this text instead of the whole card)
+                    _TimeAgoText(order: order),
                   ],
                 ),
               ),
@@ -234,20 +214,7 @@ class OrderListItem extends ConsumerWidget {
                 decoration: BoxDecoration(
                   color: AppTheme.backgroundCard,
                   borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.7),
-                      blurRadius: 6,
-                      offset: const Offset(0, 3),
-                      spreadRadius: -2,
-                    ),
-                    BoxShadow(
-                      color: Colors.white.withValues(alpha: 0.08),
-                      blurRadius: 1,
-                      offset: const Offset(0, -1),
-                      spreadRadius: 0,
-                    ),
-                  ],
+                  boxShadow: _innerShadow,
                 ),
                 child: Row(
                   children: [
@@ -281,20 +248,7 @@ class OrderListItem extends ConsumerWidget {
                 decoration: BoxDecoration(
                   color: AppTheme.backgroundCard,
                   borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.7),
-                      blurRadius: 6,
-                      offset: const Offset(0, 3),
-                      spreadRadius: -2,
-                    ),
-                    BoxShadow(
-                      color: Colors.white.withValues(alpha: 0.08),
-                      blurRadius: 1,
-                      offset: const Offset(0, -1),
-                      spreadRadius: 0,
-                    ),
-                  ],
+                  boxShadow: _innerShadow,
                 ),
                 child: _buildRatingRow(context, order),
               ),
@@ -307,11 +261,11 @@ class OrderListItem extends ConsumerWidget {
   }
 
   Widget _buildRatingRow(BuildContext context, NostrEvent order) {
-    final rating = order.rating?.totalRating ?? 0.0;
-
-    final int reviews = order.rating?.totalReviews ?? 0;
-
-    final int daysOld = order.rating?.days ?? 0;
+    // Parse the rating tag once: the getter deserializes JSON per access.
+    final orderRating = order.rating;
+    final rating = orderRating?.totalRating ?? 0.0;
+    final int reviews = orderRating?.totalReviews ?? 0;
+    final int daysOld = orderRating?.days ?? 0;
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -327,27 +281,8 @@ class OrderListItem extends ConsumerWidget {
               ),
             ),
             const SizedBox(width: 4),
-            SizedBox(
-              height: 20,
-              child: ListView.builder(
-                  shrinkWrap: true,
-                  scrollDirection: Axis.horizontal,
-                  itemCount: 5,
-                  itemBuilder: (context, index) {
-                    const Color starColor = Colors.amber;
-
-                    if (index < rating.floor()) {
-                      return const Icon(Icons.star, color: starColor, size: 14);
-                    } else if (index == rating.floor() &&
-                        rating - rating.floor() >= 0.5) {
-                      return const Icon(Icons.star_half,
-                          color: starColor, size: 14);
-                    } else {
-                      return Icon(Icons.star_border,
-                          color: starColor, size: 14);
-                    }
-                  }),
-            ),
+            const SizedBox(width: 0),
+            StarRatingRow(rating: rating),
           ],
         ),
         Row(
@@ -404,6 +339,59 @@ class OrderListItem extends ConsumerWidget {
           ],
         ),
       ],
+    );
+  }
+}
+
+// Shadow lists hoisted: they were re-allocated per card per build.
+final List<BoxShadow> _labelShadow = List.unmodifiable([
+  BoxShadow(
+    color: Colors.black.withValues(alpha: 0.6),
+    blurRadius: 4,
+    offset: const Offset(0, 2),
+    spreadRadius: -1,
+  ),
+  BoxShadow(
+    color: Colors.white.withValues(alpha: 0.08),
+    blurRadius: 1,
+    offset: const Offset(0, -1),
+    spreadRadius: 0,
+  ),
+]);
+
+final List<BoxShadow> _innerShadow = List.unmodifiable([
+  BoxShadow(
+    color: Colors.black.withValues(alpha: 0.7),
+    blurRadius: 6,
+    offset: const Offset(0, 3),
+    spreadRadius: -2,
+  ),
+  BoxShadow(
+    color: Colors.white.withValues(alpha: 0.08),
+    blurRadius: 1,
+    offset: const Offset(0, -1),
+    spreadRadius: 0,
+  ),
+]);
+
+/// Relative timestamp that owns the 30 s ticker dependency, so the periodic
+/// tick rebuilds this text only instead of every visible card.
+class _TimeAgoText extends ConsumerWidget {
+  const _TimeAgoText({required this.order});
+
+  final NostrEvent order;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(timeProvider);
+    return Text(
+      order.timeAgoWithLocale(
+              Localizations.localeOf(context).languageCode) ??
+          S.of(context)!.hoursAgo('9'),
+      style: const TextStyle(
+        color: Colors.white60,
+        fontSize: 14,
+      ),
     );
   }
 }

--- a/lib/features/trades/widgets/trades_list_item.dart
+++ b/lib/features/trades/widgets/trades_list_item.dart
@@ -14,7 +14,6 @@ import 'package:mostro_mobile/features/order/providers/order_notifier_provider.d
 import 'package:mostro_mobile/shared/providers/mostro_storage_provider.dart';
 import 'package:mostro_mobile/shared/providers/order_repository_provider.dart';
 import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
-import 'package:mostro_mobile/shared/providers/time_provider.dart';
 import 'package:mostro_mobile/shared/providers/exchange_service_provider.dart';
 import 'package:mostro_mobile/shared/utils/bond_payout_helpers.dart';
 import 'package:mostro_mobile/shared/utils/currency_utils.dart';
@@ -27,7 +26,6 @@ class TradesListItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(timeProvider);
     final currencyData = ref.watch(currencyCodesProvider).asData?.value;
     final session = ref.watch(sessionProvider(trade.orderId!));
     final role = session?.role;

--- a/lib/shared/widgets/star_rating_row.dart
+++ b/lib/shared/widgets/star_rating_row.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// Five-star rating strip used by the order cards.
+///
+/// Replaces a per-card horizontal `ListView.builder(shrinkWrap: true)` —
+/// a Scrollable + Viewport + Sliver just to lay out five icons.
+class StarRatingRow extends StatelessWidget {
+  const StarRatingRow({
+    super.key,
+    required this.rating,
+    this.size = 14,
+    this.color = Colors.amber,
+  });
+
+  final double rating;
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(5, (index) {
+        final IconData icon;
+        if (index < rating.floor()) {
+          icon = Icons.star;
+        } else if (index == rating.floor() && rating - rating.floor() >= 0.5) {
+          icon = Icons.star_half;
+        } else {
+          icon = Icons.star_border;
+        }
+        return Icon(icon, color: color, size: size);
+      }),
+    );
+  }
+}

--- a/test/shared/widgets/star_rating_row_test.dart
+++ b/test/shared/widgets/star_rating_row_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/shared/widgets/star_rating_row.dart';
+
+/// The 5-star rating in every order card used to be a horizontal
+/// `ListView.builder(shrinkWrap: true)` — a Scrollable + Viewport + Sliver
+/// per card just to lay out five icons.
+void main() {
+  Future<void> pump(WidgetTester tester, double rating) => tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: StarRatingRow(rating: rating)),
+        ),
+      );
+
+  testWidgets('renders five icons without any scrollable', (tester) async {
+    await pump(tester, 3.5);
+
+    expect(find.byType(Scrollable), findsNothing);
+    expect(find.byIcon(Icons.star), findsNWidgets(3));
+    expect(find.byIcon(Icons.star_half), findsOneWidget);
+    expect(find.byIcon(Icons.star_border), findsOneWidget);
+  });
+
+  testWidgets('a fraction below .5 rounds down to border stars',
+      (tester) async {
+    await pump(tester, 2.4);
+
+    expect(find.byIcon(Icons.star), findsNWidgets(2));
+    expect(find.byIcon(Icons.star_half), findsNothing);
+    expect(find.byIcon(Icons.star_border), findsNWidgets(3));
+  });
+
+  testWidgets('zero and full ratings render edge cases', (tester) async {
+    await pump(tester, 0);
+    expect(find.byIcon(Icons.star_border), findsNWidgets(5));
+
+    await pump(tester, 5);
+    expect(find.byIcon(Icons.star), findsNWidgets(5));
+  });
+}


### PR DESCRIPTION
## Summary

Item **2.7** of the performance plan. Per visible order card, every build paid:

- a horizontal `ListView.builder(shrinkWrap: true)` — a Scrollable + Viewport + Sliver — to lay out **five icons**;
- three JSON deserializations of the rating tag (`order.rating` getter parses per access);
- three freshly allocated `BoxShadow` lists;
- a `ref.watch(timeProvider)` at card level, so the 30 s tick rebuilt **every** visible card (and `TradesListItem` watched it while rendering no relative time at all);
- the filter pill watched the whole `filteredOrdersProvider` list to print a count, rebuilding on every book emission.

## Changes

- **`StarRatingRow`** (new shared widget, plain `Row`): same star semantics (full/half/border, half at ≥ .5) pinned by widget test with `find.byType(Scrollable) → findsNothing`.
- `order.rating` parsed once per build; the two inner shadow pairs and the label shadow hoisted to shared unmodifiable lists (visuals identical).
- The relative timestamp moved into a tiny `_TimeAgoText` consumer that owns the ticker dependency — a tick now rebuilds five `Text`s, not five full cards.
- `TradesListItem`: vestigial ticker watch removed.
- Filter pill: `filteredOrdersProvider.select((l) => l.length)`.

**Left as a deliberate visual decision for the team:** the outer `AppTheme.cardShadow` still uses blur 15 (~40 blur passes per scroll frame with 4–6 cards); flattening it or lowering the radius is a look change, not a refactor.

## Test plan

- [x] New `test/shared/widgets/star_rating_row_test.dart` (RED on `main`: widget didn't exist): no scrollable, 3.5/2.4/0/5 distributions
- [x] Targeted suites (shared/widgets, home, trades) — 96/96
- [x] Full `flutter test` — 1196/1196
- [x] `flutter analyze` — no new issues
- [ ] Manual: order book and My Trades look identical; timestamps still refresh every ~30 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur