### PR TITLE
perf: unread indicators through providers instead of per-build futures

### DIFF
--- a/lib/features/chat/providers/chat_room_providers.dart
+++ b/lib/features/chat/providers/chat_room_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/services/chat_read_status_service.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/data/models/chat_room.dart';
 import 'package:mostro_mobile/features/chat/notifiers/chat_rooms_notifier.dart';
@@ -70,3 +71,20 @@ int _getSessionStartTime(Ref ref, ChatRoom chatRoom, int fallbackTime) {
   }
   return fallbackTime;
 }
+
+/// Whether the chat for [orderId] has peer messages newer than the read
+/// cursor. Replaces a per-row FutureBuilder whose future (a prefs read) was
+/// recreated on every rebuild; this recomputes only when the room changes.
+/// Invalidate it after `ChatReadStatusService.markChatAsRead`.
+final chatHasUnreadProvider =
+    FutureProvider.family<bool, String>((ref, orderId) async {
+  final session = ref.watch(sessionProvider(orderId));
+  if (session == null) return false;
+  final room = ref.watch(chatRoomsProvider(orderId));
+  if (room.messages.isEmpty) return false;
+  return ChatReadStatusService.hasUnreadMessages(
+    orderId,
+    room.messages,
+    session.tradeKey.public,
+  );
+});

--- a/lib/features/chat/widgets/chat_list_item.dart
+++ b/lib/features/chat/widgets/chat_list_item.dart
@@ -83,6 +83,9 @@ class _ChatListItemState extends ConsumerState<ChatListItem> {
         final navigator = GoRouter.of(context);
         await ChatReadStatusService.markChatAsRead(widget.orderId);
         if (mounted) {
+          ref.invalidate(chatHasUnreadProvider(widget.orderId));
+        }
+        if (mounted) {
           navigator.push('/chat_room/${widget.orderId}');
         }
       },
@@ -139,30 +142,25 @@ class _ChatListItemState extends ConsumerState<ChatListItem> {
                               ),
                             ),
                             // Unread indicator positioned below the date
-                            if (!_isMarkedAsRead)
-                              FutureBuilder<bool>(
-                                future: ChatReadStatusService.hasUnreadMessages(
-                                  widget.orderId,
-                                  chatRoom.messages,
-                                  currentUserPubkey,
-                                ),
-                                builder: (context, snapshot) {
-                                  final hasUnread = snapshot.data ?? false;
-                                  if (!hasUnread) {
-                                    return const SizedBox.shrink();
-                                  }
-                                  return Padding(
-                                    padding: const EdgeInsets.only(top: 4),
-                                    child: Container(
-                                      width: 8,
-                                      height: 8,
-                                      decoration: BoxDecoration(
-                                        color: Colors.red,
-                                        shape: BoxShape.circle,
-                                      ),
+                            if (!_isMarkedAsRead &&
+                                ref
+                                    .watch(chatHasUnreadProvider(
+                                        widget.orderId))
+                                    .maybeWhen(
+                                        data: (unread) => unread,
+                                        orElse: () => false))
+                              const Padding(
+                                padding: EdgeInsets.only(top: 4),
+                                child: SizedBox(
+                                  width: 8,
+                                  height: 8,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: Colors.red,
+                                      shape: BoxShape.circle,
                                     ),
-                                  );
-                                },
+                                  ),
+                                ),
                               ),
                           ],
                         ),

--- a/lib/features/chat/widgets/chat_list_item.dart
+++ b/lib/features/chat/widgets/chat_list_item.dart
@@ -142,13 +142,15 @@ class _ChatListItemState extends ConsumerState<ChatListItem> {
                               ),
                             ),
                             // Unread indicator positioned below the date
+                            // valueOrNull keeps the previous value while the
+                            // provider recomputes, so the dot does not blink
+                            // off for a frame on every room emission.
                             if (!_isMarkedAsRead &&
-                                ref
-                                    .watch(chatHasUnreadProvider(
-                                        widget.orderId))
-                                    .maybeWhen(
-                                        data: (unread) => unread,
-                                        orElse: () => false))
+                                (ref
+                                        .watch(chatHasUnreadProvider(
+                                            widget.orderId))
+                                        .valueOrNull ??
+                                    false))
                               const Padding(
                                 padding: EdgeInsets.only(top: 4),
                                 child: SizedBox(

--- a/lib/features/disputes/providers/dispute_read_status_provider.dart
+++ b/lib/features/disputes/providers/dispute_read_status_provider.dart
@@ -1,7 +1,29 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
+import 'package:mostro_mobile/services/dispute_read_status_service.dart';
 
 /// Provider to track when disputes are marked as read
 /// This triggers UI updates when a dispute's read status changes
 final disputeReadStatusProvider = StateProvider.family<int, String>((ref, disputeId) {
   return DateTime.now().millisecondsSinceEpoch;
+});
+
+/// Whether the dispute chat has admin messages newer than the read cursor.
+/// Replaces a per-row FutureBuilder whose future (a prefs read) was recreated
+/// on every rebuild. Watching [disputeReadStatusProvider] recomputes it when
+/// the dispute is marked as read.
+final disputeHasUnreadProvider =
+    FutureProvider.family<bool, String>((ref, disputeId) async {
+  ref.watch(disputeReadStatusProvider(disputeId));
+  final messages = ref.watch(
+    disputeChatNotifierProvider(disputeId).select((s) => s.messages),
+  );
+  if (messages.isEmpty) return false;
+  final isFromUser =
+      ref.read(disputeChatNotifierProvider(disputeId).notifier).isFromUser;
+  return DisputeReadStatusService.hasUnreadMessages(
+    disputeId,
+    messages,
+    isFromUser: isFromUser,
+  );
 });

--- a/lib/features/disputes/screens/dispute_chat_screen.dart
+++ b/lib/features/disputes/screens/dispute_chat_screen.dart
@@ -35,10 +35,18 @@ class _DisputeChatScreenState extends ConsumerState<DisputeChatScreen> {
     // Mark dispute as read when screen is opened
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      unawaited(DisputeReadStatusService.markDisputeAsRead(widget.disputeId));
-      // Notify that the dispute has been marked as read
-      ref.read(disputeReadStatusProvider(widget.disputeId).notifier).state =
-          DateTime.now().millisecondsSinceEpoch;
+      // Bump the read-status provider only after the cursor write completes:
+      // disputeHasUnreadProvider recomputes on the bump and caches the
+      // result, so a bump racing the write could pin a stale unread dot.
+      unawaited(
+        DisputeReadStatusService.markDisputeAsRead(widget.disputeId)
+            .then((_) {
+          if (!mounted) return;
+          ref
+              .read(disputeReadStatusProvider(widget.disputeId).notifier)
+              .state = DateTime.now().millisecondsSinceEpoch;
+        }),
+      );
       ref
           .read(activeChatScreensProvider.notifier)
           .register(widget.disputeId);

--- a/lib/features/disputes/widgets/dispute_content.dart
+++ b/lib/features/disputes/widgets/dispute_content.dart
@@ -5,7 +5,6 @@ import 'package:mostro_mobile/features/disputes/widgets/dispute_order_id.dart';
 import 'package:mostro_mobile/features/disputes/widgets/dispute_description.dart';
 import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
 import 'package:mostro_mobile/features/disputes/providers/dispute_read_status_provider.dart';
-import 'package:mostro_mobile/services/dispute_read_status_service.dart';
 import 'package:mostro_mobile/data/models/dispute.dart';
 
 /// Main content widget for dispute information
@@ -56,29 +55,18 @@ class _DisputeContentState extends ConsumerState<DisputeContent> {
               child: DisputeHeader(dispute: widget.dispute),
             ),
             // Unread indicator for in-progress disputes
-            if (normalizedStatus == 'in-progress')
-              FutureBuilder<bool>(
-                future: DisputeReadStatusService.hasUnreadMessages(
-                  widget.dispute.disputeId,
-                  ref.watch(disputeChatNotifierProvider(widget.dispute.disputeId)).messages,
-                  isFromUser: ref.read(
-                    disputeChatNotifierProvider(widget.dispute.disputeId).notifier,
-                  ).isFromUser,
+            if (normalizedStatus == 'in-progress' &&
+                ref
+                    .watch(
+                        disputeHasUnreadProvider(widget.dispute.disputeId))
+                    .maybeWhen(data: (unread) => unread, orElse: () => false))
+              Container(
+                width: 8,
+                height: 8,
+                decoration: const BoxDecoration(
+                  color: Colors.red,
+                  shape: BoxShape.circle,
                 ),
-                builder: (context, snapshot) {
-                  final hasUnread = snapshot.data ?? false;
-                  if (!hasUnread) {
-                    return const SizedBox.shrink();
-                  }
-                  return Container(
-                    width: 8,
-                    height: 8,
-                    decoration: const BoxDecoration(
-                      color: Colors.red,
-                      shape: BoxShape.circle,
-                    ),
-                  );
-                },
               ),
           ],
         ),

--- a/lib/features/disputes/widgets/dispute_content.dart
+++ b/lib/features/disputes/widgets/dispute_content.dart
@@ -26,9 +26,6 @@ class _DisputeContentState extends ConsumerState<DisputeContent> {
 
   @override
   Widget build(BuildContext context) {
-    // Watch the read status to trigger rebuilds when dispute is marked as read
-    ref.watch(disputeReadStatusProvider(widget.dispute.disputeId));
-    
     // Get the last message for in-progress disputes
     String descriptionText = widget.dispute.getLocalizedDescription(context);
     
@@ -54,12 +51,15 @@ class _DisputeContentState extends ConsumerState<DisputeContent> {
             Expanded(
               child: DisputeHeader(dispute: widget.dispute),
             ),
-            // Unread indicator for in-progress disputes
+            // Unread indicator for in-progress disputes. valueOrNull keeps
+            // the previous value while the provider recomputes, so the dot
+            // does not blink off for a frame on every chat emission.
             if (normalizedStatus == 'in-progress' &&
-                ref
-                    .watch(
-                        disputeHasUnreadProvider(widget.dispute.disputeId))
-                    .maybeWhen(data: (unread) => unread, orElse: () => false))
+                (ref
+                        .watch(
+                            disputeHasUnreadProvider(widget.dispute.disputeId))
+                        .valueOrNull ??
+                    false))
               Container(
                 width: 8,
                 height: 8,

--- a/test/features/chat/providers/chat_unread_provider_test.dart
+++ b/test/features/chat/providers/chat_unread_provider_test.dart
@@ -1,0 +1,119 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/chat_room.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/features/chat/notifiers/chat_room_notifier.dart';
+import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
+import 'package:mostro_mobile/services/chat_read_status_service.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../mocks.mocks.dart';
+
+/// The unread dot in every chat-list row was a `FutureBuilder` whose future
+/// (a SharedPreferences read) was recreated on every rebuild of every row,
+/// flickering through `snapshot.data ?? false` each time. It is now a
+/// FutureProvider family that recomputes only when the room or the read
+/// cursor changes.
+void main() {
+  const orderId = 'order-a';
+  const tradeKeyPrivate =
+      'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+  late ProviderContainer container;
+  late List<NostrEvent> messages;
+
+  NostrEvent message(String id, String pubkey, int createdAt) => NostrEvent(
+        id: id,
+        kind: 14,
+        content: 'hola',
+        sig: '',
+        pubkey: pubkey,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt),
+        tags: const [],
+      );
+
+  Session session() {
+    final s = Session(
+      masterKey: NostrKeyPairs(
+          private:
+              '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'),
+      tradeKey: NostrKeyPairs(private: tradeKeyPrivate),
+      keyIndex: 0,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+    );
+    s.orderId = orderId;
+    return s;
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    messages = [];
+    container = ProviderContainer(overrides: [
+      sessionNotifierProvider.overrideWith((ref) {
+        final notifier = _FakeSessionNotifier(ref);
+        notifier.emit([session()]);
+        return notifier;
+      }),
+      chatRoomsProvider.overrideWith((ref, id) => ChatRoomNotifier(
+            ChatRoom(orderId: id, messages: messages),
+            id,
+            ref,
+          )),
+    ]);
+  });
+
+  tearDown(() => container.dispose());
+
+  String userPubkey() =>
+      container.read(sessionProvider(orderId))!.tradeKey.public;
+
+  test('a peer message with no read cursor is unread', () async {
+    messages = [message('m1', 'peer-pubkey', 1000)];
+
+    final unread =
+        await container.read(chatHasUnreadProvider(orderId).future);
+
+    expect(unread, isTrue);
+  });
+
+  test('own messages never count as unread', () async {
+    container.read(sessionNotifierProvider);
+    messages = [message('m1', userPubkey(), 1000)];
+
+    final unread =
+        await container.read(chatHasUnreadProvider(orderId).future);
+
+    expect(unread, isFalse);
+  });
+
+  test('messages older than the read cursor are read', () async {
+    await ChatReadStatusService.markChatAsRead(orderId);
+    messages = [message('m1', 'peer-pubkey', 1000)];
+
+    final unread =
+        await container.read(chatHasUnreadProvider(orderId).future);
+
+    expect(unread, isFalse);
+  });
+
+  test('without a session there is nothing unread', () async {
+    final unread =
+        await container.read(chatHasUnreadProvider('unknown-order').future);
+
+    expect(unread, isFalse);
+  });
+}
+
+/// Session list the provider can read without touching storage.
+class _FakeSessionNotifier extends SessionNotifier {
+  _FakeSessionNotifier(Ref ref)
+      : super(ref, MockSessionStorage(), MockSettings()) {
+    state = const [];
+  }
+
+  void emit(List<Session> sessions) => state = sessions;
+}

--- a/test/features/disputes/providers/dispute_unread_provider_test.dart
+++ b/test/features/disputes/providers/dispute_unread_provider_test.dart
@@ -1,0 +1,105 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
+import 'package:mostro_mobile/features/disputes/providers/dispute_read_status_provider.dart';
+import 'package:mostro_mobile/services/dispute_read_status_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The dispute unread dot was a `FutureBuilder` whose future (a prefs read)
+/// was recreated on every rebuild. It is now [disputeHasUnreadProvider],
+/// which caches its value and recomputes on [disputeReadStatusProvider]
+/// bumps — the bump after `markDisputeAsRead` replaces the FutureBuilder's
+/// per-rebuild self-healing, so it must observe the fresh cursor.
+void main() {
+  const disputeId = 'dispute-a';
+  const userPubkey = 'user-pubkey';
+  const adminPubkey = 'admin-pubkey';
+
+  late ProviderContainer container;
+  late List<DisputeChatMessage> messages;
+
+  DisputeChatMessage message(String id, String pubkey, int createdAt) =>
+      DisputeChatMessage(
+        event: NostrEvent(
+          id: id,
+          kind: 14,
+          content: 'hola',
+          sig: '',
+          pubkey: pubkey,
+          createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt),
+          tags: const [],
+        ),
+      );
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    messages = [];
+    container = ProviderContainer(overrides: [
+      disputeChatNotifierProvider.overrideWith(
+        (ref, id) => _FakeDisputeChatNotifier(id, ref, messages),
+      ),
+    ]);
+  });
+
+  tearDown(() => container.dispose());
+
+  test('an admin message with no read cursor is unread', () async {
+    messages = [message('m1', adminPubkey, 1000)];
+
+    final unread =
+        await container.read(disputeHasUnreadProvider(disputeId).future);
+
+    expect(unread, isTrue);
+  });
+
+  test('own messages never count as unread', () async {
+    messages = [message('m1', userPubkey, 1000)];
+
+    final unread =
+        await container.read(disputeHasUnreadProvider(disputeId).future);
+
+    expect(unread, isFalse);
+  });
+
+  test('the read-status bump recomputes against the fresh cursor', () async {
+    messages = [message('m1', adminPubkey, 1000)];
+
+    final before =
+        await container.read(disputeHasUnreadProvider(disputeId).future);
+    expect(before, isTrue);
+
+    // What DisputeChatScreen does on open: persist the cursor, then bump.
+    await DisputeReadStatusService.markDisputeAsRead(disputeId);
+    container.read(disputeReadStatusProvider(disputeId).notifier).state =
+        DateTime.now().millisecondsSinceEpoch;
+
+    final after =
+        await container.read(disputeHasUnreadProvider(disputeId).future);
+    expect(after, isFalse);
+  });
+
+  test('an empty dispute chat has nothing unread', () async {
+    final unread =
+        await container.read(disputeHasUnreadProvider(disputeId).future);
+
+    expect(unread, isFalse);
+  });
+}
+
+/// Dispute chat state the provider can read without touching Nostr or
+/// storage. [isFromUser] is overridden because the real implementation walks
+/// sessions and order state to find the trade key.
+class _FakeDisputeChatNotifier extends DisputeChatNotifier {
+  _FakeDisputeChatNotifier(
+    super.disputeId,
+    super.ref,
+    List<DisputeChatMessage> messages,
+  ) {
+    state = DisputeChatState(messages: messages);
+  }
+
+  @override
+  bool isFromUser(DisputeChatMessage message) =>
+      message.event.pubkey == 'user-pubkey';
+}


### PR DESCRIPTION
## Summary

Item **2.8** (last of Phase 2) of the performance plan. The unread dots were `FutureBuilder`s whose future — a SharedPreferences read plus a message scan — was **recreated on every rebuild of every row** (`chat_list_item.dart`, `dispute_content.dart`), flickering through `snapshot.data ?? false` on each rebuild.

## Changes

- **`chatHasUnreadProvider`** (`FutureProvider.family<bool, String>` by orderId): derived from `sessionProvider` + `chatRoomsProvider`, so it recomputes only when the room actually changes; the row invalidates it right after `markChatAsRead`, keeping the dot's disappearance immediate.
- **`disputeHasUnreadProvider`**: same pattern over the dispute chat messages, re-evaluated via `disputeReadStatusProvider` when the dispute is marked read.
- Both rows render from the cached value (`maybeWhen(data: ..., orElse: false)`) — no per-rebuild storage I/O, no flicker.

**Deliberately out of scope:** `DisputeContent` still watches `disputeChatNotifierProvider` for the live message preview — deriving previews from stored data (avoiding a live notifier per row) is plan item 4.5/5.

## Test plan

- [x] New `test/features/chat/providers/chat_unread_provider_test.dart` (compile-RED on `main`): peer message with no cursor → unread; own messages → read; cursor newer than messages → read; no session → read
- [x] Chat + disputes suites — green
- [x] Full `flutter test` — all green
- [x] `flutter analyze` — no new issues
- [ ] Manual: receive a chat message → dot appears without flicker on scroll; open the chat → dot gone immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur