### PR TITLE
perf: cache key derivation and make session ECDH lazy

### DIFF
--- a/lib/data/models/session.dart
+++ b/lib/data/models/session.dart
@@ -42,14 +42,13 @@ class Session {
     String? adminPubkey,
   }) {
     _peer = peer;
-    if (peer != null) {
-      _sharedKey = NostrUtils.computeSharedKey(
-        tradeKey.private,
-        peer.publicKey,
-      );
-    }
     if (adminPubkey != null) {
-      setAdminPeer(adminPubkey);
+      if (adminPubkey.isEmpty || adminPubkey.length != 64) {
+        throw ArgumentError(
+          'Invalid admin pubkey: expected 64-char hex, got ${adminPubkey.length} chars',
+        );
+      }
+      _adminPubkey = adminPubkey;
     }
   }
 
@@ -199,10 +198,28 @@ class Session {
     }
   }
 
-  NostrKeyPairs? get sharedKey => _sharedKey;
+  /// Lazy: ECDH costs an EC multiplication and used to run in the
+  /// constructor for every decoded session at startup and on each cleanup.
+  NostrKeyPairs? get sharedKey {
+    if (_sharedKey == null && _peer != null) {
+      _sharedKey = NostrUtils.computeSharedKey(
+        tradeKey.private,
+        _peer!.publicKey,
+      );
+    }
+    return _sharedKey;
+  }
 
   String? get adminPubkey => _adminPubkey;
-  NostrKeyPairs? get adminSharedKey => _adminSharedKey;
+  NostrKeyPairs? get adminSharedKey {
+    if (_adminSharedKey == null && _adminPubkey != null) {
+      _adminSharedKey = NostrUtils.computeSharedKey(
+        tradeKey.private,
+        _adminPubkey!,
+      );
+    }
+    return _adminSharedKey;
+  }
 
   /// Inner event signers accepted in the dispute chat conversation.
   /// adminPubkey is always set when adminSharedKey is (see setAdminPeer).
@@ -226,10 +243,7 @@ class Session {
       );
     }
     _adminPubkey = adminPubkey;
-    _adminSharedKey = NostrUtils.computeSharedKey(
-      tradeKey.private,
-      adminPubkey,
-    );
+    _adminSharedKey = null; // recomputed lazily on next access
   }
 
   Peer? get peer => _peer;
@@ -241,9 +255,6 @@ class Session {
       return;
     }
     _peer = newPeer;
-    _sharedKey = NostrUtils.computeSharedKey(
-      tradeKey.private,
-      newPeer.publicKey,
-    );
+    _sharedKey = null; // recomputed lazily on next access
   }
 }

--- a/lib/features/key_manager/key_derivator.dart
+++ b/lib/features/key_manager/key_derivator.dart
@@ -31,14 +31,34 @@ class KeyDerivator {
     return root.toBase58();
   }
 
+  // Derivation is deterministic: cache the parsed root (base58check is paid
+  // once per master key) and the derived child hex per (root, index). Session
+  // decode used to re-run the full path per session, per startup and per
+  // 30-minute cleanup.
+  final Map<String, bip32.BIP32> _rootCache = {};
+  final Map<String, String> _childCache = {};
+  static const int _childCacheLimit = 4096;
+
   String derivePrivateKey(String extendedPrivateKey, int index) {
-    final root = bip32.BIP32.fromBase58(extendedPrivateKey);
+    final cacheKey = '$extendedPrivateKey/$index';
+    final cached = _childCache[cacheKey];
+    if (cached != null) return cached;
+
+    final root = _rootCache.putIfAbsent(
+      extendedPrivateKey,
+      () => bip32.BIP32.fromBase58(extendedPrivateKey),
+    );
     final child = root.derivePath('$derivationPath/$index');
     if (child.privateKey == null) {
       throw Exception(
           "Derived child key has no private key. Possibly a neutered node?");
     }
-    return hex.encode(child.privateKey!);
+    final derived = hex.encode(child.privateKey!);
+    if (_childCache.length >= _childCacheLimit) {
+      _childCache.clear();
+    }
+    _childCache[cacheKey] = derived;
+    return derived;
   }
 
   String privateToPublicKey(String privateKeyHex) {

--- a/lib/features/key_manager/key_manager.dart
+++ b/lib/features/key_manager/key_manager.dart
@@ -1,4 +1,5 @@
 import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mostro_mobile/features/key_manager/key_derivator.dart';
 import 'package:mostro_mobile/features/key_manager/key_storage.dart';
 import 'package:mostro_mobile/features/key_manager/key_manager_errors.dart';
@@ -10,6 +11,21 @@ class KeyManager {
   NostrKeyPairs? masterKeyPair;
   String? _masterKeyHex;
   int? tradeKeyIndex;
+
+  /// Memoized trade keys: derivation per index is deterministic and costs
+  /// base58 + CKD + an EC multiplication each time. Cleared whenever the
+  /// master key changes.
+  final Map<int, NostrKeyPairs> _tradeKeyCache = {};
+
+  /// Test hook: prime the in-memory master key without touching secure
+  /// storage. Clears the trade-key memo like a real master-key change.
+  @visibleForTesting
+  void debugSetMasterKey(String extendedPrivateKey) {
+    _masterKeyHex = extendedPrivateKey;
+    _tradeKeyCache.clear();
+    masterKeyPair =
+        NostrKeyPairs(private: _derivator.derivePrivateKey(extendedPrivateKey, 0));
+  }
 
   KeyManager(this._storage, this._derivator);
 
@@ -40,6 +56,8 @@ class KeyManager {
     await _storage.clear();
     await _storage.storeMnemonic(mnemonic);
     await _storage.storeMasterKey(masterKeyHex);
+    _masterKeyHex = masterKeyHex;
+    _tradeKeyCache.clear();
     await setCurrentKeyIndex(1);
     masterKeyPair = await _getMasterKey();
     tradeKeyIndex = await getCurrentKeyIndex();
@@ -66,7 +84,7 @@ class KeyManager {
   }
 
   Future<NostrKeyPairs> deriveTradeKey() async {
-    final masterKeyHex = await _storage.readMasterKey();
+    final masterKeyHex = _masterKeyHex ??= await _storage.readMasterKey();
     if (masterKeyHex == null) {
       throw MasterKeyNotFoundException('No master key found in secure storage');
     }
@@ -82,14 +100,17 @@ class KeyManager {
   }
 
   NostrKeyPairs deriveTradeKeyPair(int index) {
-    final tradePrivateHex = _derivator.derivePrivateKey(_masterKeyHex!, index);
-
-    return NostrKeyPairs(private: tradePrivateHex);
+    return _tradeKeyCache.putIfAbsent(
+      index,
+      () => NostrKeyPairs(
+        private: _derivator.derivePrivateKey(_masterKeyHex!, index),
+      ),
+    );
   }
 
   /// Derive a trade key for a specific index
   Future<NostrKeyPairs> deriveTradeKeyFromIndex(int index) async {
-    final masterKeyHex = await _storage.readMasterKey();
+    final masterKeyHex = _masterKeyHex ??= await _storage.readMasterKey();
     if (masterKeyHex == null) {
       throw MasterKeyNotFoundException(
         'No master key found in secure storage',

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -144,9 +144,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
 
     final cutoff = DateTime.now()
         .subtract(Duration(hours: _expirationHours));
-    final expiredSessions = await _storage.getAllSessions();
+    // Iterate the in-memory sessions: getAllSessions() re-decoded every row,
+    // re-running trade-key derivation per session every 30 minutes.
+    final candidates = _sessions.values.toList();
 
-    for (final session in expiredSessions) {
+    for (final session in candidates) {
       if (session.startTime.isBefore(cutoff)) {
         if (await _isActiveSession(session)) {
           logger.i('Skipping cleanup for active session ${session.orderId}');

--- a/test/features/key_manager/key_manager_cache_test.dart
+++ b/test/features/key_manager/key_manager_cache_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/features/key_manager/key_derivator.dart';
+import 'package:mostro_mobile/features/key_manager/key_manager.dart';
+import 'package:mostro_mobile/features/key_manager/key_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+/// Decoding a session used to re-run the whole trade-key derivation —
+/// BIP32.fromBase58 (base58check) + 5 CKD levels + an EC multiplication for
+/// the pubkey — per session, at startup and again on every 30-minute
+/// cleanup. Derivation is deterministic per (master key, index), so the
+/// derived pairs are now memoized.
+void main() {
+  // Public NIP-06 test vector, same as key_derivator_test.dart.
+  const mnemonicA =
+      'leader monkey parrot ring guide accident before fence cannon height naive bean';
+  const mnemonicB =
+      'what bleak badge arrange retreat wolf trade produce cricket blur garlic valid proud rude strong choose busy staff weather area salt hollow arm fade';
+  const derivationPath = "m/44'/1237'/38383'/0";
+
+  late KeyDerivator derivator;
+  late KeyManager manager;
+
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    derivator = KeyDerivator(derivationPath);
+    manager = KeyManager(
+      KeyStorage(
+        secureStorage: const FlutterSecureStorage(),
+        sharedPrefs: SharedPreferencesAsync(),
+      ),
+      derivator,
+    );
+    manager.debugSetMasterKey(derivator.extendedKeyFromMnemonic(mnemonicA));
+  });
+
+  test('deriveTradeKeyPair memoizes per index', () {
+    final first = manager.deriveTradeKeyPair(1);
+    final second = manager.deriveTradeKeyPair(1);
+
+    expect(identical(first, second), isTrue,
+        reason: 'the same index must not repeat CKD + EC multiplication');
+  });
+
+  test('different indices derive different keys', () {
+    expect(
+      manager.deriveTradeKeyPair(1).private,
+      isNot(manager.deriveTradeKeyPair(2).private),
+    );
+  });
+
+  test('changing the master key invalidates the memo', () {
+    final before = manager.deriveTradeKeyPair(1);
+
+    manager.debugSetMasterKey(derivator.extendedKeyFromMnemonic(mnemonicB));
+    final after = manager.deriveTradeKeyPair(1);
+
+    expect(before.private, isNot(after.private));
+  });
+
+  test('derivation stays correct through the derivator root cache', () {
+    final xprv = derivator.extendedKeyFromMnemonic(mnemonicA);
+
+    final direct = derivator.derivePrivateKey(xprv, 7);
+    final cached = derivator.derivePrivateKey(xprv, 7);
+
+    expect(cached, direct);
+    expect(derivator.privateToPublicKey(cached),
+        derivator.privateToPublicKey(direct));
+  });
+}


### PR DESCRIPTION
## Summary

Item **3.1** of the performance plan (crypto costs on the UI isolate — all of it pure-Dart BigInt secp256k1, 5–30 ms per scalar multiplication on a mid phone).

Decoding one session re-ran the full derivation pipeline every time: `BIP32.fromBase58` (base58check) + 5 CKD levels + an EC multiplication for the pubkey (`KeyManager.deriveTradeKeyPair`), plus 1–2 ECDH computations in the `Session` constructor (`computeSharedKey` also wraps the secret in a `NostrKeyPairs`, another multiplication). This ran **per session** at startup and again from the **30-minute cleanup**, which re-read and re-decoded every session from disk although `SessionNotifier` already held them in memory. ≈3–5 multiplications × N sessions ≈ 0.5–2 s of synchronous UI-thread work, repeated every half hour.

## Changes

- **`KeyDerivator`**: parsed BIP32 root cached per master key; derived child hex memoized per (root, index) with a bounded map. Deterministic, so behaviour pinned against the NIP-06 vectors.
- **`KeyManager`**: trade key pairs memoized per index (`identical` pinned by test), cleared on master-key change; `deriveTradeKey`/`deriveTradeKeyFromIndex` reuse the cached master hex instead of a secure-storage read per call. `@visibleForTesting debugSetMasterKey` allows storage-free tests.
- **`Session`**: `sharedKey`/`adminSharedKey` computed lazily on first access; the constructor and the `peer`/`setAdminPeer` setters only record the inputs (the admin pubkey validation stays in the constructor path).
- **`SessionNotifier._cleanup`**: iterates the in-memory sessions instead of `getAllSessions()` (which re-decoded — and before this PR re-derived — every row). Note: sessions written by other isolates between cleanups are picked up at next app start, same as before for anything the notifier didn't know about.

## Test plan

- [x] New `test/features/key_manager/key_manager_cache_test.dart` (RED on `main`): per-index memoization by identity, distinct indices, master-key change invalidation, derivator cache correctness against NIP-06 vectors
- [x] `key_derivator_test.dart` (NIP-06 vectors) — green
- [x] Subscriptions + chat suites (consumers of `sharedKey`/`adminSharedKey`) — green
- [x] Full `flutter test` — all green
- [x] `flutter analyze` — no new issues
- [ ] Manual: cold start with many trades — no multi-second freeze before the list paints; chat and dispute filters still built correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur