### PR TITLE
perf: cache NIP-44 conversation keys per key pair

### DIFF
--- a/lib/data/models/nostr_event.dart
+++ b/lib/data/models/nostr_event.dart
@@ -123,6 +123,8 @@ extension NostrEventExtensions on NostrEvent {
           content!,
           receiver.private,
           ephemeralPubkey,
+          // One-shot wrapper pubkey: keep it out of the conversation cache.
+          cacheConversationKey: false,
         );
 
         final sanitizedSeal = _sanitizeEventJson(decryptedSeal);
@@ -231,6 +233,8 @@ extension NostrEventExtensions on NostrEvent {
         sealJson,
         ephemeralKeyPair.private,
         receiverPubkey,
+        // Single-use ephemeral key: keep it out of the conversation cache.
+        cacheConversationKey: false,
       );
 
       // Create Gift Wrap with randomized timestamp (±2 days)
@@ -277,6 +281,8 @@ extension NostrEventExtensions on NostrEvent {
         content!,
         receiver.private,
         ephemeralPubkey,
+        // One-shot wrapper pubkey: keep it out of the conversation cache.
+        cacheConversationKey: false,
       );
 
       // Parse the inner event

--- a/lib/shared/notifiers/session_notifier.dart
+++ b/lib/shared/notifiers/session_notifier.dart
@@ -15,6 +15,7 @@ import 'package:mostro_mobile/data/models/order.dart';
 import 'package:mostro_mobile/features/settings/settings.dart';
 import 'package:mostro_mobile/services/push_notification_service.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:mostro_mobile/data/models/peer.dart';
@@ -53,6 +54,26 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       _settings.sessionExpirationHours ?? Config.sessionExpirationHours;
 
   bool get _isForever => _expirationHours == 0;
+
+  /// Removes the session's key material from the NIP-44 conversation-key
+  /// cache: the trade key conversations (node, seals) and the chat `K_conv`
+  /// self-conversations derived from the peer/admin shared keys. Without this
+  /// the cache would retain secrets of retired sessions until process exit.
+  void _evictSessionKeyMaterial(Session session) {
+    NostrUtils.evictConversationKeysFor(session.tradeKey.private);
+    final sharedKey = session.sharedKey;
+    if (sharedKey != null) {
+      NostrUtils.evictConversationKeysFor(
+        ChatKeys.fromSharedKey(sharedKey).conv.private,
+      );
+    }
+    final adminSharedKey = session.adminSharedKey;
+    if (adminSharedKey != null) {
+      NostrUtils.evictConversationKeysFor(
+        ChatKeys.fromSharedKey(adminSharedKey).conv.private,
+      );
+    }
+  }
 
   Future<void> _cleanupSessionData(Session session) async {
     final orderId = session.orderId;
@@ -111,6 +132,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
           }
           await _storage.deleteSession(session.orderId!);
           _sessions.remove(session.orderId!);
+          _evictSessionKeyMaterial(session);
           try {
             await _cleanupSessionData(session);
           } catch (e) {
@@ -154,6 +176,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
         }
         await _storage.deleteSession(session.orderId!);
         _sessions.remove(session.orderId!);
+        _evictSessionKeyMaterial(session);
         try {
           await _cleanupSessionData(session);
         } catch (e) {
@@ -162,9 +185,11 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       }
     }
 
-    _pendingChildSessions.removeWhere(
-      (_, session) => session.startTime.isBefore(cutoff),
-    );
+    _pendingChildSessions.removeWhere((_, session) {
+      final expired = session.startTime.isBefore(cutoff);
+      if (expired) _evictSessionKeyMaterial(session);
+      return expired;
+    });
 
     _emitState();
   }
@@ -289,6 +314,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
     _sessions.clear();
     _pendingChildSessions.clear();
     _requestIdToSession.clear();
+    NostrUtils.clearConversationKeyCache();
     state = [];
   }
 
@@ -299,6 +325,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
           .removeWhere((_, session) => identical(session, removed));
       _requestIdToSession
           .removeWhere((_, session) => identical(session, removed));
+      _evictSessionKeyMaterial(removed);
     }
     await _storage.deleteSession(sessionId);
     _emitState();
@@ -307,7 +334,10 @@ class SessionNotifier extends StateNotifier<List<Session>> {
   /// Delete session by requestId for timeout cleanup
   /// Used when create order timeout expires after 10s with no Mostro response
   Future<void> deleteSessionByRequestId(int requestId) async {
-    _requestIdToSession.remove(requestId);
+    final removed = _requestIdToSession.remove(requestId);
+    if (removed != null) {
+      _evictSessionKeyMaterial(removed);
+    }
     // Note: No storage deletion - these are temporary sessions in memory only
     _emitState();
   }
@@ -320,6 +350,7 @@ class SessionNotifier extends StateNotifier<List<Session>> {
       _pendingChildSessions
           .removeWhere((_, pending) => identical(pending, session));
       _sessions.removeWhere((_, stored) => identical(stored, session));
+      _evictSessionKeyMaterial(session);
       _emitState();
       logger.d('Cleaned up temporary session for requestId: $requestId');
     }

--- a/lib/shared/utils/nostr_utils.dart
+++ b/lib/shared/utils/nostr_utils.dart
@@ -347,11 +347,17 @@ class NostrUtils {
   /// Conversation keys are constant per (our key, their key) pair, but every
   /// encrypt/decrypt recomputed them: one EC scalar multiplication plus HKDF
   /// per message. Bounded cache; entries are evicted when their session is
-  /// cleaned up ([evictConversationKeysFor]) and one-shot NIP-59 wrapper
-  /// conversations are never stored (`cache: false`).
+  /// cleaned up ([evictConversationKeysFor]), the whole map is dropped on
+  /// account wipe (`SessionNotifier.reset()` calls
+  /// [clearConversationKeyCache] — the map is static, so no provider
+  /// invalidation reaches it), and one-shot NIP-59 wrapper conversations are
+  /// never stored (`cache: false`).
   static const int _conversationKeyCacheLimit = 512;
   static final Map<String, Uint8List> _conversationKeys = {};
 
+  /// Returns a defensive copy on cache hits and stores its own copy on
+  /// misses: a caller mutating the returned bytes must never corrupt the
+  /// cached key process-wide.
   static Uint8List conversationKeyFor(
     String privateKey,
     String publicKey, {
@@ -359,14 +365,14 @@ class NostrUtils {
   }) {
     final cacheKey = '$privateKey|$publicKey';
     final cached = _conversationKeys[cacheKey];
-    if (cached != null) return cached;
+    if (cached != null) return Uint8List.fromList(cached);
     final sharedSecret = Nip44.computeSharedSecret(privateKey, publicKey);
     final conversationKey = Nip44.deriveConversationKey(sharedSecret);
     if (!cache) return conversationKey;
     if (_conversationKeys.length >= _conversationKeyCacheLimit) {
       _conversationKeys.clear();
     }
-    _conversationKeys[cacheKey] = conversationKey;
+    _conversationKeys[cacheKey] = Uint8List.fromList(conversationKey);
     return conversationKey;
   }
 

--- a/lib/shared/utils/nostr_utils.dart
+++ b/lib/shared/utils/nostr_utils.dart
@@ -304,10 +304,12 @@ class NostrUtils {
       createdAt: randomNow(),
     );
 
+    // The wrapper key is single-use; never retain its conversation key.
     return await encryptNIP44(
       jsonEncode(sealEvent.toMap()),
       wrapperKey,
       recipientPubKey,
+      cacheConversationKey: false,
     );
   }
 
@@ -344,23 +346,47 @@ class NostrUtils {
 
   /// Conversation keys are constant per (our key, their key) pair, but every
   /// encrypt/decrypt recomputed them: one EC scalar multiplication plus HKDF
-  /// per message. Bounded cache; key material lives as long as the session
-  /// keys it derives from already do.
+  /// per message. Bounded cache; entries are evicted when their session is
+  /// cleaned up ([evictConversationKeysFor]) and one-shot NIP-59 wrapper
+  /// conversations are never stored (`cache: false`).
   static const int _conversationKeyCacheLimit = 512;
   static final Map<String, Uint8List> _conversationKeys = {};
 
-  static Uint8List conversationKeyFor(String privateKey, String publicKey) {
+  static Uint8List conversationKeyFor(
+    String privateKey,
+    String publicKey, {
+    bool cache = true,
+  }) {
     final cacheKey = '$privateKey|$publicKey';
     final cached = _conversationKeys[cacheKey];
     if (cached != null) return cached;
     final sharedSecret = Nip44.computeSharedSecret(privateKey, publicKey);
     final conversationKey = Nip44.deriveConversationKey(sharedSecret);
+    if (!cache) return conversationKey;
     if (_conversationKeys.length >= _conversationKeyCacheLimit) {
       _conversationKeys.clear();
     }
     _conversationKeys[cacheKey] = conversationKey;
     return conversationKey;
   }
+
+  /// Drops every cached conversation key derived from [privateKey]. Session
+  /// cleanup calls this so retired trade/chat key material does not outlive
+  /// its session inside the cache.
+  static void evictConversationKeysFor(String privateKey) {
+    _conversationKeys.removeWhere((key, _) => key.startsWith('$privateKey|'));
+  }
+
+  /// Drops the whole conversation-key cache (full session reset / tests).
+  static void clearConversationKeyCache() => _conversationKeys.clear();
+
+  @visibleForTesting
+  static int get conversationKeyCacheSize => _conversationKeys.length;
+
+  @visibleForTesting
+  static bool conversationKeyCacheContains(
+          String privateKey, String publicKey) =>
+      _conversationKeys.containsKey('$privateKey|$publicKey');
 
   static NostrKeyPairs computeSharedKey(String privateKey, String publicKey) {
     final sharedKey = Nip44.computeSharedSecret(privateKey, publicKey);
@@ -447,10 +473,12 @@ class NostrUtils {
     }
 
     try {
+      // event.pubkey is the sender's one-shot wrapper key; never cache it.
       final decryptedContent = await decryptNIP44(
         event.content!,
         privateKey,
         event.pubkey,
+        cacheConversationKey: false,
       );
 
       final rumorEvent = NostrEvent.deserialized(
@@ -599,17 +627,22 @@ class NostrUtils {
     return true;
   }
 
+  /// [cacheConversationKey] must be false when either side of the pair is a
+  /// one-shot key (NIP-59 ephemeral wrappers), so the derived key is not
+  /// retained in the static cache.
   static Future<String> encryptNIP44(
     String content,
     String privkey,
-    String pubkey,
-  ) async {
+    String pubkey, {
+    bool cacheConversationKey = true,
+  }) async {
     try {
       return await Nip44.encryptMessage(
         content,
         privkey,
         pubkey,
-        customConversationKey: conversationKeyFor(privkey, pubkey),
+        customConversationKey:
+            conversationKeyFor(privkey, pubkey, cache: cacheConversationKey),
       );
     } catch (e) {
       // Handle encryption error appropriately
@@ -617,17 +650,22 @@ class NostrUtils {
     }
   }
 
+  /// [cacheConversationKey] must be false when either side of the pair is a
+  /// one-shot key (NIP-59 ephemeral wrappers), so the derived key is not
+  /// retained in the static cache.
   static Future<String> decryptNIP44(
     String encryptedContent,
     String privkey,
-    String pubkey,
-  ) async {
+    String pubkey, {
+    bool cacheConversationKey = true,
+  }) async {
     try {
       return await Nip44.decryptMessage(
         encryptedContent,
         privkey,
         pubkey,
-        customConversationKey: conversationKeyFor(privkey, pubkey),
+        customConversationKey:
+            conversationKeyFor(privkey, pubkey, cache: cacheConversationKey),
       );
     } catch (e) {
       // Handle encryption error appropriately

--- a/lib/shared/utils/nostr_utils.dart
+++ b/lib/shared/utils/nostr_utils.dart
@@ -342,6 +342,26 @@ class NostrUtils {
     return wrapEvent;
   }
 
+  /// Conversation keys are constant per (our key, their key) pair, but every
+  /// encrypt/decrypt recomputed them: one EC scalar multiplication plus HKDF
+  /// per message. Bounded cache; key material lives as long as the session
+  /// keys it derives from already do.
+  static const int _conversationKeyCacheLimit = 512;
+  static final Map<String, Uint8List> _conversationKeys = {};
+
+  static Uint8List conversationKeyFor(String privateKey, String publicKey) {
+    final cacheKey = '$privateKey|$publicKey';
+    final cached = _conversationKeys[cacheKey];
+    if (cached != null) return cached;
+    final sharedSecret = Nip44.computeSharedSecret(privateKey, publicKey);
+    final conversationKey = Nip44.deriveConversationKey(sharedSecret);
+    if (_conversationKeys.length >= _conversationKeyCacheLimit) {
+      _conversationKeys.clear();
+    }
+    _conversationKeys[cacheKey] = conversationKey;
+    return conversationKey;
+  }
+
   static NostrKeyPairs computeSharedKey(String privateKey, String publicKey) {
     final sharedKey = Nip44.computeSharedSecret(privateKey, publicKey);
     final nkey = hex.encode(sharedKey);
@@ -585,7 +605,12 @@ class NostrUtils {
     String pubkey,
   ) async {
     try {
-      return await Nip44.encryptMessage(content, privkey, pubkey);
+      return await Nip44.encryptMessage(
+        content,
+        privkey,
+        pubkey,
+        customConversationKey: conversationKeyFor(privkey, pubkey),
+      );
     } catch (e) {
       // Handle encryption error appropriately
       throw Exception('Encryption failed: $e');
@@ -598,7 +623,12 @@ class NostrUtils {
     String pubkey,
   ) async {
     try {
-      return await Nip44.decryptMessage(encryptedContent, privkey, pubkey);
+      return await Nip44.decryptMessage(
+        encryptedContent,
+        privkey,
+        pubkey,
+        customConversationKey: conversationKeyFor(privkey, pubkey),
+      );
     } catch (e) {
       // Handle encryption error appropriately
       throw Exception('Decryption failed: $e');

--- a/test/shared/utils/nip44_conversation_key_cache_test.dart
+++ b/test/shared/utils/nip44_conversation_key_cache_test.dart
@@ -1,0 +1,56 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+
+/// Every NIP-44 encrypt/decrypt recomputed the conversation key — one EC
+/// scalar multiplication (5-30 ms of BigInt math on a mid phone) plus HKDF —
+/// even though it is constant per (our key, their key) pair: the node
+/// conversation for a session and each chat conversation reuse the same pair
+/// for every message. The key is now cached and injected through the nip44
+/// fork's `customConversationKey`.
+void main() {
+  const alicePriv =
+      'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+  const bobPriv =
+      '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+  final alicePub = NostrKeyPairs(private: alicePriv).public;
+  final bobPub = NostrKeyPairs(private: bobPriv).public;
+
+  test('the conversation key is computed once per key pair', () {
+    final first = NostrUtils.conversationKeyFor(alicePriv, bobPub);
+    final second = NostrUtils.conversationKeyFor(alicePriv, bobPub);
+
+    expect(identical(first, second), isTrue,
+        reason: 'repeat messages on the same conversation must not repeat '
+            'ECDH + HKDF');
+  });
+
+  test('different pairs derive different keys', () {
+    final ab = NostrUtils.conversationKeyFor(alicePriv, bobPub);
+    final ba = NostrUtils.conversationKeyFor(bobPriv, alicePub);
+    final aa = NostrUtils.conversationKeyFor(alicePriv, alicePub);
+
+    // ECDH is symmetric: both directions of one conversation agree...
+    expect(ab, equals(ba));
+    // ...and a different pair does not.
+    expect(aa, isNot(equals(ab)));
+  });
+
+  test('encrypt/decrypt roundtrip works through the cached key', () async {
+    const content = 'mensaje de prueba nip44';
+
+    final cipher = await NostrUtils.encryptNIP44(content, alicePriv, bobPub);
+    // Prime + reuse: decrypt goes through the cache on the other side.
+    final plain = await NostrUtils.decryptNIP44(cipher, bobPriv, alicePub);
+
+    expect(plain, content);
+  });
+
+  test('two messages on the same conversation decrypt correctly', () async {
+    final c1 = await NostrUtils.encryptNIP44('uno', alicePriv, bobPub);
+    final c2 = await NostrUtils.encryptNIP44('dos', alicePriv, bobPub);
+
+    expect(await NostrUtils.decryptNIP44(c1, bobPriv, alicePub), 'uno');
+    expect(await NostrUtils.decryptNIP44(c2, bobPriv, alicePub), 'dos');
+  });
+}

--- a/test/shared/utils/nip44_conversation_key_cache_test.dart
+++ b/test/shared/utils/nip44_conversation_key_cache_test.dart
@@ -1,13 +1,15 @@
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro_mobile/shared/utils/nostr_utils.dart';
+import 'package:nip44/nip44.dart';
 
 /// Every NIP-44 encrypt/decrypt recomputed the conversation key — one EC
 /// scalar multiplication (5-30 ms of BigInt math on a mid phone) plus HKDF —
 /// even though it is constant per (our key, their key) pair: the node
 /// conversation for a session and each chat conversation reuse the same pair
 /// for every message. The key is now cached and injected through the nip44
-/// fork's `customConversationKey`.
+/// fork's `customConversationKey`. Callers receive a defensive copy, so a
+/// caller writing into the returned buffer cannot corrupt the cache.
 void main() {
   const alicePriv =
       'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
@@ -16,13 +18,37 @@ void main() {
   final alicePub = NostrKeyPairs(private: alicePriv).public;
   final bobPub = NostrKeyPairs(private: bobPriv).public;
 
-  test('the conversation key is computed once per key pair', () {
+  test('the conversation key is cached after the first derivation', () {
+    NostrUtils.clearConversationKeyCache();
+
     final first = NostrUtils.conversationKeyFor(alicePriv, bobPub);
     final second = NostrUtils.conversationKeyFor(alicePriv, bobPub);
 
-    expect(identical(first, second), isTrue,
+    expect(NostrUtils.conversationKeyCacheContains(alicePriv, bobPub), isTrue,
         reason: 'repeat messages on the same conversation must not repeat '
             'ECDH + HKDF');
+    expect(second, equals(first));
+    // Callers get a defensive copy, never the cached buffer itself: a caller
+    // mutating the returned bytes must not corrupt the cache process-wide.
+    expect(identical(first, second), isFalse);
+  });
+
+  test('mutating a returned key does not corrupt the cache', () async {
+    NostrUtils.clearConversationKeyCache();
+
+    final leaked = NostrUtils.conversationKeyFor(alicePriv, bobPub);
+    leaked.fillRange(0, leaked.length, 0);
+
+    final cipher = await NostrUtils.encryptNIP44('hola', alicePriv, bobPub);
+    expect(await Nip44.decryptMessage(cipher, bobPriv, alicePub), 'hola');
+  });
+
+  test('cached key == what the library derives on its own', () {
+    final cached = NostrUtils.conversationKeyFor(alicePriv, bobPub);
+    final plain = Nip44.deriveConversationKey(
+        Nip44.computeSharedSecret(alicePriv, bobPub));
+
+    expect(cached, equals(plain));
   });
 
   test('different pairs derive different keys', () {
@@ -46,6 +72,32 @@ void main() {
     expect(plain, content);
   });
 
+  test('library encrypts -> cached path decrypts', () async {
+    const msg = 'ciphertext produced WITHOUT the cache';
+    final cipher = await Nip44.encryptMessage(msg, alicePriv, bobPub);
+
+    expect(await NostrUtils.decryptNIP44(cipher, bobPriv, alicePub), msg);
+  });
+
+  test('cached path encrypts -> library decrypts', () async {
+    const msg = 'ciphertext produced WITH the cache';
+    final cipher = await NostrUtils.encryptNIP44(msg, alicePriv, bobPub);
+
+    expect(await Nip44.decryptMessage(cipher, bobPriv, alicePub), msg);
+  });
+
+  test('a tampered payload is still rejected (MAC check survives)', () async {
+    final cipher = await NostrUtils.encryptNIP44('hola', alicePriv, bobPub);
+    final chars = cipher.split('');
+    final mid = chars.length ~/ 2;
+    chars[mid] = chars[mid] == 'A' ? 'B' : 'A';
+
+    await expectLater(
+      NostrUtils.decryptNIP44(chars.join(), bobPriv, alicePub),
+      throwsA(isA<Exception>()),
+    );
+  });
+
   test('two messages on the same conversation decrypt correctly', () async {
     final c1 = await NostrUtils.encryptNIP44('uno', alicePriv, bobPub);
     final c2 = await NostrUtils.encryptNIP44('dos', alicePriv, bobPub);
@@ -59,34 +111,36 @@ void main() {
 
     final uncached =
         NostrUtils.conversationKeyFor(alicePriv, bobPub, cache: false);
-    final later = NostrUtils.conversationKeyFor(alicePriv, bobPub);
 
-    // Equal derivation, but the first call must not have populated the cache.
-    expect(later, equals(uncached));
-    expect(identical(later, uncached), isFalse,
+    expect(NostrUtils.conversationKeyCacheContains(alicePriv, bobPub), isFalse,
         reason: 'a cache:false derivation must not be stored for reuse');
+    expect(NostrUtils.conversationKeyFor(alicePriv, bobPub), equals(uncached));
   });
 
   test('evictConversationKeysFor drops every entry for that private key', () {
     NostrUtils.clearConversationKeyCache();
 
-    final aliceToBob = NostrUtils.conversationKeyFor(alicePriv, bobPub);
-    final aliceToSelf = NostrUtils.conversationKeyFor(alicePriv, alicePub);
-    final bobToAlice = NostrUtils.conversationKeyFor(bobPriv, alicePub);
+    NostrUtils.conversationKeyFor(alicePriv, bobPub);
+    NostrUtils.conversationKeyFor(alicePriv, alicePub);
+    NostrUtils.conversationKeyFor(bobPriv, alicePub);
 
     NostrUtils.evictConversationKeysFor(alicePriv);
 
-    // Alice's entries were recomputed (new instances), Bob's survived.
+    // Alice's entries were dropped, Bob's survived.
     expect(
-        identical(NostrUtils.conversationKeyFor(alicePriv, bobPub), aliceToBob),
-        isFalse);
+        NostrUtils.conversationKeyCacheContains(alicePriv, bobPub), isFalse);
     expect(
-        identical(
-            NostrUtils.conversationKeyFor(alicePriv, alicePub), aliceToSelf),
-        isFalse);
-    expect(
-        identical(NostrUtils.conversationKeyFor(bobPriv, alicePub), bobToAlice),
-        isTrue);
+        NostrUtils.conversationKeyCacheContains(alicePriv, alicePub), isFalse);
+    expect(NostrUtils.conversationKeyCacheContains(bobPriv, alicePub), isTrue);
+  });
+
+  test('clearConversationKeyCache empties the cache (account wipe path)', () {
+    NostrUtils.conversationKeyFor(alicePriv, bobPub);
+    expect(NostrUtils.conversationKeyCacheSize, greaterThan(0));
+
+    NostrUtils.clearConversationKeyCache();
+
+    expect(NostrUtils.conversationKeyCacheSize, 0);
   });
 
   test('NIP-59 wrapping leaves no ephemeral wrapper keys in the cache',

--- a/test/shared/utils/nip44_conversation_key_cache_test.dart
+++ b/test/shared/utils/nip44_conversation_key_cache_test.dart
@@ -53,4 +53,62 @@ void main() {
     expect(await NostrUtils.decryptNIP44(c1, bobPriv, alicePub), 'uno');
     expect(await NostrUtils.decryptNIP44(c2, bobPriv, alicePub), 'dos');
   });
+
+  test('cache: false derives without retaining one-shot key material', () {
+    NostrUtils.clearConversationKeyCache();
+
+    final uncached =
+        NostrUtils.conversationKeyFor(alicePriv, bobPub, cache: false);
+    final later = NostrUtils.conversationKeyFor(alicePriv, bobPub);
+
+    // Equal derivation, but the first call must not have populated the cache.
+    expect(later, equals(uncached));
+    expect(identical(later, uncached), isFalse,
+        reason: 'a cache:false derivation must not be stored for reuse');
+  });
+
+  test('evictConversationKeysFor drops every entry for that private key', () {
+    NostrUtils.clearConversationKeyCache();
+
+    final aliceToBob = NostrUtils.conversationKeyFor(alicePriv, bobPub);
+    final aliceToSelf = NostrUtils.conversationKeyFor(alicePriv, alicePub);
+    final bobToAlice = NostrUtils.conversationKeyFor(bobPriv, alicePub);
+
+    NostrUtils.evictConversationKeysFor(alicePriv);
+
+    // Alice's entries were recomputed (new instances), Bob's survived.
+    expect(
+        identical(NostrUtils.conversationKeyFor(alicePriv, bobPub), aliceToBob),
+        isFalse);
+    expect(
+        identical(
+            NostrUtils.conversationKeyFor(alicePriv, alicePub), aliceToSelf),
+        isFalse);
+    expect(
+        identical(NostrUtils.conversationKeyFor(bobPriv, alicePub), bobToAlice),
+        isTrue);
+  });
+
+  test('NIP-59 wrapping leaves no ephemeral wrapper keys in the cache',
+      () async {
+    NostrUtils.clearConversationKeyCache();
+
+    final wrap = await NostrUtils.createNIP59Event(
+      'contenido de prueba',
+      bobPub,
+      alicePriv,
+    );
+    await NostrUtils.decryptNIP59Event(wrap, bobPriv);
+
+    // The seal encrypt uses a one-shot wrapper private key and the wrap
+    // decrypt uses its one-shot wrapper pubkey; neither may be cached.
+    expect(
+        NostrUtils.conversationKeyCacheContains(bobPriv, wrap.pubkey), isFalse,
+        reason: 'the ephemeral wrapper conversation must not be cached');
+
+    // Only the stable sender<->recipient conversations may remain: the rumor
+    // encrypt (alice side) and the rumor decrypt (bob side).
+    expect(NostrUtils.conversationKeyCacheSize, 2,
+        reason: 'only stable sender<->recipient entries may be cached');
+  });
 }


### PR DESCRIPTION
## Summary

Item **3.2** of the performance plan. Every NIP-44 encrypt/decrypt recomputed the conversation key — one secp256k1 scalar multiplication (5–30 ms of pure-Dart BigInt on a mid phone) plus HKDF — although it is **constant per (our key, their key) pair**: the node conversation of a session (kind 14) and each chat/dispute conversation reuse the same pair for every message. Chat history loads pay it once per stored envelope.

## Changes

- `NostrUtils.conversationKeyFor(priv, pub)`: derives via the fork's public `Nip44.computeSharedSecret` + `Nip44.deriveConversationKey` and caches in a bounded map (512 entries). Callers receive a defensive copy, so mutating a returned buffer cannot corrupt the cache.
- `encryptNIP44` / `decryptNIP44` — the choke point for Mostro NIP-44 traffic (node messages, chat, dispute chat, media blobs; NWC uses its own direct `Nip44` calls in `nwc_crypto.dart` and bypasses the cache) — inject it via the fork's `customConversationKey`, which skips both ECDH and HKDF.
- **Lifecycle** (review feedback): `evictConversationKeysFor(privateKey)` drops every cached entry derived from a private key; `SessionNotifier` calls it on all session cleanup paths (expiry at init, periodic cleanup, `deleteSession`, request-id cleanup, pending child expiry) for the trade key and the chat `K_conv` keys derived from the peer/admin shared keys. `SessionNotifier.reset()` — reached by `RestoreService._clearAll()` on account restore — clears the whole cache, so key material never outlives its session or the account.
- **One-shot keys** (review feedback): NIP-59 ephemeral wrapper conversations (`createSeal`, the wrap layer of `decryptNIP59Event`, `mostroWrap`/`mostroUnWrap`/`p2pUnwrap`) derive with `cache: false` and never enter the map.

Saves ~1 EC multiplication per node message and per chat message after the first one of each conversation; history re-decrypts of a 200-message chat drop ~200 multiplications.

## Test plan

- [x] `test/shared/utils/nip44_conversation_key_cache_test.dart`: memoization, ECDH symmetry, cross-checks against the library's own derivation (library encrypts → cached path decrypts and vice versa), tampered-payload MAC rejection, mutation of a returned key does not corrupt the cache, eviction per private key, full clear on account wipe, no ephemeral NIP-59 entries
- [x] Full `flutter test` — 1206/1206
- [x] `flutter analyze` — no new issues
- [ ] Manual: send/receive messages in a trade and a chat; open a long chat history — content identical, faster load
