### PR TITLE
perf: skip re-verifying and re-decrypting already-unwrapped envelopes

### DIFF
--- a/lib/features/chat/notifiers/chat_room_notifier.dart
+++ b/lib/features/chat/notifiers/chat_room_notifier.dart
@@ -55,6 +55,24 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
   ChatKeys? _chatKeys;
   String? _chatKeysSource;
 
+  /// Unwrapped inner events by outer envelope id. An envelope is verified and
+  /// decrypted (~5 EC multiplications) exactly once per notifier; relay
+  /// re-deliveries and history reloads reuse the result.
+  final Map<String, NostrEvent> _unwrapCache = {};
+  static const int _unwrapCacheLimit = 2000;
+
+  /// Test hook: number of chatUnwrap executions performed by this notifier.
+  @visibleForTesting
+  int debugUnwrapCount = 0;
+
+  NostrEvent _cacheUnwrap(String outerId, NostrEvent inner) {
+    if (_unwrapCache.length >= _unwrapCacheLimit) {
+      _unwrapCache.clear();
+    }
+    _unwrapCache[outerId] = inner;
+    return inner;
+  }
+
   ChatRoomNotifier(
     super.state,
     this.orderId,
@@ -162,17 +180,39 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       }
 
       // Already on disk means a relay re-delivery, an own echo, or an event
-      // the background service stored while the app slept. Keep processing:
-      // state is keyed by inner id, so only the write is redundant.
+      // the background service stored while the app slept. The stored copy
+      // was verified before being persisted, so re-verifying and
+      // re-decrypting it (~5 EC multiplications) is pure waste: advance the
+      // cursor and reuse the cached unwrap if the state lacks it (history
+      // load covers the cold-start case, since initialize() runs before
+      // subscribe()).
       final eventStore = ref.read(eventStorageProvider);
       final alreadyStored = await eventStore.hasItem(event.id!);
+      final cachedUnwrap = _unwrapCache[event.id!];
+      if (alreadyStored && cachedUnwrap != null) {
+        // This notifier already verified and decrypted this envelope: a
+        // relay re-delivery only needs the cursor advanced and the cached
+        // inner event surfaced if state lost it. An envelope stored by the
+        // background isolate (not in this cache) still gets unwrapped below.
+        unawaited(
+          ref.read(chatCursorStoreProvider).advance(orderId, event.createdAt!),
+        );
+        if (!state.messages.any((m) => m.id == cachedUnwrap.id)) {
+          state = state.copy(messages: [...state.messages, cachedUnwrap]);
+        }
+        return;
+      }
 
       // Unwrap and authenticate BEFORE persisting: the signature is not part
       // of the event id, so storing an unverified copy would let a corrupted
       // duplicate occupy the id and dedup away the valid one for good
-      final chat = await event.chatUnwrap(
-        chatKeys,
-        session.peerChatAllowedSigners,
+      debugUnwrapCount++;
+      final chat = _cacheUnwrap(
+        event.id!,
+        await event.chatUnwrap(
+          chatKeys,
+          session.peerChatAllowedSigners,
+        ),
       );
 
       if (!alreadyStored) {
@@ -384,12 +424,22 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
           });
 
           // Decrypt and unwrap: kind 14 envelope, or legacy gift wrap
-          // stored before the kind-14 migration
+          // stored before the kind-14 migration. Envelopes already unwrapped
+          // by this notifier are reused instead of re-verified.
+          final cachedUnwrap = _unwrapCache[storedEvent.id];
+          if (cachedUnwrap != null) {
+            historicalMessages.add(cachedUnwrap);
+            continue;
+          }
           final NostrEvent unwrappedMessage;
           if (storedEvent.kind == 14) {
-            unwrappedMessage = await storedEvent.chatUnwrap(
-              _getChatKeys(session),
-              session.peerChatAllowedSigners,
+            debugUnwrapCount++;
+            unwrappedMessage = _cacheUnwrap(
+              storedEvent.id!,
+              await storedEvent.chatUnwrap(
+                _getChatKeys(session),
+                session.peerChatAllowedSigners,
+              ),
             );
           } else {
             if (session.sharedKey?.public != storedEvent.recipient) {

--- a/lib/features/chat/notifiers/chat_room_notifier.dart
+++ b/lib/features/chat/notifiers/chat_room_notifier.dart
@@ -55,22 +55,56 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
   ChatKeys? _chatKeys;
   String? _chatKeysSource;
 
-  /// Unwrapped inner events by outer envelope id. An envelope is verified and
-  /// decrypted (~5 EC multiplications) exactly once per notifier; relay
-  /// re-deliveries and history reloads reuse the result.
-  final Map<String, NostrEvent> _unwrapCache = {};
+  /// Unwrapped inner events by outer envelope id, keyed on the *in-flight*
+  /// future so the reservation is made synchronously. An envelope is verified
+  /// and decrypted (~5 EC multiplications) exactly once per notifier: relay
+  /// re-deliveries, concurrent deliveries and history reloads reuse the
+  /// result.
+  final Map<String, Future<NostrEvent>> _unwrapCache = {};
   static const int _unwrapCacheLimit = 2000;
 
   /// Test hook: number of chatUnwrap executions performed by this notifier.
   @visibleForTesting
   int debugUnwrapCount = 0;
 
-  NostrEvent _cacheUnwrap(String outerId, NostrEvent inner) {
+  /// Start the single unwrap of [event], or join the one already running.
+  /// The reservation happens synchronously — before any await — so a second
+  /// relay copy arriving while the first is still being verified shares its
+  /// result instead of paying for another verification. A failed unwrap is
+  /// never cached: the reservation is dropped so a later valid copy of the
+  /// envelope is verified normally.
+  Future<NostrEvent> _unwrapOnce(
+    NostrEvent event,
+    ChatKeys chatKeys,
+    Session session,
+  ) {
+    final outerId = event.id!;
+    final pending = _unwrapCache[outerId];
+    if (pending != null) return pending;
     if (_unwrapCache.length >= _unwrapCacheLimit) {
       _unwrapCache.clear();
     }
-    _unwrapCache[outerId] = inner;
-    return inner;
+    debugUnwrapCount++;
+    // The map entry is written synchronously, before the first await inside
+    // chatUnwrap, so a second delivery arriving meanwhile joins this future.
+    final unwrap = _unwrapAndForgetOnFailure(event, chatKeys, session);
+    _unwrapCache[outerId] = unwrap;
+    return unwrap;
+  }
+
+  Future<NostrEvent> _unwrapAndForgetOnFailure(
+    NostrEvent event,
+    ChatKeys chatKeys,
+    Session session,
+  ) async {
+    try {
+      return await event.chatUnwrap(chatKeys, session.peerChatAllowedSigners);
+    } catch (_) {
+      // Never cache a rejection: a corrupted copy delivered first must not
+      // lock the envelope id out for the valid event that shares it.
+      _unwrapCache.remove(event.id!);
+      rethrow;
+    }
   }
 
   ChatRoomNotifier(
@@ -179,44 +213,38 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
         return;
       }
 
-      // Already on disk means a relay re-delivery, an own echo, or an event
-      // the background service stored while the app slept. The stored copy
-      // was verified before being persisted, so re-verifying and
-      // re-decrypting it (~5 EC multiplications) is pure waste: advance the
-      // cursor and reuse the cached unwrap if the state lacks it (history
-      // load covers the cold-start case, since initialize() runs before
-      // subscribe()).
-      final eventStore = ref.read(eventStorageProvider);
-      final alreadyStored = await eventStore.hasItem(event.id!);
-      final cachedUnwrap = _unwrapCache[event.id!];
-      if (alreadyStored && cachedUnwrap != null) {
-        // This notifier already verified and decrypted this envelope: a
-        // relay re-delivery only needs the cursor advanced and the cached
-        // inner event surfaced if state lost it. An envelope stored by the
-        // background isolate (not in this cache) still gets unwrapped below.
-        unawaited(
-          ref.read(chatCursorStoreProvider).advance(orderId, event.createdAt!),
-        );
-        if (!state.messages.any((m) => m.id == cachedUnwrap.id)) {
-          state = state.copy(messages: [...state.messages, cachedUnwrap]);
+      final outerId = event.id!;
+
+      // This notifier already verified and decrypted this envelope (a relay
+      // re-delivery, an own echo, or a copy racing an unwrap still in
+      // flight): reuse the verified inner event and surface it if state lost
+      // it. Nothing is written and the cursor is NOT advanced from here —
+      // this copy's signature has not been checked, and both the envelope id
+      // and the author key are public, so its created_at is attacker
+      // controlled. For legitimate traffic the advance would be a no-op
+      // anyway: a re-delivery carries the same id and therefore the same
+      // created_at, which the store already rejects as not newer.
+      final pending = _unwrapCache[outerId];
+      if (pending != null) {
+        final cached = await pending;
+        if (!state.messages.any((m) => m.id == cached.id)) {
+          state = state.copy(messages: [...state.messages, cached]);
         }
         return;
       }
 
       // Unwrap and authenticate BEFORE persisting: the signature is not part
       // of the event id, so storing an unverified copy would let a corrupted
-      // duplicate occupy the id and dedup away the valid one for good
-      debugUnwrapCount++;
-      final chat = _cacheUnwrap(
-        event.id!,
-        await event.chatUnwrap(
-          chatKeys,
-          session.peerChatAllowedSigners,
-        ),
-      );
+      // duplicate occupy the id and dedup away the valid one for good. An
+      // envelope the background service stored while the app slept is on disk
+      // but not in this cache, so it is verified here like any other.
+      final chat = await _unwrapOnce(event, chatKeys, session);
+
+      final eventStore = ref.read(eventStorageProvider);
+      final alreadyStored = await eventStore.hasItem(outerId);
 
       if (!alreadyStored) {
-        await eventStore.putItem(event.id!, event.peerChatRecord(orderId));
+        await eventStore.putItem(outerId, event.peerChatRecord(orderId));
       }
 
       // Advance the persisted since cursor only after the event is accepted
@@ -428,18 +456,15 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
           // by this notifier are reused instead of re-verified.
           final cachedUnwrap = _unwrapCache[storedEvent.id];
           if (cachedUnwrap != null) {
-            historicalMessages.add(cachedUnwrap);
+            historicalMessages.add(await cachedUnwrap);
             continue;
           }
           final NostrEvent unwrappedMessage;
           if (storedEvent.kind == 14) {
-            debugUnwrapCount++;
-            unwrappedMessage = _cacheUnwrap(
-              storedEvent.id!,
-              await storedEvent.chatUnwrap(
-                _getChatKeys(session),
-                session.peerChatAllowedSigners,
-              ),
+            unwrappedMessage = await _unwrapOnce(
+              storedEvent,
+              _getChatKeys(session),
+              session,
             );
           } else {
             if (session.sharedKey?.public != storedEvent.recipient) {

--- a/lib/features/chat/notifiers/chat_room_notifier.dart
+++ b/lib/features/chat/notifiers/chat_room_notifier.dart
@@ -226,11 +226,23 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       // created_at, which the store already rejects as not newer.
       final pending = _unwrapCache[outerId];
       if (pending != null) {
-        final cached = await pending;
-        if (!state.messages.any((m) => m.id == cached.id)) {
-          state = state.copy(messages: [...state.messages, cached]);
+        NostrEvent? cached;
+        try {
+          cached = await pending;
+        } catch (_) {
+          // The copy holding this id failed verification. Since the signature
+          // is not part of the id, that copy may be a forgery reusing a valid
+          // envelope's id, so this one falls through and is verified on its
+          // own instead of being suppressed by the forgery.
+          cached = null;
         }
-        return;
+        if (cached != null) {
+          final verified = cached;
+          if (!state.messages.any((m) => m.id == verified.id)) {
+            state = state.copy(messages: [...state.messages, verified]);
+          }
+          return;
+        }
       }
 
       // Unwrap and authenticate BEFORE persisting: the signature is not part
@@ -240,11 +252,20 @@ class ChatRoomNotifier extends StateNotifier<ChatRoom> with MediaCacheMixin {
       // but not in this cache, so it is verified here like any other.
       final chat = await _unwrapOnce(event, chatKeys, session);
 
-      final eventStore = ref.read(eventStorageProvider);
-      final alreadyStored = await eventStore.hasItem(outerId);
+      try {
+        final eventStore = ref.read(eventStorageProvider);
+        final alreadyStored = await eventStore.hasItem(outerId);
 
-      if (!alreadyStored) {
-        await eventStore.putItem(outerId, event.peerChatRecord(orderId));
+        if (!alreadyStored) {
+          await eventStore.putItem(outerId, event.peerChatRecord(orderId));
+        }
+      } catch (_) {
+        // Persisting failed, so this envelope is not durably handled: drop
+        // the cached unwrap, or a later relay delivery would take the
+        // already-unwrapped shortcut above and never retry the write or the
+        // cursor advance, and the message would be gone after a restart.
+        _unwrapCache.remove(outerId);
+        rethrow;
       }
 
       // Advance the persisted since cursor only after the event is accepted

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -92,12 +92,20 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
   ProviderSubscription<dynamic>? _sessionListener;
   bool _isInitialized = false;
 
-  /// Outer envelope ids this notifier has verified and decrypted, or is
-  /// currently verifying. Reserved synchronously — before any await — so two
-  /// relays delivering the same envelope at once share one unwrap instead of
-  /// each paying for the ~5 EC multiplications.
+  /// Outer envelope ids this notifier has fully processed: verified,
+  /// decrypted, persisted and put in state. A later copy of one of these is a
+  /// pure duplicate and is dropped.
   final Set<String> _unwrappedOuterIds = {};
   static const int _unwrappedOuterIdsLimit = 2000;
+
+  /// Envelopes currently being processed, keyed by outer id and reserved
+  /// synchronously — before any await — so two relays delivering the same
+  /// envelope at once share one unwrap instead of each paying for the ~5 EC
+  /// multiplications. A copy arriving mid-flight awaits this future instead
+  /// of being dropped: the id is only public data, so the in-flight copy may
+  /// be a forgery that fails verification, and the waiter must then get its
+  /// own chance to be verified.
+  final Map<String, Future<void>> _inFlightOuterIds = {};
 
   ChatKeys? _chatKeys;
   String? _chatKeysSource;
@@ -220,84 +228,126 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       final chatKeys = _getChatKeys(session);
       if (event.pubkey != chatKeys.sign.public) return;
 
-      // Duplicate outer events (relay re-deliveries, own echoes, copies
-      // racing an unwrap still in flight) are dropped here: the first
-      // delivery verified the envelope and put its inner event in state,
-      // which dedups by inner id. Nothing is written and the cursor is NOT
-      // advanced from here — this copy's signature has not been checked, and
-      // both the envelope id and the author key are public, so its created_at
-      // is attacker controlled. For legitimate traffic the advance would be a
-      // no-op anyway: a re-delivery carries the same id and therefore the
-      // same created_at, which the store already rejects as not newer.
-      // The reservation is taken synchronously, before the first await.
       final wrapperEventId = event.id!;
+
+      // A copy of an envelope this notifier already processed end to end (a
+      // relay re-delivery or an own echo): dropped. Nothing is written and
+      // the cursor is NOT advanced from here — this copy's signature has not
+      // been checked, and both the envelope id and the author key are public,
+      // so its created_at is attacker controlled. For legitimate traffic the
+      // advance would be a no-op anyway: a re-delivery carries the same id
+      // and therefore the same created_at, which the store already rejects as
+      // not newer.
       if (_unwrappedOuterIds.contains(wrapperEventId)) return;
-      if (_unwrappedOuterIds.length >= _unwrappedOuterIdsLimit) {
-        _unwrappedOuterIds.clear();
-      }
-      _unwrappedOuterIds.add(wrapperEventId);
 
-      // Already on disk means an event the background service stored while
-      // the app slept, or an own echo. It is not in _unwrappedOuterIds, so it
-      // is still verified below; only the redundant write is skipped.
-      final eventStore = ref.read(eventStorageProvider);
-      final alreadyStored = await eventStore.hasItem(wrapperEventId);
-
-      // Unwrap and authenticate BEFORE persisting: the signature is not part
-      // of the event id, so storing an unverified copy would let a corrupted
-      // duplicate occupy the id and dedup away the valid one for good
-      final unwrappedEvent = await event.chatUnwrap(
-        chatKeys,
-        session.disputeChatAllowedSigners,
-      );
-
-      // Store the outer event (encrypted) to disk — same pattern as P2P chat
-      if (!alreadyStored) {
-        await eventStore.putItem(
-          wrapperEventId,
-          event.disputeChatRecord(disputeId),
-        );
-      }
-      if (!mounted) return;
-
-      // Advance the persisted since cursor only after the event is accepted
-      // (clamped to the local clock inside the store)
-      unawaited(
-        ref
-            .read(disputeChatCursorStoreProvider)
-            .advance(disputeId, event.createdAt!),
-      );
-
-      final messageText = unwrappedEvent.content ?? '';
-      if (messageText.isEmpty) {
-        logger.w('Received empty message, skipping');
-        return;
+      // A copy arriving while another one holding the same id is still being
+      // processed waits for it instead of racing a second verification. If
+      // that one fails — an unverifiable forgery reuses the id of a valid
+      // envelope, since the signature is not part of the id — this copy falls
+      // through and gets verified on its own, so the forgery cannot suppress
+      // the real message.
+      final inFlight = _inFlightOuterIds[wrapperEventId];
+      if (inFlight != null) {
+        try {
+          await inFlight;
+          return;
+        } catch (_) {
+          // Fall through: the in-flight copy did not make it.
+        }
+        if (!mounted) return;
       }
 
-      final isFromAdmin = unwrappedEvent.pubkey != session.tradeKey.public;
-      final message = DisputeChatMessage(event: unwrappedEvent);
-
-      // Dedup by inner event ID (handles relay echo of sent messages)
-      final allMessages = [...state.messages, message];
-      final deduped = {for (var m in allMessages) m.id: m}.values.toList();
-      deduped.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-
-      state = state.copyWith(messages: deduped);
-
-      if (isFromAdmin) {
-        _maybeShowInAppNotification();
+      // Reserved synchronously — the map entry is written before the first
+      // await below — so two relays delivering the same envelope at once
+      // share one unwrap.
+      final processing = _processChatEvent(event, session, chatKeys);
+      _inFlightOuterIds[wrapperEventId] = processing;
+      try {
+        await processing;
+      } finally {
+        _inFlightOuterIds.remove(wrapperEventId);
       }
-
-      // Fire-and-forget: pre-download media after message is in state
-      unawaited(_processMessageContent(unwrappedEvent));
-      logger.i('Added dispute chat message for dispute: $disputeId '
-          '(from ${isFromAdmin ? "admin" : "user"})');
     } catch (e, stackTrace) {
-      // Drop the reservation: a failed unwrap must never lock the envelope id
-      // out, or a later valid copy of it would be silently discarded.
-      if (event.id != null) _unwrappedOuterIds.remove(event.id);
       logger.e('Error processing dispute chat event: $e', stackTrace: stackTrace);
     }
+  }
+
+  /// Verifies, persists and displays one envelope. Throws on any failure so
+  /// the id is never marked processed: a later copy retries the whole path.
+  Future<void> _processChatEvent(
+    NostrEvent event,
+    Session session,
+    ChatKeys chatKeys,
+  ) async {
+    final wrapperEventId = event.id!;
+
+      // Already on disk means an event the background service stored while
+    // the app slept, or an own echo. It is not in _unwrappedOuterIds, so it
+    // is still verified below; only the redundant write is skipped.
+    final eventStore = ref.read(eventStorageProvider);
+    final alreadyStored = await eventStore.hasItem(wrapperEventId);
+
+    // Unwrap and authenticate BEFORE persisting: the signature is not part
+    // of the event id, so storing an unverified copy would let a corrupted
+    // duplicate occupy the id and dedup away the valid one for good
+    final unwrappedEvent = await event.chatUnwrap(
+      chatKeys,
+      session.disputeChatAllowedSigners,
+    );
+
+    // Store the outer event (encrypted) to disk — same pattern as P2P chat
+    if (!alreadyStored) {
+      await eventStore.putItem(
+        wrapperEventId,
+        event.disputeChatRecord(disputeId),
+      );
+    }
+    if (!mounted) return;
+
+    // Advance the persisted since cursor only after the event is accepted
+    // (clamped to the local clock inside the store)
+    unawaited(
+      ref
+          .read(disputeChatCursorStoreProvider)
+          .advance(disputeId, event.createdAt!),
+    );
+
+    // Only now is the envelope done: everything that could throw (unwrap,
+    // disk) has succeeded, so a copy arriving later is a true duplicate. A
+    // failure above leaves the id unmarked and the next copy retries.
+    _markOuterProcessed(wrapperEventId);
+
+    final messageText = unwrappedEvent.content ?? '';
+    if (messageText.isEmpty) {
+      logger.w('Received empty message, skipping');
+      return;
+    }
+
+    final isFromAdmin = unwrappedEvent.pubkey != session.tradeKey.public;
+    final message = DisputeChatMessage(event: unwrappedEvent);
+
+    // Dedup by inner event ID (handles relay echo of sent messages)
+    final allMessages = [...state.messages, message];
+    final deduped = {for (var m in allMessages) m.id: m}.values.toList();
+    deduped.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+    state = state.copyWith(messages: deduped);
+
+    if (isFromAdmin) {
+      _maybeShowInAppNotification();
+    }
+
+    // Fire-and-forget: pre-download media after message is in state
+    unawaited(_processMessageContent(unwrappedEvent));
+    logger.i('Added dispute chat message for dispute: $disputeId '
+        '(from ${isFromAdmin ? "admin" : "user"})');
+  }
+
+  void _markOuterProcessed(String wrapperEventId) {
+    if (_unwrappedOuterIds.length >= _unwrappedOuterIdsLimit) {
+      _unwrappedOuterIds.clear();
+    }
+    _unwrappedOuterIds.add(wrapperEventId);
   }
 
   /// Show an in-app snackbar for incoming admin messages when the user is not

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -89,6 +89,10 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
   final Ref ref;
 
   StreamSubscription<NostrEvent>? _subscription;
+
+  /// Outer envelope ids this notifier already verified and decrypted.
+
+  final Set<String> _unwrappedOuterIds = {};
   ProviderSubscription<dynamic>? _sessionListener;
   bool _isInitialized = false;
 
@@ -214,13 +218,25 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       if (event.pubkey != chatKeys.sign.public) return;
 
       // Check for duplicate outer events (relay re-deliveries)
-      final wrapperEventId = event.id;
+      final wrapperEventId = event.id!;
       if (wrapperEventId == null) return;
       // Already on disk means a relay re-delivery, an own echo, or an event
-      // the background service stored while the app slept. Keep processing:
-      // state is keyed by inner id, so only the write is redundant.
+      // the background service stored while the app slept. The stored copy
+      // was verified before being persisted; skip the redundant re-verify +
+      // re-decrypt (history load covers cold-start state).
       final eventStore = ref.read(eventStorageProvider);
       final alreadyStored = await eventStore.hasItem(wrapperEventId);
+      if (alreadyStored && _unwrappedOuterIds.contains(wrapperEventId)) {
+        // Verified and decrypted by this notifier before: a relay
+        // re-delivery only needs the cursor advanced (state dedups by inner
+        // id). Envelopes stored by the background isolate still unwrap below.
+        unawaited(
+          ref
+              .read(disputeChatCursorStoreProvider)
+              .advance(disputeId, event.createdAt!),
+        );
+        return;
+      }
 
       // Unwrap and authenticate BEFORE persisting: the signature is not part
       // of the event id, so storing an unverified copy would let a corrupted
@@ -229,6 +245,10 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
         chatKeys,
         session.disputeChatAllowedSigners,
       );
+      if (_unwrappedOuterIds.length >= 2000) {
+        _unwrappedOuterIds.clear();
+      }
+      _unwrappedOuterIds.add(wrapperEventId);
 
       // Store the outer event (encrypted) to disk — same pattern as P2P chat
       if (!alreadyStored) {

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -219,7 +219,6 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
 
       // Check for duplicate outer events (relay re-deliveries)
       final wrapperEventId = event.id!;
-      if (wrapperEventId == null) return;
       // Already on disk means a relay re-delivery, an own echo, or an event
       // the background service stored while the app slept. The stored copy
       // was verified before being persisted; skip the redundant re-verify +

--- a/lib/features/disputes/notifiers/dispute_chat_notifier.dart
+++ b/lib/features/disputes/notifiers/dispute_chat_notifier.dart
@@ -89,12 +89,15 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
   final Ref ref;
 
   StreamSubscription<NostrEvent>? _subscription;
-
-  /// Outer envelope ids this notifier already verified and decrypted.
-
-  final Set<String> _unwrappedOuterIds = {};
   ProviderSubscription<dynamic>? _sessionListener;
   bool _isInitialized = false;
+
+  /// Outer envelope ids this notifier has verified and decrypted, or is
+  /// currently verifying. Reserved synchronously — before any await — so two
+  /// relays delivering the same envelope at once share one unwrap instead of
+  /// each paying for the ~5 EC multiplications.
+  final Set<String> _unwrappedOuterIds = {};
+  static const int _unwrappedOuterIdsLimit = 2000;
 
   ChatKeys? _chatKeys;
   String? _chatKeysSource;
@@ -217,25 +220,28 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       final chatKeys = _getChatKeys(session);
       if (event.pubkey != chatKeys.sign.public) return;
 
-      // Check for duplicate outer events (relay re-deliveries)
+      // Duplicate outer events (relay re-deliveries, own echoes, copies
+      // racing an unwrap still in flight) are dropped here: the first
+      // delivery verified the envelope and put its inner event in state,
+      // which dedups by inner id. Nothing is written and the cursor is NOT
+      // advanced from here — this copy's signature has not been checked, and
+      // both the envelope id and the author key are public, so its created_at
+      // is attacker controlled. For legitimate traffic the advance would be a
+      // no-op anyway: a re-delivery carries the same id and therefore the
+      // same created_at, which the store already rejects as not newer.
+      // The reservation is taken synchronously, before the first await.
       final wrapperEventId = event.id!;
-      // Already on disk means a relay re-delivery, an own echo, or an event
-      // the background service stored while the app slept. The stored copy
-      // was verified before being persisted; skip the redundant re-verify +
-      // re-decrypt (history load covers cold-start state).
+      if (_unwrappedOuterIds.contains(wrapperEventId)) return;
+      if (_unwrappedOuterIds.length >= _unwrappedOuterIdsLimit) {
+        _unwrappedOuterIds.clear();
+      }
+      _unwrappedOuterIds.add(wrapperEventId);
+
+      // Already on disk means an event the background service stored while
+      // the app slept, or an own echo. It is not in _unwrappedOuterIds, so it
+      // is still verified below; only the redundant write is skipped.
       final eventStore = ref.read(eventStorageProvider);
       final alreadyStored = await eventStore.hasItem(wrapperEventId);
-      if (alreadyStored && _unwrappedOuterIds.contains(wrapperEventId)) {
-        // Verified and decrypted by this notifier before: a relay
-        // re-delivery only needs the cursor advanced (state dedups by inner
-        // id). Envelopes stored by the background isolate still unwrap below.
-        unawaited(
-          ref
-              .read(disputeChatCursorStoreProvider)
-              .advance(disputeId, event.createdAt!),
-        );
-        return;
-      }
 
       // Unwrap and authenticate BEFORE persisting: the signature is not part
       // of the event id, so storing an unverified copy would let a corrupted
@@ -244,10 +250,6 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
         chatKeys,
         session.disputeChatAllowedSigners,
       );
-      if (_unwrappedOuterIds.length >= 2000) {
-        _unwrappedOuterIds.clear();
-      }
-      _unwrappedOuterIds.add(wrapperEventId);
 
       // Store the outer event (encrypted) to disk — same pattern as P2P chat
       if (!alreadyStored) {
@@ -291,6 +293,9 @@ class DisputeChatNotifier extends StateNotifier<DisputeChatState> with MediaCach
       logger.i('Added dispute chat message for dispute: $disputeId '
           '(from ${isFromAdmin ? "admin" : "user"})');
     } catch (e, stackTrace) {
+      // Drop the reservation: a failed unwrap must never lock the envelope id
+      // out, or a later valid copy of it would be silently discarded.
+      if (event.id != null) _unwrappedOuterIds.remove(event.id);
       logger.e('Error processing dispute chat event: $e', stackTrace: stackTrace);
     }
   }

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -105,7 +105,18 @@ class MostroService {
     return false;
   }
 
+  /// Ids seen this run, checked synchronously: two relay copies arriving
+  /// within the hasItem round-trip both passed the async check and were
+  /// decrypted twice.
+  final Set<String> _seenEventIds = {};
+  static const int _seenEventIdsLimit = 4096;
+
   Future<void> _onData(NostrEvent event) async {
+    if (_seenEventIds.length >= _seenEventIdsLimit) {
+      _seenEventIds.clear();
+    }
+    if (!_seenEventIds.add(event.id!)) return;
+
     final eventStore = ref.read(eventStorageProvider);
 
     if (await eventStore.hasItem(event.id!)) return;

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -22,6 +22,11 @@ class MostroService {
   Settings _settings;
   StreamSubscription<NostrEvent>? _ordersSubscription;
 
+  /// Event ids seen this run, reserved synchronously so two relay copies
+  /// arriving within the storage round-trip are not both decrypted.
+  final Set<String> _seenEventIds = {};
+  static const int _seenEventIdsLimit = 4096;
+
   MostroService(this.ref) : _settings = ref.read(settingsProvider);
 
   void init() {
@@ -105,27 +110,38 @@ class MostroService {
     return false;
   }
 
-  /// Ids seen this run, checked synchronously: two relay copies arriving
-  /// within the hasItem round-trip both passed the async check and were
-  /// decrypted twice.
-  final Set<String> _seenEventIds = {};
-  static const int _seenEventIdsLimit = 4096;
-
   Future<void> _onData(NostrEvent event) async {
+    final eventId = event.id!;
+
+    // Synchronous reservation: two relay copies arriving within the hasItem
+    // round-trip both passed the async check and were decrypted twice.
     if (_seenEventIds.length >= _seenEventIdsLimit) {
       _seenEventIds.clear();
     }
-    if (!_seenEventIds.add(event.id!)) return;
+    if (!_seenEventIds.add(eventId)) return;
 
     final eventStore = ref.read(eventStorageProvider);
 
-    if (await eventStore.hasItem(event.id!)) return;
+    try {
+      if (await eventStore.hasItem(eventId)) return;
 
-    // Reserve event ID immediately to prevent duplicate processing from multiple relays
-    await eventStore.putItem(event.id!, {
-      'id': event.id,
-      'created_at': event.createdAt!.millisecondsSinceEpoch ~/ 1000,
-    });
+      // Reserve event ID immediately to prevent duplicate processing from multiple relays
+      await eventStore.putItem(eventId, {
+        'id': event.id,
+        'created_at': event.createdAt!.millisecondsSinceEpoch ~/ 1000,
+      });
+    } catch (e, stackTrace) {
+      // The durable reservation failed. Release the in-memory one too, or a
+      // transient storage error would discard every later redelivery of this
+      // event for the rest of the run and lose the order update for good.
+      _seenEventIds.remove(eventId);
+      logger.e(
+        'Failed to reserve event $eventId in storage',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return;
+    }
 
     final sessions = ref.read(sessionNotifierProvider);
     final matchingSession = sessions.firstWhereOrNull(

--- a/test/features/chat/chat_room_notifier_redundant_decrypt_test.dart
+++ b/test/features/chat/chat_room_notifier_redundant_decrypt_test.dart
@@ -33,6 +33,23 @@ class _StubChatRoomsNotifier extends ChatRoomsNotifier {
   Future<void> refreshChatList() async {}
 }
 
+class _FlakyEventStorage extends EventStorage {
+  _FlakyEventStorage({required super.db});
+
+  bool failNextPut = false;
+  int putCount = 0;
+
+  @override
+  Future<void> putItem(String id, Map<String, dynamic> item) async {
+    putCount++;
+    if (failNextPut) {
+      failNextPut = false;
+      throw Exception('disk full');
+    }
+    return super.putItem(id, item);
+  }
+}
+
 class _FakeSharedPreferencesAsync implements SharedPreferencesAsync {
   final Map<String, int> ints = {};
 
@@ -63,7 +80,7 @@ void main() {
   );
 
   late Session session;
-  late EventStorage eventStorage;
+  late _FlakyEventStorage eventStorage;
   late ProviderContainer container;
   late ChatRoomNotifier notifier;
   late ChatKeys chatKeys;
@@ -90,7 +107,7 @@ void main() {
 
     final db =
         await newDatabaseFactoryMemory().openDatabase('redundant_decrypt.db');
-    eventStorage = EventStorage(db: db);
+    eventStorage = _FlakyEventStorage(db: db);
 
     cursorStore = ChatCursorStore(
       _FakeSharedPreferencesAsync(),
@@ -204,6 +221,53 @@ void main() {
     expect(notifier.debugUnwrapCount, 1,
         reason: 'the second delivery must join the in-flight unwrap instead '
             'of starting its own');
+    expect(container.read(chatRoomProvider).messages, hasLength(1));
+  });
+
+  test('a valid copy is still processed when a forged one with the same id '
+      'is being verified', () async {
+    final real = await envelope('legit');
+
+    // Hostile relay wins the race: same envelope id (the signature is not
+    // part of it), correct claimed author, garbage payload.
+    final forged = NostrEvent.deserialized('["EVENT","",${jsonEncode({
+          'id': real.id,
+          'pubkey': chatKeys.sign.public,
+          'created_at': real.createdAt!.millisecondsSinceEpoch ~/ 1000,
+          'kind': 14,
+          'tags': <List<String>>[],
+          'content': 'undecryptable garbage',
+          'sig': '0' * 128,
+        })}]');
+
+    await Future.wait([
+      notifier.handleChatEvent(forged),
+      notifier.handleChatEvent(real),
+    ]);
+
+    expect(container.read(chatRoomProvider).messages, hasLength(1),
+        reason: 'a forgery reusing a valid envelope id must not suppress the '
+            'real message that arrives while it is being verified');
+    expect(container.read(chatRoomProvider).messages.single.content,
+        isNot('undecryptable garbage'));
+  });
+
+  test('a re-delivery retries persistence after a failed store', () async {
+    final event = await envelope('hola');
+
+    eventStorage.failNextPut = true;
+    await notifier.handleChatEvent(event);
+
+    expect(await eventStorage.hasItem(event.id!), isFalse,
+        reason: 'the write failed, so the envelope is not on disk');
+
+    // A later relay delivery of the same envelope must redo the write instead
+    // of taking the already-unwrapped shortcut.
+    await notifier.handleChatEvent(event);
+
+    expect(await eventStorage.hasItem(event.id!), isTrue,
+        reason: 'the envelope must be persisted by the retry, or it would be '
+            'gone after a restart');
     expect(container.read(chatRoomProvider).messages, hasLength(1));
   });
 }

--- a/test/features/chat/chat_room_notifier_redundant_decrypt_test.dart
+++ b/test/features/chat/chat_room_notifier_redundant_decrypt_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -65,6 +67,7 @@ void main() {
   late ProviderContainer container;
   late ChatRoomNotifier notifier;
   late ChatKeys chatKeys;
+  late ChatCursorStore cursorStore;
 
   final chatRoomProvider = StateNotifierProvider<ChatRoomNotifier, ChatRoom>(
     (ref) => ChatRoomNotifier(
@@ -89,13 +92,15 @@ void main() {
         await newDatabaseFactoryMemory().openDatabase('redundant_decrypt.db');
     eventStorage = EventStorage(db: db);
 
+    cursorStore = ChatCursorStore(
+      _FakeSharedPreferencesAsync(),
+      keyPrefix: 'chat_since_',
+    );
+
     container = ProviderContainer(overrides: [
       sessionProvider(orderId).overrideWith((ref) => session),
       eventStorageProvider.overrideWithValue(eventStorage),
-      chatCursorStoreProvider.overrideWithValue(
-        ChatCursorStore(_FakeSharedPreferencesAsync(),
-              keyPrefix: 'chat_since_'),
-      ),
+      chatCursorStoreProvider.overrideWithValue(cursorStore),
       chatRoomsNotifierProvider
           .overrideWith((ref) => _StubChatRoomsNotifier(ref)),
     ]);
@@ -138,6 +143,67 @@ void main() {
     expect(notifier.debugUnwrapCount, 1,
         reason: 'reloading history must not re-verify and re-decrypt '
             'envelopes already unwrapped in this notifier');
+    expect(container.read(chatRoomProvider).messages, hasLength(1));
+  });
+
+  test('an envelope stored by the background isolate is still verified',
+      () async {
+    final event = await envelope('from background');
+    // On disk, but this notifier never verified it.
+    await eventStorage.putItem(event.id!, event.peerChatRecord(orderId));
+
+    await notifier.handleChatEvent(event);
+
+    expect(notifier.debugUnwrapCount, 1,
+        reason: 'an envelope this notifier never verified must be unwrapped, '
+            'even though it is already on disk');
+    expect(container.read(chatRoomProvider).messages, hasLength(1));
+  });
+
+  test('the cursor does not advance from an unverified envelope', () async {
+    final real = await envelope('legit');
+    await notifier.handleChatEvent(real);
+    // The accepted event advances the cursor fire-and-forget; let it land.
+    await Future<void>.delayed(Duration.zero);
+    final before = await cursorStore.cursorFor(orderId);
+    expect(before, isNotNull, reason: 'the verified event advances the cursor');
+
+    // Hostile relay: real envelope id, correct claimed author (both are
+    // public), bogus signature and a created_at far in the future.
+    final forged = NostrEvent.deserialized('["EVENT","",${jsonEncode({
+          'id': real.id,
+          'pubkey': chatKeys.sign.public,
+          'created_at': DateTime.now()
+                  .add(const Duration(days: 3650))
+                  .millisecondsSinceEpoch ~/
+              1000,
+          'kind': 14,
+          'tags': <List<String>>[],
+          'content': 'undecryptable garbage',
+          'sig': '0' * 128,
+        })}]');
+
+    await notifier.handleChatEvent(forged);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(await cursorStore.cursorFor(orderId), before,
+        reason: 'a copy whose signature was never checked must not move the '
+            'since cursor: a forged created_at would push it to the local '
+            'clock and drop older messages after a reconnect');
+  });
+
+  test('concurrent deliveries of the same envelope share one unwrap',
+      () async {
+    final event = await envelope('hola');
+
+    await Future.wait([
+      notifier.handleChatEvent(event),
+      notifier.handleChatEvent(event),
+    ]);
+
+    expect(notifier.debugUnwrapCount, 1,
+        reason: 'the second delivery must join the in-flight unwrap instead '
+            'of starting its own');
     expect(container.read(chatRoomProvider).messages, hasLength(1));
   });
 }

--- a/test/features/chat/chat_room_notifier_redundant_decrypt_test.dart
+++ b/test/features/chat/chat_room_notifier_redundant_decrypt_test.dart
@@ -1,0 +1,143 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/chat_room.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/data/models/peer.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/data/repositories/event_storage.dart';
+import 'package:mostro_mobile/features/chat/notifiers/chat_room_notifier.dart';
+import 'package:mostro_mobile/features/chat/notifiers/chat_rooms_notifier.dart';
+import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
+import 'package:mostro_mobile/services/chat_cursor_store.dart';
+import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
+import 'package:sembast/sembast_memory.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A chat envelope costs ~5 EC multiplications to verify + decrypt. With R
+/// relays each message used to be unwrapped R times (the handler continued
+/// past `alreadyStored`), and every history load re-unwrapped every stored
+/// envelope. Already-verified envelopes are now skipped and unwraps are
+/// cached per outer id.
+class _StubChatRoomsNotifier extends ChatRoomsNotifier {
+  _StubChatRoomsNotifier(super.ref);
+
+  @override
+  Future<void> loadChats() async {}
+
+  @override
+  Future<void> refreshChatList() async {}
+}
+
+class _FakeSharedPreferencesAsync implements SharedPreferencesAsync {
+  final Map<String, int> ints = {};
+
+  @override
+  Future<int?> getInt(String key) async => ints[key];
+
+  @override
+  Future<void> setInt(String key, int value) async {
+    ints[key] = value;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const orderId = 'a4b7c9e1-0000-4000-8000-redundant-dec';
+  final ownKey = NostrKeyPairs(
+    private:
+        '0000000000000000000000000000000000000000000000000000000000000001',
+  );
+  final peerKey = NostrKeyPairs(
+    private:
+        '0000000000000000000000000000000000000000000000000000000000000002',
+  );
+
+  late Session session;
+  late EventStorage eventStorage;
+  late ProviderContainer container;
+  late ChatRoomNotifier notifier;
+  late ChatKeys chatKeys;
+
+  final chatRoomProvider = StateNotifierProvider<ChatRoomNotifier, ChatRoom>(
+    (ref) => ChatRoomNotifier(
+      ChatRoom(orderId: orderId, messages: []),
+      orderId,
+      ref,
+    ),
+  );
+
+  setUp(() async {
+    session = Session(
+      masterKey: ownKey,
+      tradeKey: ownKey,
+      keyIndex: 1,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+      orderId: orderId,
+    )..peer = Peer(publicKey: peerKey.public);
+    chatKeys = ChatKeys.fromSharedKey(session.sharedKey!);
+
+    final db =
+        await newDatabaseFactoryMemory().openDatabase('redundant_decrypt.db');
+    eventStorage = EventStorage(db: db);
+
+    container = ProviderContainer(overrides: [
+      sessionProvider(orderId).overrideWith((ref) => session),
+      eventStorageProvider.overrideWithValue(eventStorage),
+      chatCursorStoreProvider.overrideWithValue(
+        ChatCursorStore(_FakeSharedPreferencesAsync(),
+              keyPrefix: 'chat_since_'),
+      ),
+      chatRoomsNotifierProvider
+          .overrideWith((ref) => _StubChatRoomsNotifier(ref)),
+    ]);
+    notifier = container.read(chatRoomProvider.notifier);
+  });
+
+  tearDown(() => container.dispose());
+
+  Future<NostrEvent> envelope(String text) {
+    final rumor = NostrEventExtensions.createChatRumor(
+      senderKeys: peerKey,
+      content: text,
+    );
+    return rumor.chatWrap(chatKeys);
+  }
+
+  test('a relay re-delivery of a stored envelope is not unwrapped again',
+      () async {
+    final event = await envelope('hola');
+
+    await notifier.handleChatEvent(event);
+    expect(notifier.debugUnwrapCount, 1);
+    expect(container.read(chatRoomProvider).messages, hasLength(1));
+
+    // Same envelope from a second relay.
+    await notifier.handleChatEvent(event);
+
+    expect(notifier.debugUnwrapCount, 1,
+        reason: 'the stored copy was already verified when first accepted');
+    expect(container.read(chatRoomProvider).messages, hasLength(1));
+  });
+
+  test('history load reuses the unwrap of a live-handled envelope', () async {
+    final event = await envelope('hola');
+    await notifier.handleChatEvent(event);
+    expect(notifier.debugUnwrapCount, 1);
+
+    await notifier.initialize();
+
+    expect(notifier.debugUnwrapCount, 1,
+        reason: 'reloading history must not re-verify and re-decrypt '
+            'envelopes already unwrapped in this notifier');
+    expect(container.read(chatRoomProvider).messages, hasLength(1));
+  });
+}

--- a/test/features/disputes/dispute_chat_duplicate_envelope_test.dart
+++ b/test/features/disputes/dispute_chat_duplicate_envelope_test.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/dispute.dart';
+import 'package:mostro_mobile/data/models/enums/action.dart' as actions;
+import 'package:mostro_mobile/data/models/enums/status.dart';
+import 'package:mostro_mobile/data/models/nostr_event.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/data/repositories/event_storage.dart';
+import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
+import 'package:mostro_mobile/features/order/models/order_state.dart';
+import 'package:mostro_mobile/features/order/notifiers/order_notifier.dart';
+import 'package:mostro_mobile/features/order/providers/order_notifier_provider.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/services/mostro_service.dart';
+import 'package:mostro_mobile/services/nostr_service.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/shared/providers/mostro_database_provider.dart';
+import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/nostr_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:mostro_mobile/shared/providers/storage_providers.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
+import 'package:sembast/sembast_memory.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../../mocks.mocks.dart';
+
+/// Nostr service whose subscription is driven by the test.
+class _ControlledNostrService extends NostrService {
+  final StreamController<NostrEvent> controller =
+      StreamController<NostrEvent>.broadcast();
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Stream<NostrEvent> subscribeToEvents(NostrRequest request) {
+    // Only the dispute chat subscription is driven by the test; anything else
+    // (the open orders repository, for one) must not see these envelopes.
+    final wantsChat =
+        request.filters.any((f) => f.kinds?.contains(14) ?? false);
+    return wantsChat ? controller.stream : const Stream.empty();
+  }
+}
+
+class _IdleMostroService extends MostroService {
+  _IdleMostroService(super.ref);
+}
+
+class _FixedOrderNotifier extends OrderNotifier {
+  _FixedOrderNotifier(super.orderId, super.ref, OrderState fixedState) {
+    state = fixedState;
+  }
+
+  @override
+  Future<void> sync() async {}
+
+  @override
+  void subscribe() {}
+}
+
+class _FixedSessionNotifier extends SessionNotifier {
+  _FixedSessionNotifier(Ref ref, List<Session> sessions)
+      : super(
+          ref,
+          MockSessionStorage(),
+          Settings(
+            relays: [],
+            fullPrivacyMode: false,
+            mostroPublicKey: 'test',
+          ),
+        ) {
+    state = sessions;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const orderId = 'order-1';
+  const disputeId = 'dispute-1';
+
+  final tradeKey = NostrKeyPairs(
+    private:
+        '0000000000000000000000000000000000000000000000000000000000000001',
+  );
+  final adminKey = NostrKeyPairs(
+    private:
+        '0000000000000000000000000000000000000000000000000000000000000003',
+  );
+
+  late Session session;
+  late Database db;
+  late ProviderContainer container;
+  late _ControlledNostrService nostrService;
+
+  setUp(() async {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+
+    session = Session(
+      masterKey: tradeKey,
+      tradeKey: tradeKey,
+      keyIndex: 1,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+      orderId: orderId,
+    )..setAdminPeer(adminKey.public);
+
+    db = await newDatabaseFactoryMemory()
+        .openDatabase('dispute_duplicate_envelope.db');
+    nostrService = _ControlledNostrService();
+
+    final orderState = OrderState(
+      status: Status.dispute,
+      action: actions.Action.disputeInitiatedByYou,
+      order: null,
+      dispute: Dispute(disputeId: disputeId, orderId: orderId),
+    );
+
+    container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(SharedPreferencesAsync()),
+        mostroDatabaseProvider.overrideWithValue(db),
+        nostrServiceProvider.overrideWithValue(nostrService),
+        mostroServiceProvider.overrideWith((ref) => _IdleMostroService(ref)),
+        eventStorageProvider.overrideWithValue(EventStorage(db: db)),
+        sessionNotifierProvider
+            .overrideWith((ref) => _FixedSessionNotifier(ref, [session])),
+        orderNotifierProvider.overrideWith(
+          (ref, id) => _FixedOrderNotifier(id, ref, orderState),
+        ),
+      ],
+    );
+  });
+
+  tearDown(() async {
+    await nostrService.controller.close();
+    container.dispose();
+    await db.close();
+  });
+
+  test(
+      'a valid envelope is still processed when a forged copy with the same '
+      'id is being verified', () async {
+    final notifier =
+        container.read(disputeChatNotifierProvider(disputeId).notifier);
+    await pumpEventQueue(times: 100);
+
+    final chatKeys = ChatKeys.fromSharedKey(session.adminSharedKey!);
+    final rumor = NostrEventExtensions.createChatRumor(
+      senderKeys: adminKey,
+      content: 'admin says hi',
+    );
+    final real = await rumor.chatWrap(chatKeys);
+
+    // The signature is not part of the event id, so a hostile relay can reuse
+    // a valid envelope's id on an unverifiable copy. It wins the race here.
+    final forged = NostrEvent.deserialized('["EVENT","",${jsonEncode({
+          'id': real.id,
+          'pubkey': chatKeys.sign.public,
+          'created_at': real.createdAt!.millisecondsSinceEpoch ~/ 1000,
+          'kind': 14,
+          'tags': <List<String>>[],
+          'content': 'undecryptable garbage',
+          'sig': '0' * 128,
+        })}]');
+
+    nostrService.controller.add(forged);
+    nostrService.controller.add(real);
+    await pumpEventQueue(times: 200);
+
+    final messages =
+        container.read(disputeChatNotifierProvider(disputeId)).messages;
+    expect(messages, hasLength(1),
+        reason: 'the forgery must not suppress the real message that arrives '
+            'while the forged copy is still being verified');
+    expect(messages.single.content, 'admin says hi');
+    expect(notifier.mounted, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Item **3.3** of the performance plan. A chat envelope costs ~5 EC multiplications (two Schnorr verifications + NIP-44 decrypt) on the UI isolate. Three redundancy sources:

1. **Per-relay re-deliveries**: `_onChatEvent` checked `hasItem` but deliberately continued to `chatUnwrap` — with R relays, R full unwraps per message.
2. **History loads**: `_loadHistoricalMessages` re-verified and re-decrypted every stored envelope on every init/reload.
3. **Node messages**: `stream.listen(_onData)` doesn't await the handler, so two relay copies arriving within the Sembast `hasItem` round trip both passed the check and were both decrypted.

## Changes

- **`ChatRoomNotifier`**: unwraps cached per outer envelope id (bounded). A re-delivery of an envelope *this notifier already verified* only advances the cursor and re-surfaces the cached inner event if state lost it; history loads consult the cache first. **The pinned security/handoff behaviours are preserved**: an envelope persisted by the background isolate is not in the cache, so it is still unwrapped on first sight (the existing security-test pin for that path stays green), and nothing unverified is ever persisted (the verify-before-persist order is untouched — `putItem` remains conditional on `!alreadyStored`).
- **`DisputeChatNotifier`**: same skip via a set of locally verified outer ids.
- **`MostroService._onData`**: synchronous seen-id set checked before the async `hasItem`, closing the two-relay decrypt race (disk dedup still guards across restarts).
- `@visibleForTesting debugUnwrapCount` on `ChatRoomNotifier` pins the unwrap count.

## Test plan

- [x] New `test/features/chat/chat_room_notifier_redundant_decrypt_test.dart` (RED on `main`): a second relay delivery does not unwrap again; a history reload reuses the live unwrap — both with real crypto against the in-memory store
- [x] `chat_room_notifier_security_test.dart` — all pins green, including "an event the background already persisted still reaches the UI" (which drove the cache-aware skip design)
- [x] Chat + disputes + mostro_service suites — 105/105
- [x] Full `flutter test` — 1195/1195
- [x] `flutter analyze` — no new issues
- [ ] Manual: chat with multiple relays configured — messages appear once, instantly; resume from background with pending admin/chat messages — they surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced repeated verification of chat message envelopes during relay redeliveries, concurrent deliveries, and history reloads.
  * Improved chat loading efficiency by reusing previously verified messages.

* **Reliability**
  * Failed or corrupted envelope verification attempts can be retried safely.
  * Duplicate dispute chat deliveries are filtered to prevent redundant processing.

* **Tests**
  * Added coverage for duplicate delivery, concurrent handling, history reloads, background-stored messages, and invalid signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->