### PR TITLE
perf: run media sanitizing and file crypto off the main isolate

### DIFF
--- a/lib/services/encrypted_file_upload_service.dart
+++ b/lib/services/encrypted_file_upload_service.dart
@@ -80,17 +80,12 @@ class EncryptedFileUploadService {
       );
       
       // 2. Encrypt with ChaCha20-Poly1305
-      final encryptionResult = EncryptionService.encryptChaCha20Poly1305(
+      final encryptedBlob = await EncryptionService.encryptToBlobAsync(
         key: sharedKey,
         plaintext: validationResult.validatedData,
       );
-      
-      final encryptedBlob = encryptionResult.toBlob();
       logger.i(
         '🔐 File encrypted successfully: ${encryptedBlob.length} bytes '
-        '(nonce: ${encryptionResult.nonce.length}B, '
-        'data: ${encryptionResult.encryptedData.length}B, '
-        'tag: ${encryptionResult.authTag.length}B)'
       );
       
       // 3. Upload encrypted blob to Blossom
@@ -136,7 +131,7 @@ class EncryptedFileUploadService {
       logger.i('📥 Downloaded encrypted blob: ${encryptedBlob.length} bytes');
       
       // 2. Decrypt with ChaCha20-Poly1305
-      final decryptedFile = EncryptionService.decryptFromBlob(
+      final decryptedFile = await EncryptionService.decryptFromBlobAsync(
         key: sharedKey,
         blob: encryptedBlob,
       );

--- a/lib/services/encrypted_file_upload_service.dart
+++ b/lib/services/encrypted_file_upload_service.dart
@@ -80,12 +80,17 @@ class EncryptedFileUploadService {
       );
       
       // 2. Encrypt with ChaCha20-Poly1305
-      final encryptedBlob = await EncryptionService.encryptToBlobAsync(
+      final encryptionResult = await EncryptionService.encryptChaCha20Poly1305Async(
         key: sharedKey,
         plaintext: validationResult.validatedData,
       );
+      
+      final encryptedBlob = encryptionResult.toBlob();
       logger.i(
         '🔐 File encrypted successfully: ${encryptedBlob.length} bytes '
+        '(nonce: ${encryptionResult.nonce.length}B, '
+        'data: ${encryptionResult.encryptedData.length}B, '
+        'tag: ${encryptionResult.authTag.length}B)'
       );
       
       // 3. Upload encrypted blob to Blossom

--- a/lib/services/encrypted_image_upload_service.dart
+++ b/lib/services/encrypted_image_upload_service.dart
@@ -91,17 +91,12 @@ class EncryptedImageUploadService {
       );
       
       // 3. Encrypt with ChaCha20-Poly1305
-      final encryptionResult = EncryptionService.encryptChaCha20Poly1305(
+      final encryptedBlob = await EncryptionService.encryptToBlobAsync(
         key: sharedKey,
         plaintext: validationResult.validatedData,
       );
-      
-      final encryptedBlob = encryptionResult.toBlob();
       logger.i(
         '🔐 Image encrypted successfully: ${encryptedBlob.length} bytes '
-        '(nonce: ${encryptionResult.nonce.length}B, '
-        'data: ${encryptionResult.encryptedData.length}B, '
-        'tag: ${encryptionResult.authTag.length}B)'
       );
       
       // 4. Upload encrypted blob to Blossom
@@ -151,7 +146,7 @@ class EncryptedImageUploadService {
       logger.i('📥 Downloaded encrypted blob: ${encryptedBlob.length} bytes');
       
       // 2. Decrypt with ChaCha20-Poly1305
-      final decryptedImage = EncryptionService.decryptFromBlob(
+      final decryptedImage = await EncryptionService.decryptFromBlobAsync(
         key: sharedKey,
         blob: encryptedBlob,
       );

--- a/lib/services/encrypted_image_upload_service.dart
+++ b/lib/services/encrypted_image_upload_service.dart
@@ -91,12 +91,17 @@ class EncryptedImageUploadService {
       );
       
       // 3. Encrypt with ChaCha20-Poly1305
-      final encryptedBlob = await EncryptionService.encryptToBlobAsync(
+      final encryptionResult = await EncryptionService.encryptChaCha20Poly1305Async(
         key: sharedKey,
         plaintext: validationResult.validatedData,
       );
+      
+      final encryptedBlob = encryptionResult.toBlob();
       logger.i(
         '🔐 Image encrypted successfully: ${encryptedBlob.length} bytes '
+        '(nonce: ${encryptionResult.nonce.length}B, '
+        'data: ${encryptionResult.encryptedData.length}B, '
+        'tag: ${encryptionResult.authTag.length}B)'
       );
       
       // 4. Upload encrypted blob to Blossom

--- a/lib/services/encryption_service.dart
+++ b/lib/services/encryption_service.dart
@@ -1,3 +1,4 @@
+import 'dart:isolate';
 import 'dart:typed_data';
 import 'dart:math';
 import 'package:pointycastle/export.dart';
@@ -183,6 +184,38 @@ class EncryptionService {
       logger.e('❌ ChaCha20-Poly1305 decryption failed: $e');
       throw EncryptionException('Decryption failed: $e');
     }
+  }
+
+  /// Isolate-backed variants: ChaCha20-Poly1305 here is pure Dart
+  /// (pointycastle) over whole files (up to 25 MB), which froze the UI while
+  /// sending or opening media. Inputs and outputs are plain byte buffers, so
+  /// they transfer cheaply.
+  static Future<Uint8List> encryptToBlobAsync({
+    required Uint8List key,
+    required Uint8List plaintext,
+    Uint8List? additionalData,
+  }) {
+    return Isolate.run(
+      () => encryptToBlob(
+        key: key,
+        plaintext: plaintext,
+        additionalData: additionalData,
+      ),
+    );
+  }
+
+  static Future<Uint8List> decryptFromBlobAsync({
+    required Uint8List key,
+    required Uint8List blob,
+    Uint8List? additionalData,
+  }) {
+    return Isolate.run(
+      () => decryptFromBlob(
+        key: key,
+        blob: blob,
+        additionalData: additionalData,
+      ),
+    );
   }
 
   /// Convenience method to encrypt and return a blob

--- a/lib/services/encryption_service.dart
+++ b/lib/services/encryption_service.dart
@@ -190,6 +190,22 @@ class EncryptionService {
   /// (pointycastle) over whole files (up to 25 MB), which froze the UI while
   /// sending or opening media. Inputs and outputs are plain byte buffers, so
   /// they transfer cheaply.
+  /// Isolate-backed encrypt that preserves access to the nonce/tag parts
+  /// (the upload results carry the nonce as protocol metadata).
+  static Future<EncryptionResult> encryptChaCha20Poly1305Async({
+    required Uint8List key,
+    required Uint8List plaintext,
+    Uint8List? additionalData,
+  }) {
+    return Isolate.run(
+      () => encryptChaCha20Poly1305(
+        key: key,
+        plaintext: plaintext,
+        additionalData: additionalData,
+      ),
+    );
+  }
+
   static Future<Uint8List> encryptToBlobAsync({
     required Uint8List key,
     required Uint8List plaintext,

--- a/lib/services/file_validation_service.dart
+++ b/lib/services/file_validation_service.dart
@@ -1,3 +1,4 @@
+import 'dart:isolate';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:mime/mime.dart';
@@ -226,7 +227,7 @@ class FileValidationService {
       }
       
       // Basic macro detection for DOC files using byte pattern search
-      if (_containsMacroPatterns(fileData)) {
+      if (await Isolate.run(() => _containsMacroPatterns(fileData))) {
         throw FileValidationException('Document contains macros which are not allowed for security reasons');
       }
     } 
@@ -242,7 +243,7 @@ class FileValidationService {
       }
       
       // Basic macro detection - look for vbaProject.bin in the ZIP structure
-      if (_containsMacroPatterns(fileData)) {
+      if (await Isolate.run(() => _containsMacroPatterns(fileData))) {
         throw FileValidationException('Document contains macros which are not allowed for security reasons');
       }
     }

--- a/lib/services/media_validation_service.dart
+++ b/lib/services/media_validation_service.dart
@@ -1,3 +1,4 @@
+import 'dart:isolate';
 import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import 'package:mime/mime.dart';
@@ -59,8 +60,10 @@ class MediaValidationService {
   /// 3. Re-encodes to eliminate malicious metadata
   static Future<MediaValidationResult> validateAndSanitizeImage(
     Uint8List imageData,
-  ) async {
-    return _sanitizeImageHeavy(imageData);
+  ) {
+    // Pure-Dart decode + re-encode takes seconds for a phone photo; run it
+    // off the main isolate (bytes and the result transfer cheaply).
+    return Isolate.run(() => _sanitizeImageHeavy(imageData));
   }
   
   /// Light image sanitization for better performance
@@ -69,6 +72,12 @@ class MediaValidationService {
   /// 3. Strips metadata only (no heavy pixel validation)
   /// 4. Quick re-encode with minimal quality loss
   static Future<MediaValidationResult> validateAndSanitizeImageLight(
+    Uint8List imageData,
+  ) {
+    return Isolate.run(() => _sanitizeImageLightImpl(imageData));
+  }
+
+  static Future<MediaValidationResult> _sanitizeImageLightImpl(
     Uint8List imageData,
   ) async {
     logger.i('📸 Light image sanitization started: ${imageData.length} bytes');

--- a/test/services/media_crypto_isolate_test.dart
+++ b/test/services/media_crypto_isolate_test.dart
@@ -1,0 +1,83 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:mostro_mobile/services/encryption_service.dart';
+import 'package:mostro_mobile/services/media_validation_service.dart';
+
+/// Image sanitizing (pure-Dart decode + re-encode: 1-5 s for a phone photo)
+/// and whole-file ChaCha20-Poly1305 ran on the main isolate, freezing the UI
+/// while sending or opening media. Both now run through Isolate.run; these
+/// tests pin the async variants' behaviour, including error propagation
+/// across the isolate boundary.
+void main() {
+  final key = Uint8List.fromList(List.generate(32, (i) => i));
+
+  Uint8List tinyPng() {
+    final image = img.Image(width: 2, height: 2);
+    img.fill(image, color: img.ColorRgb8(200, 50, 50));
+    return Uint8List.fromList(img.encodePng(image));
+  }
+
+  group('EncryptionService isolate variants', () {
+    test('async blob roundtrip matches the sync implementation', () async {
+      final plaintext = Uint8List.fromList(List.generate(1024, (i) => i % 251));
+
+      final blob = await EncryptionService.encryptToBlobAsync(
+        key: key,
+        plaintext: plaintext,
+      );
+      final decrypted = await EncryptionService.decryptFromBlobAsync(
+        key: key,
+        blob: blob,
+      );
+
+      expect(decrypted, plaintext);
+      // Cross-compatibility: sync decrypt reads the async-produced blob.
+      expect(EncryptionService.decryptFromBlob(key: key, blob: blob),
+          plaintext);
+    });
+
+    test('a tampered blob fails across the isolate boundary', () async {
+      final blob = await EncryptionService.encryptToBlobAsync(
+        key: key,
+        plaintext: Uint8List.fromList([1, 2, 3]),
+      );
+      blob[blob.length - 1] ^= 0xFF;
+
+      await expectLater(
+        EncryptionService.decryptFromBlobAsync(key: key, blob: blob),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('MediaValidationService off the main isolate', () {
+    test('light sanitization still validates and strips a PNG', () async {
+      final result =
+          await MediaValidationService.validateAndSanitizeImageLight(tinyPng());
+
+      expect(result.mimeType, 'image/png');
+      expect(result.width, 2);
+      expect(result.height, 2);
+      expect(img.decodePng(result.validatedData), isNotNull);
+    });
+
+    test('heavy sanitization still validates a PNG', () async {
+      final result =
+          await MediaValidationService.validateAndSanitizeImage(tinyPng());
+
+      expect(result.mimeType, 'image/png');
+      expect(img.decodePng(result.validatedData), isNotNull);
+    });
+
+    test('garbage input propagates the validation error', () async {
+      await expectLater(
+        MediaValidationService.validateAndSanitizeImageLight(
+          Uint8List.fromList(List.filled(64, 7)),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Item **3.5** of the performance plan. Three CPU-heavy media paths ran on the UI isolate:

- **Image sanitizing** (`package:image`, pure Dart): decode + re-encode of a 12 MP photo takes 1–5 s, per image sent (`media_validation_service.dart`).
- **Whole-file ChaCha20-Poly1305** (pointycastle, files up to 25 MB): per media send, per download, and per history auto-download (`encryption_service.dart`).
- **Macro-pattern scan** (O(n·m) over the whole file) in document validation.

## Changes

- `validateAndSanitizeImage` / `validateAndSanitizeImageLight` keep their public signatures but execute through `Isolate.run` (byte buffers and `MediaValidationResult`/exceptions transfer across the boundary; propagation pinned by test).
- `EncryptionService.encryptToBlobAsync` / `decryptFromBlobAsync`: `Isolate.run` over the existing sync implementations (which stay for callers that need them and for the isolate itself). The encrypted image/file upload services now use the async variants in both directions.
- The macro scan runs through `Isolate.run` at both call sites.

**Left for 3.4 (worker isolate):** per-message NIP-44/Schnorr work — batching those into a long-lived worker is the remaining phase-3 item, done after the caches (#700, #701, #702) so the isolate doesn't inherit redundant work.

## Test plan

- [x] New `test/services/media_crypto_isolate_test.dart` (RED on `main`): async blob roundtrip + cross-compat with sync, tampered-blob failure across the isolate, PNG light/heavy sanitize results, garbage-input error propagation
- [x] `file_messaging_test.dart` + chat suites — green
- [x] Full `flutter test` — all green
- [x] `flutter analyze` — no new issues
- [ ] Manual: send a large photo in chat — UI stays responsive during sanitize+encrypt; open received media — decrypts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur