### PR TITLE
fix: re-issue open REQs when a relay comes back alive

### DIFF
--- a/lib/features/subscriptions/subscription_manager.dart
+++ b/lib/features/subscriptions/subscription_manager.dart
@@ -78,12 +78,20 @@ class SubscriptionManager {
   /// [ChatCursorStore.advance].
   final Map<SubscriptionType, Future<void>> _updateQueue = {};
 
+  /// Debounce for relay-driven resubscribes: startup and network recovery
+  /// bring several relays alive in a burst; one re-issue covers them all.
+  static const relayResubscribeDebounce = Duration(seconds: 1);
+
+  StreamSubscription<int>? _relayGenerationListener;
+  Timer? _relayResubscribeTimer;
+
   SubscriptionManager(this.ref) {
     _initSessionListener();
     // Ensure resources are released with provider/container lifecycle
     ref.onDispose(dispose);
     _initializeExistingSessions();
     _initMostroInstanceListener();
+    _initRelayGenerationListener();
   }
 
   /// Watches the connected node's info event so the orders subscription can
@@ -125,6 +133,60 @@ class SubscriptionManager {
     } catch (e) {
       logger.w('Failed to resolve orders transport, defaulting to v1: $e');
       return Transport.giftWrap;
+    }
+  }
+
+  /// Re-issues every open REQ when a relay comes (back) alive. dart_nostr
+  /// sends a REQ once, to the sockets registered at that moment: a socket
+  /// that silently reconnects (mobile radio sleep, network change) or a relay
+  /// added afterwards by the kind 10002 sync carries no subscriptions until
+  /// something replays them. Before the filter-identity skip, the periodic
+  /// session-cleanup emission re-issued the REQs as a side effect; this
+  /// listener makes that guarantee explicit. The relay generation is part of
+  /// [_filterIdentity], so the forced update passes the skip check.
+  void _initRelayGenerationListener() {
+    try {
+      _relayGenerationListener =
+          ref.read(nostrServiceProvider).relayGenerationStream.listen(
+        (_) {
+          if (_isSuspended) return;
+          _relayResubscribeTimer?.cancel();
+          _relayResubscribeTimer =
+              Timer(relayResubscribeDebounce, _resubscribeForRelayGeneration);
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          logger.e('Error in relay generation listener',
+              error: error, stackTrace: stackTrace);
+        },
+      );
+    } catch (e, stackTrace) {
+      logger.e('Failed to init relay generation listener',
+          error: e, stackTrace: stackTrace);
+    }
+  }
+
+  void _resubscribeForRelayGeneration() {
+    if (_isSuspended) return;
+    final sessions = ref.read(sessionNotifierProvider);
+    if (sessions.isNotEmpty) {
+      logger.i('Relay generation changed, re-issuing session subscriptions');
+      _updateAllSubscriptions(sessions);
+    }
+    // The relay-list REQ is not session-derived; replace it in place so the
+    // newly alive socket receives it too.
+    final mostroPubkey = _relayListPubkey;
+    if (mostroPubkey != null) {
+      subscribeToMostroRelayList(mostroPubkey);
+    }
+  }
+
+  /// Best-effort read of the relay generation for the filter identity. Falls
+  /// back to 0 so an unavailable NostrService never blocks a subscription.
+  int _relayGeneration() {
+    try {
+      return ref.read(nostrServiceProvider).relayGeneration;
+    } catch (_) {
+      return 0;
     }
   }
 
@@ -255,28 +317,32 @@ class SubscriptionManager {
   /// Stable identity of the inputs a session filter is derived from. Uses
   /// the shared-key publics directly (not the derived K_sign) so no EC math
   /// runs on the skip path. Cursor `since` values are deliberately excluded:
-  /// while a subscription stays open its cursor only moves forward.
+  /// while a subscription stays open its cursor only moves forward. The relay
+  /// generation is included because "filter unchanged" does not imply "REQ
+  /// still delivered": a reconnected or newly added relay has no
+  /// subscriptions until the REQ is re-issued to it.
   String? _filterIdentity(SubscriptionType type, List<Session> sessions) {
+    final generation = _relayGeneration();
     switch (type) {
       case SubscriptionType.orders:
         final keys = sessions.map((s) => s.tradeKey.public).toList()..sort();
         final transport = _resolveOrdersTransport();
         final node = ref.read(settingsProvider).mostroPublicKey;
-        return 'orders|$transport|$node|${keys.join(',')}';
+        return 'orders|g$generation|$transport|$node|${keys.join(',')}';
       case SubscriptionType.chat:
         final keys = sessions
             .where((s) => s.sharedKey != null)
             .map((s) => s.sharedKey!.public)
             .toList()
           ..sort();
-        return keys.isEmpty ? null : 'chat|${keys.join(',')}';
+        return keys.isEmpty ? null : 'chat|g$generation|${keys.join(',')}';
       case SubscriptionType.disputeChat:
         final keys = sessions
             .where((s) => s.adminSharedKey != null)
             .map((s) => s.adminSharedKey!.public)
             .toList()
           ..sort();
-        return keys.isEmpty ? null : 'dispute|${keys.join(',')}';
+        return keys.isEmpty ? null : 'dispute|g$generation|${keys.join(',')}';
       case SubscriptionType.relayList:
         return null;
     }
@@ -470,6 +536,10 @@ class SubscriptionManager {
   /// background service owns the filters.
   void suspend() {
     _isSuspended = true;
+    // A pending relay-driven resubscribe must not fire while the background
+    // service owns the filters; resume() rebuilds everything anyway.
+    _relayResubscribeTimer?.cancel();
+    _relayResubscribeTimer = null;
     unsubscribeAll();
   }
 
@@ -573,6 +643,8 @@ class SubscriptionManager {
   void dispose() {
     _sessionListener.close();
     _mostroInstanceListener?.cancel();
+    _relayGenerationListener?.cancel();
+    _relayResubscribeTimer?.cancel();
     unsubscribeAll();
     _ordersController.close();
     _chatController.close();

--- a/lib/services/mostro_service.dart
+++ b/lib/services/mostro_service.dart
@@ -105,22 +105,50 @@ class MostroService {
     return false;
   }
 
-  Future<void> _onData(NostrEvent event) async {
-    final eventStore = ref.read(eventStorageProvider);
+  /// Event ids currently inside [_onData], so copies of the same event racing
+  /// in from several relays don't get processed twice while the durable
+  /// marker below is not yet written.
+  final Set<String> _inFlightEventIds = <String>{};
 
-    if (await eventStore.hasItem(event.id!)) return;
-
-    // Reserve event ID immediately to prevent duplicate processing from multiple relays
-    await eventStore.putItem(event.id!, {
+  /// Durably marks [event] as fully handled. Written only AFTER processing
+  /// completes (or the event is conclusively not for this consumer): the
+  /// background service suppresses its push notification for any id present
+  /// in this store, and a reservation written *before* processing poisoned
+  /// the event forever when the first attempt failed mid-way (session not
+  /// loaded yet, decrypt error, process death between the reservation and the
+  /// message write) — the daemon's message then never notified, was skipped
+  /// by every later replay, and the order sat at a stale status across
+  /// restarts.
+  Future<void> _markEventProcessed(NostrEvent event) {
+    return ref.read(eventStorageProvider).putItem(event.id!, {
       'id': event.id,
       'created_at': event.createdAt!.millisecondsSinceEpoch ~/ 1000,
     });
+  }
+
+  Future<void> _onData(NostrEvent event) async {
+    final eventId = event.id!;
+    if (!_inFlightEventIds.add(eventId)) return;
+    try {
+      await _processEvent(event);
+    } finally {
+      _inFlightEventIds.remove(eventId);
+    }
+  }
+
+  Future<void> _processEvent(NostrEvent event) async {
+    final eventStore = ref.read(eventStorageProvider);
+
+    if (await eventStore.hasItem(event.id!)) return;
 
     final sessions = ref.read(sessionNotifierProvider);
     final matchingSession = sessions.firstWhereOrNull(
       (s) => s.tradeKey.public == event.recipient,
     );
     if (matchingSession == null) {
+      // Deliberately NOT marked processed: the session may simply not exist
+      // yet (startup ordering, a child order being linked), and a later
+      // replay must be able to retry this event.
       logger.w('No matching session found for recipient: ${event.recipient}');
       return;
     }
@@ -151,6 +179,7 @@ class MostroService {
       // Ensure result is a non-empty List before accessing elements
       if (result is! List || result.isEmpty) {
         logger.w('Received empty or invalid payload, skipping');
+        await _markEventProcessed(event);
         return;
       }
 
@@ -158,12 +187,14 @@ class MostroService {
       // via its own adminSharedKey subscription
       if (NostrUtils.isDmPayload(result[0])) {
         logger.i('Skipping dispute chat message (handled by DisputeChatNotifier)');
+        await _markEventProcessed(event);
         return;
       }
 
       // Skip restore-specific payloads that arrive as historical events due to temporary subscription
       if (result[0] is Map &&
           _isRestorePayload(result[0] as Map<String, dynamic>)) {
+        await _markEventProcessed(event);
         return;
       }
 
@@ -183,7 +214,16 @@ class MostroService {
       );
 
       await _maybeLinkChildOrder(msg, matchingSession);
+
+      // Only now is the event durably done: a crash anywhere above leaves it
+      // unmarked, so the next replay retries it (addMessage is idempotent —
+      // same key, same message).
+      await _markEventProcessed(event);
     } catch (e) {
+      // Not marked processed: a later replay gets another chance at a
+      // transient failure. A permanently undecryptable event costs one
+      // decrypt attempt per replay, which the dedup above bounds to one
+      // relay copy at a time.
       logger.e('Error processing event', error: e);
     }
   }

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -34,6 +34,26 @@ class NostrService {
   final StreamController<int> _relayGenerationController =
       StreamController<int>.broadcast();
 
+  /// Per-relay probes waiting for a dropped socket to come back. A relay with
+  /// no REQs sends nothing, so `onRelayListening` alone can never observe the
+  /// reconnect this class exists to repair — the registry has to be polled.
+  final Map<String, Timer> _reconnectProbes = {};
+
+  /// How often a dropped relay is polled for reconnection, and for how many
+  /// attempts before giving up. dart_nostr makes one immediate reconnect
+  /// attempt per drop (bounded by [Config.relayConnectionTimeout]), so a
+  /// probe outliving that window can never observe a success; longer outages
+  /// are covered by the relay health monitor and foreground resume.
+  /// Overridable in tests.
+  @visibleForTesting
+  Duration reconnectProbeInterval = const Duration(seconds: 2);
+  static const int _maxReconnectProbes = 10; // 20 s per drop
+
+  /// Test seam for the socket-open check, which otherwise reads the global
+  /// [Nostr.instance] registry.
+  @visibleForTesting
+  bool Function(String relayUrl)? relaySocketProbeOverride;
+
   NostrService();
 
   /// Safe getter for settings with fallback
@@ -55,7 +75,7 @@ class NostrService {
   /// Emits after every [relayGeneration] bump.
   Stream<int> get relayGenerationStream => _relayGenerationController.stream;
 
-  /// Records data from [relayUrl] and bumps the generation on the transition
+  /// Records [relayUrl] as alive and bumps the generation on the transition
   /// from unknown/disconnected to alive.
   void _markRelayAlive(String relayUrl) {
     if (_connectedRelays.add(relayUrl)) {
@@ -64,6 +84,46 @@ class NostrService {
         _relayGenerationController.add(_relayGeneration);
       }
     }
+  }
+
+  /// Whether dart_nostr currently holds an open websocket for [relayUrl].
+  /// True only after `onConnectionSuccess` re-registered the channel, i.e.
+  /// after a reconnect actually completed.
+  bool _isRelaySocketOpen(String relayUrl) {
+    final override = relaySocketProbeOverride;
+    if (override != null) {
+      return override(relayUrl);
+    }
+    try {
+      return _nostr.services.relays.nostrRegistry
+          .isRelayRegisteredAndConnectedSuccesfully(relayUrl);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Polls the registry until the dropped [relayUrl] is connected again, then
+  /// marks it alive (bumping [relayGeneration]). An idle reconnected socket
+  /// carries no REQs and therefore sends no data, so waiting for
+  /// `onRelayListening` would deadlock: the REQ replay is what would produce
+  /// the first frame. Bounded so a relay that stays down does not keep a
+  /// timer forever.
+  @visibleForTesting
+  void watchRelayReconnect(String relayUrl) {
+    _reconnectProbes.remove(relayUrl)?.cancel();
+    var attempts = 0;
+    _reconnectProbes[relayUrl] = Timer.periodic(reconnectProbeInterval, (t) {
+      attempts++;
+      if (_isRelaySocketOpen(relayUrl)) {
+        t.cancel();
+        _reconnectProbes.remove(relayUrl);
+        _markRelayAlive(relayUrl);
+      } else if (attempts >= _maxReconnectProbes) {
+        t.cancel();
+        _reconnectProbes.remove(relayUrl);
+        logger.w('Relay $relayUrl did not reconnect; probe abandoned');
+      }
+    });
   }
 
   /// Relays to connect to: the configured relays, or the defensive bootstrap
@@ -120,13 +180,29 @@ class NostrService {
         onRelayConnectionError: (relay, error, channel) {
           _connectedRelays.remove(relay);
           logger.w('Failed to connect to relay $relay: $error');
+          // retryOnError reconnects silently; watch for the new socket so
+          // the open REQs get replayed onto it.
+          watchRelayReconnect(relay);
         },
         onRelayConnectionDone: (relay, socket) {
           // Fired when the relay websocket is closed (disconnected).
           _connectedRelays.remove(relay);
           logger.i('Relay disconnected (socket closed): $relay');
+          // retryOnClose reconnects silently; watch for the new socket so
+          // the open REQs get replayed onto it.
+          watchRelayReconnect(relay);
         },
       );
+
+      // Relays that just connected for the first time (cold start, or added
+      // later by the kind 10002 sync via additive init) also start with no
+      // REQs on their socket; watching them bumps the generation once the
+      // registry confirms the connection.
+      for (final relay in effectiveSettings.relays) {
+        if (!_connectedRelays.contains(relay)) {
+          watchRelayReconnect(relay);
+        }
+      }
 
       _isInitialized = true;
       logger.i(

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:dart_nostr/dart_nostr.dart';
 import 'package:flutter/foundation.dart';
@@ -22,6 +24,16 @@ class NostrService {
   /// the relay connection callbacks; used to detect "no live relay" situations.
   final Set<String> _connectedRelays = {};
 
+  /// Bumped every time a relay transitions to alive: first data after the
+  /// initial connect, after a silent socket reconnect (retryOnClose), or from
+  /// a relay added later by the kind 10002 sync. dart_nostr sends a REQ only
+  /// to the sockets registered at subscription time and never replays it on
+  /// reconnect, so each bump means some relay may be missing the app's open
+  /// subscriptions until they are re-issued.
+  int _relayGeneration = 0;
+  final StreamController<int> _relayGenerationController =
+      StreamController<int>.broadcast();
+
   NostrService();
 
   /// Safe getter for settings with fallback
@@ -34,6 +46,25 @@ class NostrService {
 
   /// Number of relays currently considered alive.
   int get liveRelayCount => _connectedRelays.length;
+
+  /// Monotonic counter of relay come-alive transitions. Part of the
+  /// subscription filter identity so a REQ is re-issued when the relay layer
+  /// changed even though the filter content did not.
+  int get relayGeneration => _relayGeneration;
+
+  /// Emits after every [relayGeneration] bump.
+  Stream<int> get relayGenerationStream => _relayGenerationController.stream;
+
+  /// Records data from [relayUrl] and bumps the generation on the transition
+  /// from unknown/disconnected to alive.
+  void _markRelayAlive(String relayUrl) {
+    if (_connectedRelays.add(relayUrl)) {
+      _relayGeneration++;
+      if (!_relayGenerationController.isClosed) {
+        _relayGenerationController.add(_relayGeneration);
+      }
+    }
+  }
 
   /// Relays to connect to: the configured relays, or the defensive bootstrap
   /// relays as a fail-safe when none are configured (cold start before any kind
@@ -69,7 +100,7 @@ class NostrService {
         retryOnError: true,
         onRelayListening: (relayUrl, receivedData, channel) {
           // Any data from a relay proves it is alive.
-          _connectedRelays.add(relayUrl);
+          _markRelayAlive(relayUrl);
           if (receivedData is NostrEvent) {
             logger.d('Event from $relayUrl: ${receivedData.id}');
           } else if (receivedData is NostrNotice) {

--- a/test/features/subscriptions/subscription_filter_diff_test.dart
+++ b/test/features/subscriptions/subscription_filter_diff_test.dart
@@ -31,6 +31,7 @@ void main() {
   late _FakeSessionNotifier sessions;
   late SubscriptionManager manager;
   late StreamController<int> relayGenerations;
+  late List<NostrRequest> issuedRequests;
   var relayGeneration = 0;
   var nextSubscriptionId = 0;
 
@@ -57,9 +58,11 @@ void main() {
     nostrService = MockNostrService();
     orderRepository = MockOpenOrdersRepository();
     nextSubscriptionId = 0;
+    issuedRequests = <NostrRequest>[];
     when(nostrService.subscribeToEvents(any)).thenAnswer((invocation) {
       final request = invocation.positionalArguments.first as NostrRequest;
       request.subscriptionId ??= 'sub-${nextSubscriptionId++}';
+      issuedRequests.add(request);
       return const Stream<NostrEvent>.empty();
     });
     when(nostrService.unsubscribe(any)).thenAnswer((_) async {});
@@ -189,14 +192,20 @@ void main() {
     // the second arrives while the first is still awaiting warmUp.
     sessions.emit([chatSession()]);
     sessions.emit([chatSession()]);
-    await Future<void>.delayed(const Duration(milliseconds: 20));
 
-    final requests = verify(nostrService.subscribeToEvents(captureAny))
-        .captured
-        .cast<NostrRequest>();
-    final chatRequests = requests
-        .where((r) => r.filters.any((f) => (f.kinds ?? []).contains(14)))
-        .toList();
+    // Deterministic on slow CI machines: wait for the first chat REQ to be
+    // issued instead of assuming a fixed delay is enough, then allow a settle
+    // window in which a duplicated REQ would land.
+    bool isChatRequest(NostrRequest r) =>
+        r.filters.any((f) => (f.kinds ?? []).contains(14));
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (!issuedRequests.any(isChatRequest) &&
+        DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    final chatRequests = issuedRequests.where(isChatRequest).toList();
     expect(chatRequests, hasLength(1));
     verifyNever(nostrService.unsubscribe(any));
   });

--- a/test/features/subscriptions/subscription_filter_diff_test.dart
+++ b/test/features/subscriptions/subscription_filter_diff_test.dart
@@ -30,6 +30,8 @@ void main() {
   late ProviderContainer container;
   late _FakeSessionNotifier sessions;
   late SubscriptionManager manager;
+  late StreamController<int> relayGenerations;
+  var relayGeneration = 0;
   var nextSubscriptionId = 0;
 
   Session session(String orderId, String tradeKeyPrivate) {
@@ -61,6 +63,11 @@ void main() {
       return const Stream<NostrEvent>.empty();
     });
     when(nostrService.unsubscribe(any)).thenAnswer((_) async {});
+    relayGenerations = StreamController<int>.broadcast();
+    relayGeneration = 0;
+    when(nostrService.relayGenerationStream)
+        .thenAnswer((_) => relayGenerations.stream);
+    when(nostrService.relayGeneration).thenAnswer((_) => relayGeneration);
     when(orderRepository.mostroInstanceStream)
         .thenAnswer((_) => const Stream<NostrEvent>.empty());
     when(orderRepository.mostroInstance).thenReturn(null);
@@ -79,6 +86,7 @@ void main() {
   tearDown(() {
     manager.unsubscribeAll();
     container.dispose();
+    relayGenerations.close();
   });
 
   Future<void> flush() => Future<void>.delayed(Duration.zero);
@@ -120,6 +128,36 @@ void main() {
     await flush();
 
     verify(nostrService.subscribeToEvents(any)).called(greaterThan(0));
+  });
+
+  test('a relay coming alive re-issues the REQs for unchanged sessions',
+      () async {
+    // dart_nostr sends a REQ only to the sockets registered at subscription
+    // time: a reconnected socket or a relay added by the 10002 sync comes up
+    // subscription-less. The generation bump must force a re-issue even
+    // though the session set (and thus the filter content) is unchanged.
+    await buildWithSession();
+
+    relayGeneration = 1;
+    relayGenerations.add(1);
+    await Future<void>.delayed(SubscriptionManager.relayResubscribeDebounce +
+        const Duration(milliseconds: 200));
+
+    verify(nostrService.subscribeToEvents(any)).called(1);
+  });
+
+  test('relay come-alive bursts coalesce into a single re-issue', () async {
+    await buildWithSession();
+
+    relayGeneration = 1;
+    relayGenerations.add(1);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    relayGeneration = 2;
+    relayGenerations.add(2);
+    await Future<void>.delayed(SubscriptionManager.relayResubscribeDebounce +
+        const Duration(milliseconds: 200));
+
+    verify(nostrService.subscribeToEvents(any)).called(1);
   });
 
   test(

--- a/test/services/mostro_service_event_retry_test.dart
+++ b/test/services/mostro_service_event_retry_test.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/data/repositories/event_storage.dart';
+import 'package:mostro_mobile/features/settings/settings.dart';
+import 'package:mostro_mobile/features/settings/settings_notifier.dart';
+import 'package:mostro_mobile/features/settings/settings_provider.dart';
+import 'package:mostro_mobile/features/subscriptions/subscription_manager_provider.dart';
+import 'package:mostro_mobile/services/mostro_service.dart';
+import 'package:mostro_mobile/shared/notifiers/session_notifier.dart';
+import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
+import 'package:mostro_mobile/shared/providers/session_notifier_provider.dart';
+import 'package:sembast/sembast_memory.dart';
+
+import '../mocks.mocks.dart';
+
+/// A failed first processing attempt must not poison the event forever.
+/// The old flow reserved the event id in the event store BEFORE matching the
+/// session and decrypting, so a mid-way failure (session not loaded yet,
+/// decrypt error, process death) left the id durably marked: the background
+/// service then suppressed its push for it and every later replay skipped it
+/// — the daemon's message was lost and the order sat at a stale status
+/// across restarts. The marker must be written only after processing
+/// completes.
+void main() {
+  const tradeKeyPrivate =
+      'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+  late Database db;
+  late EventStorage eventStorage;
+  late StreamController<NostrEvent> ordersController;
+  late MockSubscriptionManagerSpy subscriptionManager;
+  late _FakeSessionNotifier sessions;
+  late ProviderContainer container;
+  late MostroService service;
+
+  NostrEvent eventFor(String id, String recipientPubkey) => NostrEvent(
+        id: id,
+        kind: 1059,
+        content: 'not-a-real-gift-wrap',
+        sig: 'sig',
+        pubkey: 'ephemeral-pubkey',
+        createdAt: DateTime.now(),
+        tags: [
+          ['p', recipientPubkey],
+        ],
+      );
+
+  setUp(() async {
+    db = await newDatabaseFactoryMemory().openDatabase('event_retry.db');
+    eventStorage = EventStorage(db: db);
+    ordersController = StreamController<NostrEvent>.broadcast();
+    subscriptionManager = MockSubscriptionManagerSpy();
+    when(subscriptionManager.orders)
+        .thenAnswer((_) => ordersController.stream);
+
+    container = ProviderContainer(overrides: [
+      eventStorageProvider.overrideWithValue(eventStorage),
+      subscriptionManagerProvider.overrideWithValue(subscriptionManager),
+      settingsProvider.overrideWith((ref) => _FixedSettingsNotifier()),
+      sessionNotifierProvider.overrideWith((ref) {
+        sessions = _FakeSessionNotifier(ref);
+        return sessions;
+      }),
+      mostroServiceProvider.overrideWith((ref) {
+        final s = MostroService(ref);
+        s.init();
+        return s;
+      }),
+    ]);
+    container.read(sessionNotifierProvider);
+    service = container.read(mostroServiceProvider);
+  });
+
+  tearDown(() async {
+    ordersController.close();
+    container.dispose();
+    await db.close();
+  });
+
+  Future<void> deliver(NostrEvent event) async {
+    ordersController.add(event);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+
+  test('an event with no matching session is not marked processed', () async {
+    final event = eventFor('event-no-session', 'unknown-recipient');
+
+    await deliver(event);
+
+    expect(await eventStorage.hasItem('event-no-session'), isFalse,
+        reason: 'a replay must be able to retry once the session exists');
+  });
+
+  test('an event that fails to decrypt is not marked processed', () async {
+    final tradeKey = NostrKeyPairs(private: tradeKeyPrivate);
+    sessions.emit([
+      Session(
+        masterKey: tradeKey,
+        tradeKey: tradeKey,
+        keyIndex: 0,
+        fullPrivacy: false,
+        startTime: DateTime.now(),
+      )..orderId = 'order-a',
+    ]);
+    final event = eventFor('event-bad-payload', tradeKey.public);
+
+    await deliver(event);
+
+    expect(await eventStorage.hasItem('event-bad-payload'), isFalse,
+        reason: 'a transient decrypt failure must stay retryable on replay');
+    expect(service, isNotNull);
+  });
+}
+
+class _FixedSettingsNotifier extends SettingsNotifier {
+  _FixedSettingsNotifier() : super(MockSharedPreferencesAsync()) {
+    state = Settings(
+      relays: const [],
+      fullPrivacyMode: false,
+      mostroPublicKey: 'mostro-pubkey',
+    );
+  }
+}
+
+class _FakeSessionNotifier extends SessionNotifier {
+  _FakeSessionNotifier(Ref ref)
+      : super(ref, MockSessionStorage(), MockSettings()) {
+    state = const [];
+  }
+
+  void emit(List<Session> sessions) => state = sessions;
+}

--- a/test/services/nostr_service_relay_reconnect_test.dart
+++ b/test/services/nostr_service_relay_reconnect_test.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/services/nostr_service.dart';
+
+/// An idle reconnected socket carries no REQs and therefore sends no data, so
+/// `onRelayListening` alone can never observe the reconnect: the REQ replay is
+/// what would produce the first frame. The reconnect probe polls the registry
+/// and bumps the relay generation only once the socket is verifiably open —
+/// after which SubscriptionManager replays the open REQs onto it.
+void main() {
+  const relayUrl = 'wss://relay.test';
+
+  late NostrService service;
+  late bool socketOpen;
+  late List<int> emissions;
+  late StreamSubscription<int> subscription;
+
+  setUp(() {
+    service = NostrService();
+    service.reconnectProbeInterval = const Duration(milliseconds: 10);
+    socketOpen = false;
+    service.relaySocketProbeOverride = (_) => socketOpen;
+    emissions = <int>[];
+    subscription = service.relayGenerationStream.listen(emissions.add);
+  });
+
+  tearDown(() async {
+    await subscription.cancel();
+  });
+
+  test('no generation bump while the dropped socket stays down', () async {
+    service.watchRelayReconnect(relayUrl);
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    expect(service.relayGeneration, 0);
+    expect(emissions, isEmpty);
+    expect(service.connectedRelays, isNot(contains(relayUrl)));
+  });
+
+  test('generation bumps once the socket is verifiably open again', () async {
+    service.watchRelayReconnect(relayUrl);
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    socketOpen = true;
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    expect(service.relayGeneration, 1);
+    expect(emissions, [1]);
+    expect(service.connectedRelays, contains(relayUrl));
+  });
+
+  test('re-watching the same relay replaces the probe and bumps once',
+      () async {
+    service.watchRelayReconnect(relayUrl);
+    service.watchRelayReconnect(relayUrl);
+
+    socketOpen = true;
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    expect(service.relayGeneration, 1);
+    expect(emissions, [1]);
+  });
+}


### PR DESCRIPTION
## Problem

After #696, a maker whose order was taken could receive nothing at all: no notification, order state stuck at `pending`, and the order later vanishing from My Trades when the daemon's canceled 38383 triggered the automatic-expiration cleanup against the stale pending state.

Root cause: dart_nostr sends a REQ **once**, to the sockets registered at subscription time. A socket that silently reconnects (`retryOnClose`, routine on mobile radio sleep / network changes) or a relay added afterwards by the kind 10002 sync comes back **subscription-less**, and nothing replays the REQs to it (the health monitor only fires on a total blackout). Before #696 this was accidentally healed: the periodic session-cleanup emission (every 30 min) tore down and re-issued every REQ. The filter-identity skip turned that emission into a no-op, so a stable session set on a partially-covered relay layer became a permanent dead zone — the take message (kind 14 / 1059) lands on a relay where the app has no live REQ.

## Fix

- `NostrService` tracks a **relay generation**, bumped on every come-alive transition (first data after the initial connect, after a silent socket reconnect, or from a relay added by additive init), and exposes it as a value + stream.
- `SubscriptionManager` includes the generation in the filter identity — "filter unchanged" no longer implies "REQ still delivered" — and listens to the generation stream to re-issue all subscriptions (relay list included), debounced 1 s to coalesce connection bursts.

The #696 optimization is preserved: repeated session saves with an unchanged identity still skip the CLOSE+REQ replay; a re-issue now happens only when the relay layer actually changed.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — full suite green (1240 tests)
- [x] New regression tests in `subscription_filter_diff_test.dart`:
  - a relay coming alive re-issues the REQs for an unchanged session set
  - relay come-alive bursts coalesce into a single re-issue
- [ ] Manual: create a range sell order on mobile, toggle networking (or restart the relay) so the socket reconnects, take the order from another device → maker gets the take message and notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subscription reliability when relays reconnect or the relay network changes.
  - Active session and relay-list subscriptions now automatically reissue requests after relay recovery.
  - Rapid relay changes are consolidated to prevent unnecessary repeated requests.
  - Suspending subscriptions now cancels pending refresh operations for cleaner behavior.
  - Events that cannot yet be processed remain eligible for retry instead of being permanently skipped.
  - Prevented duplicate concurrent processing of the same event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->