### PR TITLE
test: fix the duplicate-envelope race pin for cross-isolate unwrapping

### DIFF
--- a/test/features/disputes/dispute_chat_duplicate_envelope_test.dart
+++ b/test/features/disputes/dispute_chat_duplicate_envelope_test.dart
@@ -174,7 +174,17 @@ void main() {
 
     nostrService.controller.add(forged);
     nostrService.controller.add(real);
-    await pumpEventQueue(times: 200);
+    // Unwrapping runs through Isolate.run: wait on the observable condition
+    // (bounded) instead of a microtask pump count, which cannot see cross-
+    // isolate port replies.
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (container
+            .read(disputeChatNotifierProvider(disputeId))
+            .messages
+            .isEmpty &&
+        DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
 
     final messages =
         container.read(disputeChatNotifierProvider(disputeId)).messages;


### PR DESCRIPTION
## Summary

`dispute_chat_duplicate_envelope_test.dart` fails on `main`. Root cause: the pin was added (during #702's review) while envelope unwrapping was synchronous; #705 later moved the per-message crypto into `Isolate.run`, and `pumpEventQueue` cannot observe cross-isolate port replies — the assertion runs before the valid envelope finishes verifying. The two PRs crossed in flight (#705 was stacked on #701, whose branch predated this test), so CI never ran the combination.

**The product behaviour is correct** (verified by log trace): the forged copy fails the p-tag check and the valid copy is processed on its own; only the test's wait was implementation-timed.

## Changes

- Bounded 5 s condition wait on the notifier's messages (same pattern already applied to `dispute_chat_reload_test` in #705).

## Test plan

- [x] `test/features/disputes/` — all green (previously 1 failing on `main`)
- [x] `flutter analyze` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur