### PR TITLE
perf: back off relay recovery and stop reconnecting on NOTICE

### DIFF
--- a/lib/features/relays/relay_health_monitor.dart
+++ b/lib/features/relays/relay_health_monitor.dart
@@ -29,7 +29,13 @@ class RelayHealthMonitor {
   static const Duration initialBackoff = Config.relayDiscoveryTimeout;
   static const Duration maxBackoff = Duration(minutes: 5);
   Duration _backoff = initialBackoff;
-  DateTime? _nextAttemptAt;
+  Duration? _nextAttemptAfter;
+
+  /// Monotonic time source for the backoff deadline. The wall clock is not
+  /// usable here: a backward correction (manual change or an NTP sync during
+  /// the outage) would park the deadline in the future and suppress recovery
+  /// for far longer than [maxBackoff].
+  final Stopwatch _elapsed = Stopwatch()..start();
 
   RelayHealthMonitor(this.ref) {
     _timer = Timer.periodic(Config.relayDiscoveryTimeout, (_) => _check());
@@ -37,11 +43,12 @@ class RelayHealthMonitor {
   }
 
   /// Runs a single health check synchronously. Exposed for tests so the
-  /// periodic timer does not need to be awaited; [now] injects the clock.
+  /// periodic timer does not need to be awaited; [elapsed] injects the
+  /// monotonic clock reading.
   @visibleForTesting
-  Future<void> checkNow({DateTime? now}) => _check(now: now);
+  Future<void> checkNow({Duration? elapsed}) => _check(elapsed: elapsed);
 
-  Future<void> _check({DateTime? now}) async {
+  Future<void> _check({Duration? elapsed}) async {
     if (_recovering) return;
 
     final nostrService = ref.read(nostrServiceProvider);
@@ -57,13 +64,13 @@ class RelayHealthMonitor {
     if (hasLiveOperatingRelay) {
       // Healthy: arm the next outage for an immediate first attempt.
       _backoff = initialBackoff;
-      _nextAttemptAt = null;
+      _nextAttemptAfter = null;
       return;
     }
 
-    final tick = now ?? DateTime.now();
-    if (_nextAttemptAt != null && tick.isBefore(_nextAttemptAt!)) return;
-    _nextAttemptAt = tick.add(_backoff);
+    final tick = elapsed ?? _elapsed.elapsed;
+    if (_nextAttemptAfter != null && tick < _nextAttemptAfter!) return;
+    _nextAttemptAfter = tick + _backoff;
     final doubled = _backoff * 2;
     _backoff = doubled > maxBackoff ? maxBackoff : doubled;
 

--- a/lib/features/relays/relay_health_monitor.dart
+++ b/lib/features/relays/relay_health_monitor.dart
@@ -48,6 +48,18 @@ class RelayHealthMonitor {
   @visibleForTesting
   Future<void> checkNow({Duration? elapsed}) => _check(elapsed: elapsed);
 
+  /// Re-arms the backoff so the next check recovers immediately.
+  ///
+  /// A healthy tick is the only other reset, and it cannot fire while the
+  /// outage lasts. After a long stretch in the background with no network the
+  /// backoff sits at [maxBackoff], so without this a foreground return with
+  /// working network could wait up to five minutes for the safety net to try
+  /// again. Called from the foreground transition.
+  void resetBackoff() {
+    _backoff = initialBackoff;
+    _nextAttemptAfter = null;
+  }
+
   Future<void> _check({Duration? elapsed}) async {
     if (_recovering) return;
 
@@ -62,9 +74,11 @@ class RelayHealthMonitor {
     final hasLiveOperatingRelay =
         nostrService.connectedRelays.any(operatingRelays.contains);
     if (hasLiveOperatingRelay) {
-      // Healthy: arm the next outage for an immediate first attempt.
-      _backoff = initialBackoff;
-      _nextAttemptAfter = null;
+      // Healthy: arm the next outage for an immediate first attempt. Note this
+      // exit is unreachable while `settings.relays` is empty (cold start before
+      // kind-10002 discovery): there is no operating relay to be alive, so the
+      // backoff only grows. That is why [resetBackoff] exists.
+      resetBackoff();
       return;
     }
 

--- a/lib/features/relays/relay_health_monitor.dart
+++ b/lib/features/relays/relay_health_monitor.dart
@@ -23,17 +23,25 @@ class RelayHealthMonitor {
   Timer? _timer;
   bool _recovering = false;
 
+  /// Exponential backoff between recovery attempts while an outage persists:
+  /// each attempt is a full CLOSE+REQ fan-out, and re-running it on every
+  /// 6-second tick against relays that stay down is a resubscription storm.
+  static const Duration initialBackoff = Config.relayDiscoveryTimeout;
+  static const Duration maxBackoff = Duration(minutes: 5);
+  Duration _backoff = initialBackoff;
+  DateTime? _nextAttemptAt;
+
   RelayHealthMonitor(this.ref) {
     _timer = Timer.periodic(Config.relayDiscoveryTimeout, (_) => _check());
     ref.onDispose(() => _timer?.cancel());
   }
 
   /// Runs a single health check synchronously. Exposed for tests so the
-  /// periodic timer does not need to be awaited.
+  /// periodic timer does not need to be awaited; [now] injects the clock.
   @visibleForTesting
-  Future<void> checkNow() => _check();
+  Future<void> checkNow({DateTime? now}) => _check(now: now);
 
-  Future<void> _check() async {
+  Future<void> _check({DateTime? now}) async {
     if (_recovering) return;
 
     final nostrService = ref.read(nostrServiceProvider);
@@ -46,7 +54,18 @@ class RelayHealthMonitor {
     final operatingRelays = ref.read(settingsProvider).relays.toSet();
     final hasLiveOperatingRelay =
         nostrService.connectedRelays.any(operatingRelays.contains);
-    if (hasLiveOperatingRelay) return;
+    if (hasLiveOperatingRelay) {
+      // Healthy: arm the next outage for an immediate first attempt.
+      _backoff = initialBackoff;
+      _nextAttemptAt = null;
+      return;
+    }
+
+    final tick = now ?? DateTime.now();
+    if (_nextAttemptAt != null && tick.isBefore(_nextAttemptAt!)) return;
+    _nextAttemptAt = tick.add(_backoff);
+    final doubled = _backoff * 2;
+    _backoff = doubled > maxBackoff ? maxBackoff : doubled;
 
     _recovering = true;
     try {

--- a/lib/services/lifecycle_manager.dart
+++ b/lib/services/lifecycle_manager.dart
@@ -9,6 +9,7 @@ import 'package:mostro_mobile/data/models/enums/storage_keys.dart';
 import 'package:mostro_mobile/services/logger_service.dart';
 import 'package:mostro_mobile/features/chat/providers/chat_room_providers.dart';
 import 'package:mostro_mobile/features/disputes/notifiers/dispute_chat_notifier.dart';
+import 'package:mostro_mobile/features/relays/relay_health_monitor.dart';
 import 'package:mostro_mobile/features/subscriptions/subscription_type.dart';
 import 'package:mostro_mobile/shared/providers/background_service_provider.dart';
 import 'package:mostro_mobile/shared/providers/mostro_service_provider.dart';
@@ -101,6 +102,11 @@ class LifecycleManager extends WidgetsBindingObserver {
       // not derived from sessions, so subscribeAll() alone cannot bring it
       // back after _switchToBackground() tore it down.
       subscriptionManager.resume();
+
+      // A long background stretch without network leaves the relay health
+      // monitor's backoff at its cap, so its safety net would be up to five
+      // minutes away right when the app is coming back.
+      ref.read(relayHealthMonitorProvider).resetBackoff();
 
       // Reinitialize the mostro service
       logger.i("Reinitializing MostroService");

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -155,10 +155,7 @@ class NostrService {
       await _nostr.services.relays.init(
         relaysUrl: effectiveSettings.relays,
         connectionTimeout: Config.relayConnectionTimeout,
-        // NOTICE frames are informational (rate limits, policy hints);
-        // reconnecting on them cycled the socket without re-sending REQs and
-        // handed the recovery cost to the health monitor.
-        shouldReconnectToRelayOnNotice: false,
+        shouldReconnectToRelayOnNotice: true,
         retryOnClose: true,
         retryOnError: true,
         onRelayListening: (relayUrl, receivedData, channel) {

--- a/lib/services/nostr_service.dart
+++ b/lib/services/nostr_service.dart
@@ -155,7 +155,10 @@ class NostrService {
       await _nostr.services.relays.init(
         relaysUrl: effectiveSettings.relays,
         connectionTimeout: Config.relayConnectionTimeout,
-        shouldReconnectToRelayOnNotice: true,
+        // NOTICE frames are informational (rate limits, policy hints);
+        // reconnecting on them cycled the socket without re-sending REQs and
+        // handed the recovery cost to the health monitor.
+        shouldReconnectToRelayOnNotice: false,
         retryOnClose: true,
         retryOnError: true,
         onRelayListening: (relayUrl, receivedData, channel) {

--- a/test/features/relays/relay_health_monitor_test.dart
+++ b/test/features/relays/relay_health_monitor_test.dart
@@ -69,9 +69,9 @@ void main() {
       when(nostrService.connectedRelays).thenReturn(<String>{});
       final monitor = buildContainer(relays: ['wss://discovered.example.com'])
           .read(relayHealthMonitorProvider);
-      final t0 = DateTime.now();
+      const t0 = Duration.zero;
 
-      await monitor.checkNow(now: t0);
+      await monitor.checkNow(elapsed: t0);
       verify(subscriptionManager.subscribeAll()).called(1);
       clearInteractions(subscriptionManager);
       clearInteractions(nostrService);
@@ -81,13 +81,14 @@ void main() {
           .thenAnswer((_) async {});
 
       // Next periodic tick, still down: within the backoff window, no re-run.
-      await monitor.checkNow(now: t0.add(const Duration(seconds: 1)));
+      await monitor.checkNow(elapsed: t0 + const Duration(seconds: 1));
       verifyNever(subscriptionManager.subscribeAll());
 
       // After the first backoff interval elapses, it retries once...
       await monitor.checkNow(
-          now: t0.add(RelayHealthMonitor.initialBackoff +
-              const Duration(seconds: 1)));
+          elapsed: t0 +
+              RelayHealthMonitor.initialBackoff +
+              const Duration(seconds: 1));
       verify(subscriptionManager.subscribeAll()).called(1);
       clearInteractions(subscriptionManager);
       clearInteractions(nostrService);
@@ -98,8 +99,9 @@ void main() {
 
       // ...and the second window is wider than the first.
       await monitor.checkNow(
-          now: t0.add(RelayHealthMonitor.initialBackoff * 2 +
-              const Duration(seconds: 2)));
+          elapsed: t0 +
+              RelayHealthMonitor.initialBackoff * 2 +
+              const Duration(seconds: 2));
       verifyNever(subscriptionManager.subscribeAll());
     });
 
@@ -107,8 +109,8 @@ void main() {
       when(nostrService.connectedRelays).thenReturn(<String>{});
       final monitor = buildContainer(relays: ['wss://discovered.example.com'])
           .read(relayHealthMonitorProvider);
-      final t0 = DateTime.now();
-      await monitor.checkNow(now: t0);
+      const t0 = Duration.zero;
+      await monitor.checkNow(elapsed: t0);
       clearInteractions(subscriptionManager);
       clearInteractions(nostrService);
       when(nostrService.isInitialized).thenReturn(true);
@@ -118,12 +120,31 @@ void main() {
       // Relay comes back: healthy tick resets the backoff...
       when(nostrService.connectedRelays)
           .thenReturn({'wss://discovered.example.com'});
-      await monitor.checkNow(now: t0.add(const Duration(seconds: 1)));
+      await monitor.checkNow(elapsed: t0 + const Duration(seconds: 1));
 
       // ...so a new outage right after recovers immediately.
       when(nostrService.connectedRelays).thenReturn(<String>{});
-      await monitor.checkNow(now: t0.add(const Duration(seconds: 2)));
+      await monitor.checkNow(elapsed: t0 + const Duration(seconds: 2));
       verify(subscriptionManager.subscribeAll()).called(1);
+    });
+
+    test('drives the backoff from its own monotonic clock, not the wall clock',
+        () async {
+      // Without an injected reading the monitor must use its internal
+      // Stopwatch: two back-to-back checks are one backoff window apart in
+      // monotonic terms, so the second is skipped regardless of what the
+      // device wall clock does in between (a backward correction during an
+      // outage must not park the deadline in the future).
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
+
+      await monitor.checkNow();
+      verify(subscriptionManager.subscribeAll()).called(1);
+      clearInteractions(subscriptionManager);
+
+      await monitor.checkNow();
+      verifyNever(subscriptionManager.subscribeAll());
     });
 
     test('stays idle while an operating relay is alive', () async {

--- a/test/features/relays/relay_health_monitor_test.dart
+++ b/test/features/relays/relay_health_monitor_test.dart
@@ -147,6 +147,60 @@ void main() {
       verifyNever(subscriptionManager.subscribeAll());
     });
 
+    test('caps the backoff at maxBackoff', () async {
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
+
+      // Ten attempts, each far past its window, so the backoff saturates.
+      var t = Duration.zero;
+      var lastAttempt = t;
+      for (var i = 0; i < 10; i++) {
+        await monitor.checkNow(elapsed: t);
+        lastAttempt = t;
+        t += const Duration(hours: 1);
+      }
+      clearInteractions(subscriptionManager);
+
+      // Uncapped, doubling would put the next window ~1.7h out. It must be
+      // exactly maxBackoff: just under is skipped...
+      await monitor.checkNow(
+          elapsed: lastAttempt +
+              RelayHealthMonitor.maxBackoff -
+              const Duration(seconds: 1));
+      verifyNever(subscriptionManager.subscribeAll());
+
+      // ...and just over retries.
+      await monitor.checkNow(
+          elapsed: lastAttempt +
+              RelayHealthMonitor.maxBackoff +
+              const Duration(seconds: 1));
+      verify(subscriptionManager.subscribeAll()).called(1);
+    });
+
+    test('resetBackoff re-arms an immediate attempt', () async {
+      // The healthy tick is the only other reset, and it is unreachable while
+      // the outage lasts: after a long background stretch with no network the
+      // backoff sits at the cap, so a foreground return would otherwise wait
+      // up to five minutes for the safety net to try again.
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
+      const t0 = Duration.zero;
+
+      await monitor.checkNow(elapsed: t0);
+      clearInteractions(subscriptionManager);
+
+      // Inside the backoff window: nothing happens...
+      await monitor.checkNow(elapsed: t0 + const Duration(seconds: 1));
+      verifyNever(subscriptionManager.subscribeAll());
+
+      // ...until the reset, which recovers on the very next check.
+      monitor.resetBackoff();
+      await monitor.checkNow(elapsed: t0 + const Duration(seconds: 2));
+      verify(subscriptionManager.subscribeAll()).called(1);
+    });
+
     test('stays idle while an operating relay is alive', () async {
       when(nostrService.connectedRelays)
           .thenReturn({'wss://discovered.example.com'});

--- a/test/features/relays/relay_health_monitor_test.dart
+++ b/test/features/relays/relay_health_monitor_test.dart
@@ -65,6 +65,67 @@ void main() {
       verify(subscriptionManager.subscribeToMostroRelayList('test')).called(1);
     });
 
+    test('holds an exponential backoff while the outage persists', () async {
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
+      final t0 = DateTime.now();
+
+      await monitor.checkNow(now: t0);
+      verify(subscriptionManager.subscribeAll()).called(1);
+      clearInteractions(subscriptionManager);
+      clearInteractions(nostrService);
+      when(nostrService.isInitialized).thenReturn(true);
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      when(nostrService.ensureBootstrapConnectivity())
+          .thenAnswer((_) async {});
+
+      // Next periodic tick, still down: within the backoff window, no re-run.
+      await monitor.checkNow(now: t0.add(const Duration(seconds: 1)));
+      verifyNever(subscriptionManager.subscribeAll());
+
+      // After the first backoff interval elapses, it retries once...
+      await monitor.checkNow(
+          now: t0.add(RelayHealthMonitor.initialBackoff +
+              const Duration(seconds: 1)));
+      verify(subscriptionManager.subscribeAll()).called(1);
+      clearInteractions(subscriptionManager);
+      clearInteractions(nostrService);
+      when(nostrService.isInitialized).thenReturn(true);
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      when(nostrService.ensureBootstrapConnectivity())
+          .thenAnswer((_) async {});
+
+      // ...and the second window is wider than the first.
+      await monitor.checkNow(
+          now: t0.add(RelayHealthMonitor.initialBackoff * 2 +
+              const Duration(seconds: 2)));
+      verifyNever(subscriptionManager.subscribeAll());
+    });
+
+    test('a healthy check resets the backoff', () async {
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      final monitor = buildContainer(relays: ['wss://discovered.example.com'])
+          .read(relayHealthMonitorProvider);
+      final t0 = DateTime.now();
+      await monitor.checkNow(now: t0);
+      clearInteractions(subscriptionManager);
+      clearInteractions(nostrService);
+      when(nostrService.isInitialized).thenReturn(true);
+      when(nostrService.ensureBootstrapConnectivity())
+          .thenAnswer((_) async {});
+
+      // Relay comes back: healthy tick resets the backoff...
+      when(nostrService.connectedRelays)
+          .thenReturn({'wss://discovered.example.com'});
+      await monitor.checkNow(now: t0.add(const Duration(seconds: 1)));
+
+      // ...so a new outage right after recovers immediately.
+      when(nostrService.connectedRelays).thenReturn(<String>{});
+      await monitor.checkNow(now: t0.add(const Duration(seconds: 2)));
+      verify(subscriptionManager.subscribeAll()).called(1);
+    });
+
     test('stays idle while an operating relay is alive', () async {
       when(nostrService.connectedRelays)
           .thenReturn({'wss://discovered.example.com'});


### PR DESCRIPTION
## Summary

Item **4.3** of the performance plan. Two recovery-path wastes:

1. **Recovery storm**: while every discovered relay stayed down, `RelayHealthMonitor` re-ran the full recovery — bootstrap engagement + a CLOSE+REQ fan-out of every subscription — on **every 6-second tick** (`_recovering` only prevented overlap, not repetition).
2. **NOTICE reconnects**: `shouldReconnectToRelayOnNotice: true` cycled the socket on informational frames (rate-limit/policy notices) without re-sending REQs, handing the recovery cost back to the monitor.

## Changes

- Exponential backoff between recovery attempts (`initialBackoff` 6 s, doubling to a 5 min cap), with an injectable clock for tests. A healthy tick resets the backoff, so a *new* outage still recovers immediately (pinned).
- `shouldReconnectToRelayOnNotice: false`. Socket-level `retryOnClose`/`retryOnError` stay on and remain covered by the relay-generation listener that re-issues REQs after silent reconnects.
- Patching the fork itself (reconnect without delay, double `jsonDecode` per frame) is a follow-up in the `dart_nostr` repository, out of this app repo's scope.

## Test plan

- [x] `relay_health_monitor_test.dart` extended (compile-RED first): backoff holds within the window, retries after it, second window wider, healthy tick resets
- [x] Relays + subscriptions suites — 99/99; services/shared/data — 596/596
- [x] `flutter analyze` — no new issues
- [ ] Manual: airplane mode 2 min — recovery attempts spaced 6 s/12 s/24 s… in logs; reconnect on network return is immediate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay health recovery by spacing repeated attempts with progressive delays.
  * Recovery attempts now resume promptly after the app returns to the foreground.
  * Successful health checks reset recovery delays.
  * Added safeguards to prevent excessive retry delays and ensure consistent timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->