### PR TITLE
perf: cache sessions and chat keys in the background isolate

### DIFF
--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -1,3 +1,4 @@
+import 'package:mostro_mobile/features/notifications/services/background_session_cache.dart';
 import 'dart:convert';
 import 'dart:math';
 
@@ -168,7 +169,7 @@ Future<void> showLocalNotification(NostrEvent event) async {
     final mostroMessage = await _decryptAndProcessEvent(event);
     if (mostroMessage == null) return;
 
-    final sessions = await _loadSessionsFromDatabase();
+    final sessions = await backgroundSessionCache.sessions(_loadSessionsFromDatabase);
     final matchingSession = sessions.cast<Session?>().firstWhere(
       (session) => session?.orderId == mostroMessage.id,
       orElse: () => null,
@@ -252,7 +253,7 @@ Future<MostroMessage?> _decryptAndProcessEvent(NostrEvent event) async {
       return null;
     }
 
-    final sessions = await _loadSessionsFromDatabase();
+    final sessions = await backgroundSessionCache.sessions(_loadSessionsFromDatabase);
 
     // Chat (kind 14 envelope): the outer author is the K_sign key derived
     // from the conversation's shared key, so match by author, not recipient.
@@ -262,7 +263,7 @@ Future<MostroMessage?> _decryptAndProcessEvent(NostrEvent event) async {
       for (final session in sessions) {
         final adminShared = session.adminSharedKey;
         if (adminShared == null) continue;
-        final chatKeys = ChatKeys.fromSharedKey(adminShared);
+        final chatKeys = backgroundSessionCache.chatKeysFor(adminShared);
         if (event.pubkey == chatKeys.sign.public) {
           return _processAdminDm(event, session, chatKeys);
         }
@@ -270,7 +271,7 @@ Future<MostroMessage?> _decryptAndProcessEvent(NostrEvent event) async {
       for (final session in sessions) {
         final shared = session.sharedKey;
         if (shared == null) continue;
-        final chatKeys = ChatKeys.fromSharedKey(shared);
+        final chatKeys = backgroundSessionCache.chatKeysFor(shared);
         if (event.pubkey == chatKeys.sign.public) {
           return _processPeerChat(event, session, chatKeys);
         }
@@ -343,7 +344,8 @@ Future<MostroMessage?> _handleTradeKeyEvent(NostrEvent event, Session session) a
   // decrypts straight to the tuple. Both converge on jsonDecode below.
   final String? content;
   if (event.kind == 14) {
-    final mostroPubkey = await _loadMostroPubkey();
+    final mostroPubkey =
+        await backgroundSessionCache.mostroPubkey(_loadMostroPubkey);
     if (mostroPubkey == null) {
       logger.w('No Mostro pubkey available, cannot decrypt kind-14 event');
       return null;
@@ -451,6 +453,8 @@ Future<void> _maybeUpdateSessionWithPeer(
     await keyManager.init();
     final sessionStorage = SessionStorage(keyManager, db: db);
     await sessionStorage.putSession(session);
+    // Local write: the cached session list is stale now.
+    backgroundSessionCache.invalidate();
 
     logger.i('Background persisted peer for order ${session.orderId}');
 
@@ -459,7 +463,7 @@ Future<void> _maybeUpdateSessionWithPeer(
     final shared = session.sharedKey;
     if (shared != null) {
       bg.addChatSubscriptionFromBackground?.call(
-        ChatKeys.fromSharedKey(shared).sign.public,
+        backgroundSessionCache.chatKeysFor(shared).sign.public,
         session.orderId,
       );
     }
@@ -538,6 +542,9 @@ Future<String?> _loadMostroPubkey() async {
     return null;
   }
 }
+
+/// Isolate-wide cache: reads go through it, local writes invalidate it.
+final BackgroundSessionCache backgroundSessionCache = BackgroundSessionCache();
 
 Future<List<Session>> _loadSessionsFromDatabase() async {
   try {

--- a/lib/features/notifications/services/background_notification_service.dart
+++ b/lib/features/notifications/services/background_notification_service.dart
@@ -538,8 +538,10 @@ Future<String?> _loadMostroPubkey() async {
     }
     return Settings.fromJson(jsonDecode(settingsJson)).mostroPublicKey;
   } catch (e) {
+    // Rethrow for the same reason as _loadSessionsFromDatabase: a cached null
+    // means "no pubkey configured", not "the read blew up this once".
     logger.e('Failed to load Mostro pubkey in background: $e');
-    return null;
+    rethrow;
   }
 }
 
@@ -559,8 +561,11 @@ Future<List<Session>> _loadSessionsFromDatabase() async {
     final sessionStorage = SessionStorage(keyManager, db: db);
     return await sessionStorage.getAll();
   } catch (e) {
+    // Rethrow: an empty list is a valid answer the cache keeps for a whole TTL
+    // window, so returning [] here would silently discard every event that
+    // arrives during a transient database/secure-storage failure.
     logger.e('Session load error: $e');
-    return [];
+    rethrow;
   }
 }
 

--- a/lib/features/notifications/services/background_session_cache.dart
+++ b/lib/features/notifications/services/background_session_cache.dart
@@ -23,7 +23,9 @@ class BackgroundSessionCache {
   static const int _chatKeysLimit = 512;
 
   /// Sessions, loading through [loader] at most once per TTL window. A
-  /// concurrent burst shares one in-flight load.
+  /// concurrent burst shares one in-flight load. A throwing loader caches
+  /// nothing, so a transient failure does not blind the isolate for a whole
+  /// TTL window.
   Future<List<Session>> sessions(
     Future<List<Session>> Function() loader,
   ) {
@@ -50,17 +52,18 @@ class BackgroundSessionCache {
     return load;
   }
 
-  /// Node pubkey with the same TTL semantics.
+  /// Node pubkey with the same TTL semantics. An absent pubkey is a valid
+  /// answer and is cached like any other; a *failing* loader throws through,
+  /// leaving nothing cached so the next event retries.
   Future<String?> mostroPubkey(Future<String?> Function() loader) async {
     final now = DateTime.now();
-    if (_mostroPubkey != null &&
-        _pubkeyLoadedAt != null &&
-        now.difference(_pubkeyLoadedAt!) < ttl) {
+    if (_pubkeyLoadedAt != null && now.difference(_pubkeyLoadedAt!) < ttl) {
       return _mostroPubkey;
     }
-    _mostroPubkey = await loader();
+    final loaded = await loader();
+    _mostroPubkey = loaded;
     _pubkeyLoadedAt = DateTime.now();
-    return _mostroPubkey;
+    return loaded;
   }
 
   /// K_conv/K_sign pair per shared key (two EC multiplications each),

--- a/lib/features/notifications/services/background_session_cache.dart
+++ b/lib/features/notifications/services/background_session_cache.dart
@@ -1,0 +1,88 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/shared/utils/chat_keys.dart';
+
+/// Per-isolate cache for the background notification pipeline.
+///
+/// The background isolate used to open the database, construct and init a
+/// KeyManager (secure-storage reads) and re-derive every session's chat keys
+/// twice per incoming event. Session state only changes when this isolate
+/// writes it (or on a fresh service start), so reads are memoized behind a
+/// short TTL with explicit invalidation after local writes.
+class BackgroundSessionCache {
+  BackgroundSessionCache({this.ttl = const Duration(minutes: 2)});
+
+  final Duration ttl;
+
+  List<Session>? _sessions;
+  DateTime? _loadedAt;
+  Future<List<Session>>? _inFlight;
+  String? _mostroPubkey;
+  DateTime? _pubkeyLoadedAt;
+  final Map<String, ChatKeys> _chatKeys = {};
+  static const int _chatKeysLimit = 512;
+
+  /// Sessions, loading through [loader] at most once per TTL window. A
+  /// concurrent burst shares one in-flight load.
+  Future<List<Session>> sessions(
+    Future<List<Session>> Function() loader,
+  ) {
+    final now = DateTime.now();
+    final cached = _sessions;
+    if (cached != null &&
+        _loadedAt != null &&
+        now.difference(_loadedAt!) < ttl) {
+      return Future.value(cached);
+    }
+    final inFlight = _inFlight;
+    if (inFlight != null) return inFlight;
+    final load = () async {
+      try {
+        final loaded = await loader();
+        _sessions = loaded;
+        _loadedAt = DateTime.now();
+        return loaded;
+      } finally {
+        _inFlight = null;
+      }
+    }();
+    _inFlight = load;
+    return load;
+  }
+
+  /// Node pubkey with the same TTL semantics.
+  Future<String?> mostroPubkey(Future<String?> Function() loader) async {
+    final now = DateTime.now();
+    if (_mostroPubkey != null &&
+        _pubkeyLoadedAt != null &&
+        now.difference(_pubkeyLoadedAt!) < ttl) {
+      return _mostroPubkey;
+    }
+    _mostroPubkey = await loader();
+    _pubkeyLoadedAt = DateTime.now();
+    return _mostroPubkey;
+  }
+
+  /// K_conv/K_sign pair per shared key (two EC multiplications each),
+  /// derived once.
+  ChatKeys chatKeysFor(NostrKeyPairs sharedKey) {
+    final cached = _chatKeys[sharedKey.public];
+    if (cached != null) return cached;
+    final keys = ChatKeys.fromSharedKey(sharedKey);
+    if (_chatKeys.length >= _chatKeysLimit) {
+      _chatKeys.clear();
+    }
+    _chatKeys[sharedKey.public] = keys;
+    return keys;
+  }
+
+  /// Drop the cached sessions/pubkey after a local write (peer update,
+  /// settings change) so the next event sees fresh state. Chat keys are pure
+  /// derivations and stay.
+  void invalidate() {
+    _sessions = null;
+    _loadedAt = null;
+    _mostroPubkey = null;
+    _pubkeyLoadedAt = null;
+  }
+}

--- a/test/features/notifications/background_session_cache_test.dart
+++ b/test/features/notifications/background_session_cache_test.dart
@@ -1,0 +1,110 @@
+import 'package:dart_nostr/dart_nostr.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro_mobile/data/models/peer.dart';
+import 'package:mostro_mobile/data/models/session.dart';
+import 'package:mostro_mobile/features/notifications/services/background_session_cache.dart';
+
+/// The background isolate used to open the database, construct and init a
+/// KeyManager (secure-storage reads) and re-derive every session's chat keys
+/// TWICE per incoming event. Session state only changes when this isolate
+/// writes it (or on a fresh service start), so a small TTL cache with
+/// explicit invalidation removes all of that per-event work.
+void main() {
+  Session session(String orderId, {String? peerPubkey}) {
+    final s = Session(
+      masterKey: NostrKeyPairs(
+          private:
+              '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'),
+      tradeKey: NostrKeyPairs(
+          private:
+              'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'),
+      keyIndex: 0,
+      fullPrivacy: false,
+      startTime: DateTime.now(),
+    );
+    s.orderId = orderId;
+    if (peerPubkey != null) {
+      s.peer = Peer(publicKey: peerPubkey);
+    }
+    return s;
+  }
+
+  test('the loader runs once for repeated reads inside the TTL', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+    Future<List<Session>> loader() async {
+      loads++;
+      return [session('o1')];
+    }
+
+    final a = await cache.sessions(loader);
+    final b = await cache.sessions(loader);
+
+    expect(loads, 1);
+    expect(identical(a, b), isTrue);
+  });
+
+  test('invalidate forces the next read to reload', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+    Future<List<Session>> loader() async {
+      loads++;
+      return [session('o$loads')];
+    }
+
+    await cache.sessions(loader);
+    cache.invalidate();
+    final after = await cache.sessions(loader);
+
+    expect(loads, 2);
+    expect(after.single.orderId, 'o2');
+  });
+
+  test('the TTL expires the cached sessions', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache(ttl: const Duration(milliseconds: 1));
+    Future<List<Session>> loader() async {
+      loads++;
+      return [session('o1')];
+    }
+
+    await cache.sessions(loader);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await cache.sessions(loader);
+
+    expect(loads, 2);
+  });
+
+  test('chat keys are derived once per shared key', () {
+    const peer =
+        'aa11111111111111111111111111111111111111111111111111111111111111';
+    final cache = BackgroundSessionCache();
+    final shared = session('o1', peerPubkey: peer).sharedKey!;
+
+    final first = cache.chatKeysFor(shared);
+    final second = cache.chatKeysFor(shared);
+
+    expect(identical(first, second), isTrue,
+        reason: 'ChatKeys derivation costs two EC multiplications');
+    expect(first.sign.public, isNotEmpty);
+  });
+
+  test('a concurrent burst shares one in-flight load', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+    Future<List<Session>> loader() async {
+      loads++;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      return [session('o1')];
+    }
+
+    final results = await Future.wait([
+      cache.sessions(loader),
+      cache.sessions(loader),
+      cache.sessions(loader),
+    ]);
+
+    expect(loads, 1);
+    expect(results, everyElement(hasLength(1)));
+  });
+}

--- a/test/features/notifications/services/background_session_cache_test.dart
+++ b/test/features/notifications/services/background_session_cache_test.dart
@@ -107,4 +107,99 @@ void main() {
     expect(loads, 1);
     expect(results, everyElement(hasLength(1)));
   });
+
+  test('a failed session load is not cached', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+    Future<List<Session>> loader() async {
+      loads++;
+      if (loads == 1) throw StateError('transient database error');
+      return [session('o1')];
+    }
+
+    await expectLater(cache.sessions(loader), throwsStateError);
+    final after = await cache.sessions(loader);
+
+    expect(loads, 2,
+        reason: 'a transient failure must not be cached as an empty session '
+            'list, or every event in the TTL window is silently discarded');
+    expect(after.single.orderId, 'o1');
+  });
+
+  test('a missing Mostro pubkey is cached for the TTL', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+    Future<String?> loader() async {
+      loads++;
+      return null;
+    }
+
+    expect(await cache.mostroPubkey(loader), isNull);
+    expect(await cache.mostroPubkey(loader), isNull);
+
+    expect(loads, 1,
+        reason: 'an absent pubkey is a valid answer; re-reading settings on '
+            'every kind-14 event is the work this cache exists to avoid');
+  });
+
+  test('a failed pubkey load is not cached', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+    Future<String?> loader() async {
+      loads++;
+      if (loads == 1) throw StateError('secure storage unavailable');
+      return 'npubdeadbeef';
+    }
+
+    await expectLater(cache.mostroPubkey(loader), throwsStateError);
+
+    expect(await cache.mostroPubkey(loader), 'npubdeadbeef');
+    expect(loads, 2);
+  });
+
+  /// The wiring concern behind the cache: a kind-14 event is matched by the
+  /// K_sign public key derived from the session's shared key, so a cache hit
+  /// must resolve the same session a fresh load would; and the peer written by
+  /// _maybeUpdateSessionWithPeer must be visible to the very next event, which
+  /// is what its invalidate() call buys.
+  test('cached sessions resolve the event author, and a peer write is visible '
+      'after invalidate', () async {
+    const peer =
+        'aa11111111111111111111111111111111111111111111111111111111111111';
+    var loads = 0;
+    String? storedPeer;
+    final cache = BackgroundSessionCache();
+    Future<List<Session>> loader() async {
+      loads++;
+      return [session('o1', peerPubkey: storedPeer)];
+    }
+
+    Future<Session?> resolveByAuthor(String author) async {
+      for (final s in await cache.sessions(loader)) {
+        final shared = s.sharedKey;
+        if (shared == null) continue;
+        if (cache.chatKeysFor(shared).sign.public == author) return s;
+      }
+      return null;
+    }
+
+    // No peer yet: nothing to match a chat author against.
+    expect(await resolveByAuthor('cc33'), isNull);
+    expect(loads, 1);
+
+    // _maybeUpdateSessionWithPeer writes the peer, then invalidates.
+    storedPeer = peer;
+    cache.invalidate();
+
+    final signPublic = cache
+        .chatKeysFor((await cache.sessions(loader)).single.sharedKey!)
+        .sign
+        .public;
+    expect(loads, 2, reason: 'the peer write must be observed');
+
+    expect((await resolveByAuthor(signPublic))?.orderId, 'o1');
+    expect((await resolveByAuthor(signPublic))?.peer?.publicKey, peer);
+    expect(await resolveByAuthor('cc33'), isNull);
+    expect(loads, 2, reason: 'all three lookups served from one load');
+  });
 }


### PR DESCRIPTION
## Summary

Item **4.4** of the performance plan. For **every incoming event** the background notification pipeline: opened `mostro.db`, constructed and `init()`-ed a `KeyManager` (secure-storage reads), decoded every session (trade-key derivation) and derived every session's `ChatKeys` — **twice per event** (`_decryptAndProcessEvent` + `showLocalNotification` both loaded sessions), plus again inside the peer-update path. Pure CPU/battery drain while the app sleeps, worst under message bursts.

## Changes

- **`BackgroundSessionCache`** (new, pure class): session list + node pubkey memoized behind a 2-minute TTL; a concurrent burst shares one in-flight load; `ChatKeys` derived once per shared key (bounded map).
- The pipeline's read sites go through the cache; `_maybeUpdateSessionWithPeer` **invalidates** it right after its `putSession`, so the next event sees the fresh peer. A fresh service start naturally begins empty.
- Foreground/background DB co-access is unchanged by this PR (reads just stop repeating). Serializing cross-isolate writes remains the known follow-up from the plan.

## Test plan

- [x] New `background_session_cache_test.dart` (compile-RED first): single load per TTL window, invalidate reloads, TTL expiry, ChatKeys identity-memoized, concurrent burst shares one load
- [x] Notifications suite 48/48; full suite in halves — green except `dispute_chat_duplicate_envelope_test.dart`, which is the known pre-existing failure fixed by #710 (not in this branch's base)
- [x] `flutter analyze` — no new issues
- [ ] Manual: background the app, receive several trade/chat events — notifications correct; take an order while backgrounded — peer chat notification works after the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fTxqxhpdL5siTgKZqwtur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Background notifications now process more efficiently by reusing session and chat information during short periods of activity.
  - Reduced repeated database access and cryptographic setup, helping notification handling respond more quickly.
  - Cached information is refreshed automatically when session data changes or becomes outdated, ensuring notifications continue using current details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->