### PR TITLE
fix: do not cache a session load that raced a background write

### DIFF
--- a/lib/features/notifications/services/background_session_cache.dart
+++ b/lib/features/notifications/services/background_session_cache.dart
@@ -22,6 +22,10 @@ class BackgroundSessionCache {
   final Map<String, ChatKeys> _chatKeys = {};
   static const int _chatKeysLimit = 512;
 
+  /// Bumped by [invalidate]. A load that started before a local write must not
+  /// cache the snapshot it read, even though it resolves after the write.
+  int _generation = 0;
+
   /// Sessions, loading through [loader] at most once per TTL window. A
   /// concurrent burst shares one in-flight load. A throwing loader caches
   /// nothing, so a transient failure does not blind the isolate for a whole
@@ -38,11 +42,16 @@ class BackgroundSessionCache {
     }
     final inFlight = _inFlight;
     if (inFlight != null) return inFlight;
+    final generation = _generation;
     final load = () async {
       try {
         final loaded = await loader();
-        _sessions = loaded;
-        _loadedAt = DateTime.now();
+        // Callers still get this list, but caching it after an invalidate
+        // would serve a pre-write snapshot for the rest of the TTL window.
+        if (generation == _generation) {
+          _sessions = loaded;
+          _loadedAt = DateTime.now();
+        }
         return loaded;
       } finally {
         _inFlight = null;
@@ -60,9 +69,12 @@ class BackgroundSessionCache {
     if (_pubkeyLoadedAt != null && now.difference(_pubkeyLoadedAt!) < ttl) {
       return _mostroPubkey;
     }
+    final generation = _generation;
     final loaded = await loader();
-    _mostroPubkey = loaded;
-    _pubkeyLoadedAt = DateTime.now();
+    if (generation == _generation) {
+      _mostroPubkey = loaded;
+      _pubkeyLoadedAt = DateTime.now();
+    }
     return loaded;
   }
 
@@ -83,6 +95,7 @@ class BackgroundSessionCache {
   /// settings change) so the next event sees fresh state. Chat keys are pure
   /// derivations and stay.
   void invalidate() {
+    _generation++;
     _sessions = null;
     _loadedAt = null;
     _mostroPubkey = null;

--- a/lib/features/notifications/services/background_session_cache.dart
+++ b/lib/features/notifications/services/background_session_cache.dart
@@ -30,6 +30,9 @@ class BackgroundSessionCache {
   /// concurrent burst shares one in-flight load. A throwing loader caches
   /// nothing, so a transient failure does not blind the isolate for a whole
   /// TTL window.
+  ///
+  /// A caller that arrives after [invalidate] always gets a load started after
+  /// it; only one that asked before the write can miss it.
   Future<List<Session>> sessions(
     Future<List<Session>> Function() loader,
   ) {
@@ -54,7 +57,9 @@ class BackgroundSessionCache {
         }
         return loaded;
       } finally {
-        _inFlight = null;
+        // Only clear the slot if it is still this load's: invalidate() may
+        // have retired it and a newer load may already own it.
+        if (generation == _generation) _inFlight = null;
       }
     }();
     _inFlight = load;
@@ -98,6 +103,9 @@ class BackgroundSessionCache {
     _generation++;
     _sessions = null;
     _loadedAt = null;
+    // Stop sharing a load that started before this write: a caller arriving
+    // now must see the write, not that load's pre-write snapshot.
+    _inFlight = null;
     _mostroPubkey = null;
     _pubkeyLoadedAt = null;
   }

--- a/test/features/notifications/services/background_session_cache_test.dart
+++ b/test/features/notifications/services/background_session_cache_test.dart
@@ -264,4 +264,79 @@ void main() {
     expect(await cache.mostroPubkey(loader), 'new-node-pubkey');
     expect(loads, 2);
   });
+
+  /// The load that races a write is not only a caching problem: while it is
+  /// still in flight it is also *shared*. An event arriving after the peer was
+  /// persisted used to be handed that pre-write future, and background
+  /// notifications are processed once, so its kind-14 chat message was
+  /// dropped even though nothing stale was ever cached.
+  test('a call after invalidate() does not share the stale in-flight load',
+      () async {
+    const peer =
+        'aa11111111111111111111111111111111111111111111111111111111111111';
+    String? storedPeer; // what is on disk
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+
+    Future<List<Session>> loader() async {
+      loads++;
+      final snapshot = storedPeer; // read taken at load start
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      return [session('o1', peerPubkey: snapshot)];
+    }
+
+    // Event B starts a load, before the write.
+    final inFlight = cache.sessions(loader);
+
+    // Event A persists the peer and invalidates.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    storedPeer = peer;
+    cache.invalidate();
+
+    // Event C asks *after* the write but while the old load is still running.
+    final duringWindow = await cache.sessions(loader);
+
+    expect(loads, 2,
+        reason: 'a caller arriving after the write must get a load started '
+            'after it, not the shared pre-write one');
+    expect(duringWindow.single.peer?.publicKey, peer);
+
+    await inFlight;
+  });
+
+  /// Retiring the slot in invalidate() introduces its own hazard: the load it
+  /// retired still runs, and its `finally` must not clear the slot a newer
+  /// load now owns — that would break burst sharing and start a third load.
+  test('an old loader does not retire the newer in-flight load', () async {
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+
+    Future<List<Session>> loader() async {
+      loads++;
+      // The first load finishes well before the second.
+      final ms = loads == 1 ? 60 : 300;
+      await Future<void>.delayed(Duration(milliseconds: ms));
+      return [session('o$loads')];
+    }
+
+    final first = cache.sessions(loader);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    cache.invalidate();
+    final second = cache.sessions(loader);
+    expect(loads, 2);
+
+    // The retired load completes while the newer one is still in flight.
+    await first;
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    // A burst arriving now must still share the newer load.
+    final a = cache.sessions(loader);
+    final b = cache.sessions(loader);
+
+    expect(loads, 2,
+        reason: 'the finished old load must not have freed the slot the '
+            'newer load owns');
+    expect(identical(await a, await b), isTrue);
+    expect(identical(await a, await second), isTrue);
+  });
 }

--- a/test/features/notifications/services/background_session_cache_test.dart
+++ b/test/features/notifications/services/background_session_cache_test.dart
@@ -202,4 +202,66 @@ void main() {
     expect(await resolveByAuthor('cc33'), isNull);
     expect(loads, 2, reason: 'all three lookups served from one load');
   });
+
+  /// _maybeUpdateSessionWithPeer writes the peer to disk and then invalidates,
+  /// but another event may already be mid-load. Without a generation guard
+  /// that load lands after the invalidate and re-caches its pre-write
+  /// snapshot, so the peer stays invisible for the whole TTL window and every
+  /// kind-14 chat event of that conversation fails to match a session.
+  test('a load in flight when invalidate() lands is not cached', () async {
+    const peer =
+        'aa11111111111111111111111111111111111111111111111111111111111111';
+    String? storedPeer; // what is on disk
+    var loads = 0;
+    final cache = BackgroundSessionCache();
+
+    Future<List<Session>> loader() async {
+      loads++;
+      final snapshot = storedPeer; // read taken at load start
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      return [session('o1', peerPubkey: snapshot)];
+    }
+
+    // Event B starts a load; do not await it yet.
+    final inFlight = cache.sessions(loader);
+
+    // Event A meanwhile persists the peer and invalidates.
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    storedPeer = peer;
+    cache.invalidate();
+
+    await inFlight; // the stale load resolves after the invalidate
+
+    final next = await cache.sessions(loader);
+
+    expect(loads, 2,
+        reason: 'the pre-write snapshot must not be cached by a load that '
+            'started before the peer was persisted');
+    expect(next.single.peer?.publicKey, peer);
+  });
+
+  test('a pubkey load in flight when invalidate() lands is not cached',
+      () async {
+    var loads = 0;
+    var stored = 'old-node-pubkey';
+    final cache = BackgroundSessionCache();
+
+    Future<String?> loader() async {
+      loads++;
+      final snapshot = stored;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      return snapshot;
+    }
+
+    final inFlight = cache.mostroPubkey(loader);
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    stored = 'new-node-pubkey';
+    cache.invalidate();
+
+    await inFlight;
+
+    expect(await cache.mostroPubkey(loader), 'new-node-pubkey');
+    expect(loads, 2);
+  });
 }


### PR DESCRIPTION
Follow-up to #713 (`fed47b50`), which introduced `BackgroundSessionCache`. The cache is correct in the common path, but `invalidate()` clears `_sessions`/`_loadedAt` without accounting for a load that is still in flight. This PR closes that gap.

`_maybeUpdateSessionWithPeer` persists the peer and then calls `invalidate()`. If another event started a session load *before* that `putSession` reached disk, the load resolves *after* the `invalidate()` and writes its pre-write snapshot back into the cache — so the freshly persisted peer stays invisible for the full 2-minute TTL window.

**Impact:** sessions in the stale list have `sharedKey == null`, so the kind-14 author-matching loop in `_decryptAndProcessEvent` no longer recognises the conversation. Peer chat events still arrive — `addChatSubscriptionFromBackground` already opened the subscription on the correct K_sign — but they match no session and notify nothing until the TTL expires. Silent, self-healing after up to two minutes.

**Reachability:** narrow. It needs two overlapping peer updates (a range order with child sessions, or two trades going active close together), which is possible because the `subscription.listen((event) async { ... })` callbacks in `background.dart` are not serialised.

`mostroPubkey()` had the identical unguarded write after its `await` and is fixed the same way.

## Changes

- `BackgroundSessionCache`: a `_generation` counter, bumped by `invalidate()`. Both `sessions()` and `mostroPubkey()` capture it before their load and only write the cache if it still matches. Callers still receive the list/pubkey they asked for — only *caching* it is suppressed.
- Two regression tests, one per method, that start a load, invalidate mid-flight, and assert the next read reloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated notification session and public key data from being reused after updates.
  * Subsequent reads now correctly reload the latest values when an earlier load finishes late.
  * Ensured new reads do not share stale data while updated notification information is being loaded.
  * Preserved reliable sharing of current loads during rapid successive reads.

* **Tests**
  * Added coverage for updates occurring while notification data is still loading, including session and public key data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->